### PR TITLE
Add an AppleEvents usage description in an effort to get sharing with…

### DIFF
--- a/NetNewsWire/Info.plist
+++ b/NetNewsWire/Info.plist
@@ -43,6 +43,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>NetNewsWire communicates with other apps on your Mac when you choose to share a news item.</string>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
… apps like MarsEdit working again on Mojave. Hoping this fixes #427.