### PR TITLE
Removed flag check because it is passed as true even if the window is…

### DIFF
--- a/NetNewsWire/AppDelegate.swift
+++ b/NetNewsWire/AppDelegate.swift
@@ -155,10 +155,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 	}
 
 	func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-
-		if (!flag) {
-			createAndShowMainWindow()
-		}
+		createAndShowMainWindow()
 		return false
 	}
 


### PR DESCRIPTION
…n't visible due to being minimized into the app icon.  

From the API documentation "Miniaturized windows, windows in the Dock, are considered visible by this method, and cause flag to return YES, despite the fact that miniaturized windows return NO when sent an visible message."

I think it is safe to always open the main window.  We could test to make sure the info and feed windows aren't already visible and not open the main window if one is, but I don't think that is a desirable use case.