### PR TITLE
Switch to standard state restoration mechanism

### DIFF
--- a/NetNewsWire/AppDefaults.swift
+++ b/NetNewsWire/AppDefaults.swift
@@ -53,7 +53,6 @@ struct AppDefaults {
 		static let timelineSortDirection = "timelineSortDirection"
 		static let detailFontSize = "detailFontSize"
 		static let openInBrowserInBackground = "openInBrowserInBackground"
-		static let mainWindowWidths = "mainWindowWidths"
 		static let refreshInterval = "refreshInterval"
 
 		// Hidden prefs
@@ -117,15 +116,6 @@ struct AppDefaults {
 		}
 		set {
 			setSortDirection(for: Key.timelineSortDirection, newValue)
-		}
-	}
-
-	static var mainWindowWidths: [Int]? {
-		get {
-			return UserDefaults.standard.object(forKey: Key.mainWindowWidths) as? [Int]
-		}
-		set {
-			UserDefaults.standard.set(newValue, forKey: Key.mainWindowWidths)
 		}
 	}
 

--- a/NetNewsWire/AppDelegate.swift
+++ b/NetNewsWire/AppDelegate.swift
@@ -576,7 +576,6 @@ private extension AppDelegate {
 	func saveState() {
 
 		inspectorWindowController?.saveState()
-		mainWindowController?.saveState()
 	}
 
 	func updateSortMenuItems() {

--- a/NetNewsWire/MainWindow/MainWindowController.swift
+++ b/NetNewsWire/MainWindow/MainWindowController.swift
@@ -78,11 +78,17 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations, NSW
 	// MARK: - Notifications
 
 	func window(_ window: NSWindow, willEncodeRestorableState state: NSCoder) {
+
 		saveSplitViewState(to: state)
 	}
 
 	func window(_ window: NSWindow, didDecodeRestorableState state: NSCoder) {
+		
 		restoreSplitViewState(from: state)
+
+		// Make sure the timeline view is first responder if possible, to start out viewing
+		// whatever preserved selection might have been restored
+		makeTimelineViewFirstResponder()
 	}
 
 	@objc func refreshProgressDidChange(_ note: Notification) {

--- a/NetNewsWire/MainWindow/MainWindowController.swift
+++ b/NetNewsWire/MainWindow/MainWindowController.swift
@@ -11,12 +11,11 @@ import Articles
 import Account
 import RSCore
 
-class MainWindowController : NSWindowController, NSUserInterfaceValidations {
+class MainWindowController : NSWindowController, NSUserInterfaceValidations, NSWindowDelegate {
 
 	@IBOutlet var toolbarDelegate: MainWindowToolbarDelegate?
 	private var sharingServicePickerDelegate: NSSharingServicePickerDelegate?
 
-	private let windowAutosaveName = NSWindow.FrameAutosaveName("MainWindow")
 	static var didPositionWindowOnFirstRun = false
 
 	private var currentFeedOrFolder: AnyObject? = nil {
@@ -43,7 +42,6 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 			window?.titleVisibility = .hidden
 		}
 
-		window?.setFrameUsingName(windowAutosaveName, force: true)
 		if AppDefaults.isFirstRun && !MainWindowController.didPositionWindowOnFirstRun {
 
 			if let window = window {
@@ -56,9 +54,6 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 		}
 
 		detailSplitViewItem?.minimumThickness = CGFloat(MainWindowController.detailViewMinimumThickness)
-		restoreSplitViewState()
-
-		NotificationCenter.default.addObserver(self, selector: #selector(applicationWillTerminate(_:)), name: NSApplication.willTerminateNotification, object: nil)
 
 		NotificationCenter.default.addObserver(self, selector: #selector(refreshProgressDidChange(_:)), name: .AccountRefreshDidBegin, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(refreshProgressDidChange(_:)), name: .AccountRefreshDidFinish, object: nil)
@@ -75,12 +70,6 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 
 	// MARK: - API
 
-	func saveState() {
-
-		saveSplitViewState()
-	}
-
-
 	func selectedObjectsInSidebar() -> [AnyObject]? {
 
 		return sidebarViewController?.selectedObjects
@@ -88,10 +77,12 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 
 	// MARK: - Notifications
 
-	@objc func applicationWillTerminate(_ note: Notification) {
+	func window(_ window: NSWindow, willEncodeRestorableState state: NSCoder) {
+		saveSplitViewState(to: state)
+	}
 
-		saveState()
-		window?.saveFrame(usingName: windowAutosaveName)
+	func window(_ window: NSWindow, didDecodeRestorableState state: NSCoder) {
+		restoreSplitViewState(from: state)
 	}
 
 	@objc func refreshProgressDidChange(_ note: Notification) {
@@ -396,7 +387,9 @@ extension MainWindowController : ScriptingMainWindowController {
 // MARK: - Private
 
 private extension MainWindowController {
-	
+
+	private static let mainWindowWidthsStateKey = "mainWindowWidths"
+
 	var splitViewController: NSSplitViewController? {
 		guard let viewController = contentViewController else {
 			return nil
@@ -583,7 +576,7 @@ private extension MainWindowController {
 		
 	}
 
-	func saveSplitViewState() {
+	func saveSplitViewState(to coder: NSCoder) {
 
 		// TODO: Update this for multiple windows.
 
@@ -592,16 +585,25 @@ private extension MainWindowController {
 		}
 
 		let widths = splitView.arrangedSubviews.map{ Int(floor($0.frame.width)) }
-		if AppDefaults.mainWindowWidths != widths {
-			AppDefaults.mainWindowWidths = widths
-		}
+		coder.encode(widths, forKey: MainWindowController.mainWindowWidthsStateKey)
+
 	}
 
-	func restoreSplitViewState() {
+	func arrayOfIntFromCoder(_ coder: NSCoder, withKey: String) -> [Int]? {
+		let decodedFloats: [Int]?
+		do {
+			decodedFloats = try coder.decodeTopLevelObject(forKey: MainWindowController.mainWindowWidthsStateKey) as? [Int]? ?? nil
+		}
+		catch {
+			decodedFloats = nil
+		}
+		return decodedFloats
+	}
+
+	func restoreSplitViewState(from coder: NSCoder) {
 
 		// TODO: Update this for multiple windows.
-
-		guard let splitView = splitViewController?.splitView, let widths = AppDefaults.mainWindowWidths, widths.count == 3, let window = window else {
+		guard let splitView = splitViewController?.splitView, let widths = arrayOfIntFromCoder(coder, withKey: MainWindowController.mainWindowWidthsStateKey), widths.count == 3, let window = window else {
 			return
 		}
 

--- a/NetNewsWire/MainWindow/Sidebar/SidebarViewController.swift
+++ b/NetNewsWire/MainWindow/Sidebar/SidebarViewController.swift
@@ -70,6 +70,26 @@ import RSCore
 		}
 	}
 
+	// MARK: State Restoration
+
+	private static let stateRestorationSelectedRowIndexes = "selectedRowIndexes"
+
+	override func encodeRestorableState(with coder: NSCoder) {
+
+		super.encodeRestorableState(with: coder)
+
+		coder.encode(outlineView.selectedRowIndexes, forKey: SidebarViewController.stateRestorationSelectedRowIndexes)
+	}
+
+	override func restoreState(with coder: NSCoder) {
+
+		super.restoreState(with: coder)
+
+		if let restoredRowIndexes = coder.decodeObject(of: [NSIndexSet.self], forKey: SidebarViewController.stateRestorationSelectedRowIndexes) as? IndexSet {
+			outlineView.selectRowIndexes(restoredRowIndexes, byExtendingSelection: false)
+		}
+	}
+
 	// MARK: - Notifications
 
 	@objc func unreadCountDidChange(_ note: Notification) {
@@ -278,6 +298,8 @@ import RSCore
     func outlineViewSelectionDidChange(_ notification: Notification) {
 
 		postSidebarSelectionDidChangeNotification(selectedObjects.isEmpty ? nil : selectedObjects)
+
+		self.invalidateRestorableState()
     }
 
 	//MARK: - Node Manipulation

--- a/NetNewsWire/MainWindow/Timeline/TimelineViewController.swift
+++ b/NetNewsWire/MainWindow/Timeline/TimelineViewController.swift
@@ -143,6 +143,26 @@ class TimelineViewController: NSViewController, UndoableCommandRunner {
 		sharingServiceDelegate = SharingServiceDelegate(self.view.window)
 	}
 
+	// MARK: State Restoration
+
+	private static let stateRestorationSelectedArticles = "selectedArticles"
+
+	override func encodeRestorableState(with coder: NSCoder) {
+
+		super.encodeRestorableState(with: coder)
+
+		coder.encode(self.selectedArticleIDs(), forKey: TimelineViewController.stateRestorationSelectedArticles)
+	}
+
+	override func restoreState(with coder: NSCoder) {
+
+		super.restoreState(with: coder)
+
+		if let restoredArticleIDs = (try? coder.decodeTopLevelObject(forKey: TimelineViewController.stateRestorationSelectedArticles)) as? [String] {
+			self.restoreSelection(restoredArticleIDs)
+		}
+	}
+
 	// MARK: Appearance Change
 
 	private func fontSizeDidChange() {
@@ -618,6 +638,8 @@ extension TimelineViewController: NSTableViewDelegate {
 		}
 
 		postTimelineSelectionDidChangeNotification(selectedArticles)
+
+		self.invalidateRestorableState()
 	}
 
 	private func postTimelineSelectionDidChangeNotification(_ selectedArticles: ArticleArray?) {


### PR DESCRIPTION
I started looking at state restoration because I wanted to fix #547. I didn't quite figure out the best way to implement that but in the process of poking at it I revised the main window restoration approach to use standard state restoration. I noticed in #134 you mentioned wanting to use standard mechanism if possible so I offer this revision in that spirit. I don't think you need to include the manual window frame autosave name stuff either because I think it's automatically handled by AppKit's default state restoration.