### PR TITLE
Made sure an item in the timeline is selected - Issue #558

### DIFF
--- a/NetNewsWire/MainWindow/Timeline/TimelineTableView.swift
+++ b/NetNewsWire/MainWindow/Timeline/TimelineTableView.swift
@@ -20,6 +20,16 @@ class TimelineTableView: NSTableView {
 		}
 		super.keyDown(with: event)
 	}
+	
+	override func becomeFirstResponder() -> Bool {
+		if super.becomeFirstResponder() {
+			if selectedRow == -1 && numberOfRows > 0 {
+				rs_selectRowAndScrollToVisible(0)
+			}
+			return true
+		}
+		return false
+	}
 
 	// MARK: - NSView
 

--- a/NetNewsWire/MainWindow/Timeline/TimelineViewController.swift
+++ b/NetNewsWire/MainWindow/Timeline/TimelineViewController.swift
@@ -369,15 +369,12 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner {
 	}
 
 	func focus() {
-
+		
 		guard let window = tableView.window else {
 			return
 		}
-
+		
 		window.makeFirstResponderUnlessDescendantIsFirstResponder(tableView)
-		if !hasAtLeastOneSelectedArticle && articles.count > 0 {
-			tableView.rs_selectRowAndScrollToVisible(0)
-		}
 	}
 
 	// MARK: - Notifications


### PR DESCRIPTION
I left the behavior where it is the first item selected in the timeline when nothing is selected as opposed to the @danielpunkass suggestion of selecting the first unread one.