### PR TITLE
Update user defaults in technote to match script

### DIFF
--- a/Technotes/RestoreToFactory.md
+++ b/Technotes/RestoreToFactory.md
@@ -6,7 +6,7 @@ Here’s how to start over with untouched preferences and default feeds:
 
 2. Delete the application support folder. On the command line, do: `rm -rf ~/Library/Application\ Support/NetNewsWire/`
 
-3. Delete the preferences. Just deleting the file won’t do the trick — it’s necessary to use the command line. Do: `defaults delete com.ranchero.NetNewsWire` and then `killall cfprefsd`
+3. Delete the preferences. Just deleting the file won’t do the trick — it’s necessary to use the command line. Do: `defaults delete com.ranchero.NetNewsWire-Evergreen` and then `killall cfprefsd`
 
 Launch NetNewsWire. You should have the default feeds, and all preferences should be reset to their default settings.
 


### PR DESCRIPTION
I noticed that the procedure for restoring factory defaults (as described in a technote) was out of date, so I made this simple change to bring it in line with the `cleanPrefsAndData` script.

I noticed that the following steps are still undocumented—should they be mentioned, as well?

```
defaults delete com.ranchero.NetNewsWire-Evergreen.mas

rm -rf ~/Library/Containers/com.ranchero.NetNewsWire-Evergreen.mas
```