### PR TITLE
 Fixed a crash that occurs when trying to add a new feed with no active accounts

### DIFF
--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -227,6 +227,10 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 
 			return true
 		}
+		
+		if item.action == #selector(showAddFeedWindow(_:)) {
+			return canAddNewFeed()
+		}
 
 		return true
 	}
@@ -590,6 +594,10 @@ private extension MainWindowController {
 	func canMarkAllAsRead() -> Bool {
 		
 		return currentTimelineViewController?.canMarkAllAsRead() ?? false
+	}
+	
+	func canAddNewFeed() -> Bool {
+		return sidebarViewController?.canAddNewFeed() ?? false
 	}
 
 	func validateToggleRead(_ item: NSValidatedUserInterfaceItem) -> Bool {

--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -231,6 +231,10 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 		if item.action == #selector(showAddFeedWindow(_:)) {
 			return canAddNewFeed()
 		}
+		
+		if item.action == #selector(showAddFolderWindow(_:)) {
+			return canAddNewFolder()
+		}
 
 		return true
 	}
@@ -598,6 +602,10 @@ private extension MainWindowController {
 	
 	func canAddNewFeed() -> Bool {
 		return sidebarViewController?.canAddNewFeed() ?? false
+	}
+	
+	func canAddNewFolder() -> Bool {
+		return sidebarViewController?.canAddNewFolder() ?? false
 	}
 
 	func validateToggleRead(_ item: NSValidatedUserInterfaceItem) -> Bool {

--- a/Mac/MainWindow/Sidebar/SidebarViewController.swift
+++ b/Mac/MainWindow/Sidebar/SidebarViewController.swift
@@ -365,6 +365,10 @@ protocol SidebarDelegate: class {
 		return !accountNodes.isEmpty
 	}
 	
+	func canAddNewFolder() -> Bool {
+		return !accountNodes.isEmpty
+	}
+	
 }
 
 // MARK: - NSUserInterfaceValidations

--- a/Mac/MainWindow/Sidebar/SidebarViewController.swift
+++ b/Mac/MainWindow/Sidebar/SidebarViewController.swift
@@ -345,10 +345,9 @@ protocol SidebarDelegate: class {
 	// MARK: - API
 
 	func rebuildTreeAndRestoreSelection() {
-		
-		let savedAccounts = treeController.rootNode.childNodes.compactMap { $0.representedObject as? Account }
-		
+		let savedAccounts = accountNodes
 		let savedSelection = selectedNodes
+		
 		rebuildTreeAndReloadDataIfNeeded()
 		restoreSelection(to: savedSelection, sendNotificationIfChanged: true)
 		
@@ -361,6 +360,11 @@ protocol SidebarDelegate: class {
 		}
 		
 	}
+	
+	func canAddNewFeed() -> Bool {
+		return !accountNodes.isEmpty
+	}
+	
 }
 
 // MARK: - NSUserInterfaceValidations
@@ -379,6 +383,10 @@ extension SidebarViewController: NSUserInterfaceValidations {
 //MARK: - Private
 
 private extension SidebarViewController {
+	
+	var accountNodes: [Account] {
+		return treeController.rootNode.childNodes.compactMap { $0.representedObject as? Account }
+	}
 	
 	var selectedNodes: [Node] {
 		if let nodes = outlineView.selectedItems as? [Node] {


### PR DESCRIPTION
#### Description

Fixed a crash that occurs when you have no active accounts, but try to add a new feed.

#### Details

The actual crash was occurring in `AddFeedWindowController.addFeed(_:)` as a result of force unwrapping the selected container. To fix the crash, I disabled the add feed toolbar item when there are no active accounts. Since the add feed toolbar item is now disabled when there are no active accounts, I also disabled the add folder toolbar item.

#### Question

At this point, the only toolbar item that's enabled when you have no active accounts is refresh all feeds. It doesn't hurt to leave it enabled, but it looks weird having *that* toolbar item enabled when all of the rest are disabled. Should we disable that toolbar item as well?