### PR TITLE
Improved size and layout of add feed / folder popover on iPad

### DIFF
--- a/Frameworks/Account/Account.swift
+++ b/Frameworks/Account/Account.swift
@@ -67,6 +67,21 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 		public static let feeds = "feeds" // AccountDidDownloadArticles, StatusesDidChange
 	}
 
+	public static let defaultLocalAccountName: String = {
+		let defaultName: String
+		#if os(macOS)
+		defaultName = NSLocalizedString("On My Mac", comment: "Account name")
+		#else
+		if UIDevice.current.userInterfaceIdiom == .pad {
+			defaultName = NSLocalizedString("On My iPad", comment: "Account name")
+		} else {
+			defaultName = NSLocalizedString("On My iPhone", comment: "Account name")
+		}
+		#endif
+		
+		return defaultName
+	}()
+	
 	public let accountID: String
 	public let type: AccountType
 	public var nameForDisplay: String {
@@ -220,15 +235,7 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 
 		switch type {
 		case .onMyMac:
-			#if os(macOS)
-			defaultName = NSLocalizedString("On My Mac", comment: "Account name")
-			#else
-			if UIDevice.current.userInterfaceIdiom == .pad {
-				defaultName = NSLocalizedString("On My iPad", comment: "Account name")
-			} else {
-				defaultName = NSLocalizedString("On My iPhone", comment: "Account name")
-			}
-			#endif
+			defaultName = Account.defaultLocalAccountName
 		case .feedly:
 			defaultName = "Feedly"
 		case .feedbin:

--- a/Mac/Preferences/Accounts/AccountsAddLocal.xib
+++ b/Mac/Preferences/Accounts/AccountsAddLocal.xib
@@ -7,6 +7,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="AccountsAddLocalWindowController" customModule="NetNewsWire" customModuleProvider="target">
             <connections>
+                <outlet property="localAccountNameTextField" destination="80D-3X-rL2" id="B6t-AS-hDh"/>
                 <outlet property="nameTextField" destination="f9b-FM-i8Q" id="TJl-Uc-PNg"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="ENN-6Q-J5m"/>
             </connections>
@@ -17,13 +18,13 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="398" height="205"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1129"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="398" height="205"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <stackView distribution="fill" orientation="horizontal" alignment="bottom" spacing="19" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uDK-ji-zlT">
-                        <rect key="frame" x="93" y="150" width="213" height="39"/>
+                        <rect key="frame" x="95" y="150" width="209" height="39"/>
                         <subviews>
                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ySx-qg-WbT">
                                 <rect key="frame" x="0.0" y="0.0" width="36" height="36"/>
@@ -34,7 +35,7 @@
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="accountLocal" id="9RZ-J3-ioX"/>
                             </imageView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="80D-3X-rL2">
-                                <rect key="frame" x="53" y="0.0" width="162" height="39"/>
+                                <rect key="frame" x="53" y="0.0" width="158" height="39"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="On My Mac" id="1d2-Mx-TKe">
                                     <font key="font" metaFont="system" size="32"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>

--- a/Mac/Preferences/Accounts/AccountsAddLocalWindowController.swift
+++ b/Mac/Preferences/Accounts/AccountsAddLocalWindowController.swift
@@ -11,12 +11,19 @@ import Account
 
 class AccountsAddLocalWindowController: NSWindowController {
 
-	@IBOutlet weak var nameTextField: NSTextField!
-
+	@IBOutlet private weak var nameTextField: NSTextField!
+	@IBOutlet private weak var localAccountNameTextField: NSTextField!
+	
 	private weak var hostWindow: NSWindow?
 
 	convenience init() {
 		self.init(windowNibName: NSNib.Name("AccountsAddLocal"))
+	}
+	
+	override func windowDidLoad() {
+		super.windowDidLoad()
+		
+		localAccountNameTextField.stringValue = Account.defaultLocalAccountName
 	}
 	
 	// MARK: API

--- a/Mac/Preferences/Accounts/AccountsAddViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsAddViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import AppKit
+import Account
 
 class AccountsAddViewController: NSViewController {
 	
@@ -57,7 +58,7 @@ extension AccountsAddViewController: NSTableViewDelegate {
 		if let cell = tableView.makeView(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: "Cell"), owner: nil) as? AccountsAddTableCellView {
 			switch row {
 			case 0:
-				cell.accountNameLabel?.stringValue = NSLocalizedString("On My Mac", comment: "Local")
+				cell.accountNameLabel?.stringValue = Account.defaultLocalAccountName
 				cell.accountImageView?.image = AppImages.accountLocal
 			case 1:
 				cell.accountNameLabel?.stringValue = NSLocalizedString("Feedbin", comment: "Feedbin")

--- a/iOS/Add/Add.storyboard
+++ b/iOS/Add/Add.storyboard
@@ -31,7 +31,7 @@
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="URL" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eRp-AP-WFq">
                                                     <rect key="frame" x="20" y="4" width="335" height="35.666666666666664"/>
                                                     <nil key="textColor"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="URL"/>
                                                 </textField>
                                             </subviews>
@@ -53,7 +53,7 @@
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Title (Optional)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u7n-VL-Ho9">
                                                     <rect key="frame" x="20" y="4" width="335" height="35.666666666666664"/>
                                                     <nil key="textColor"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
                                             </subviews>
@@ -77,26 +77,25 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Folder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="grZ-g6-qfm">
-                                                    <rect key="frame" x="23.999999999999996" y="15" width="48.666666666666657" height="14"/>
+                                                    <rect key="frame" x="19.999999999999996" y="4" width="48.666666666666657" height="35.666666666666664"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vaV-kY-CaE">
-                                                    <rect key="frame" x="325" y="15" width="42" height="14"/>
+                                                    <rect key="frame" x="313" y="11.666666666666666" width="42" height="20.333333333333336"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="vaV-kY-CaE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="grZ-g6-qfm" secondAttribute="trailing" constant="8" id="1Dk-MH-7Hw"/>
-                                                <constraint firstItem="grZ-g6-qfm" firstAttribute="top" secondItem="sZh-wI-IW4" secondAttribute="topMargin" constant="4" id="9dF-Uj-lPA"/>
-                                                <constraint firstItem="grZ-g6-qfm" firstAttribute="leading" secondItem="sZh-wI-IW4" secondAttribute="leadingMargin" constant="8" id="NKz-GB-i4E"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="vaV-kY-CaE" secondAttribute="bottom" constant="4" id="Yfx-6j-UqX"/>
-                                                <constraint firstItem="vaV-kY-CaE" firstAttribute="trailing" secondItem="sZh-wI-IW4" secondAttribute="trailingMargin" constant="8" id="eCs-ob-UXo"/>
-                                                <constraint firstItem="vaV-kY-CaE" firstAttribute="top" secondItem="sZh-wI-IW4" secondAttribute="topMargin" constant="4" id="hUO-Ln-i29"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="grZ-g6-qfm" secondAttribute="bottom" constant="4" id="tu3-aF-XD6"/>
+                                                <constraint firstItem="vaV-kY-CaE" firstAttribute="centerY" secondItem="grZ-g6-qfm" secondAttribute="centerY" id="4I1-oT-KFl"/>
+                                                <constraint firstItem="grZ-g6-qfm" firstAttribute="leading" secondItem="sZh-wI-IW4" secondAttribute="leading" constant="20" symbolic="YES" id="5tF-au-Zv8"/>
+                                                <constraint firstAttribute="trailing" secondItem="vaV-kY-CaE" secondAttribute="trailing" constant="20" symbolic="YES" id="96f-HQ-Y0z"/>
+                                                <constraint firstItem="vaV-kY-CaE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="grZ-g6-qfm" secondAttribute="trailing" constant="8" id="Hzx-N0-6NB"/>
+                                                <constraint firstItem="grZ-g6-qfm" firstAttribute="top" secondItem="sZh-wI-IW4" secondAttribute="top" constant="4" id="PSY-sG-VGF"/>
+                                                <constraint firstAttribute="bottom" secondItem="grZ-g6-qfm" secondAttribute="bottom" constant="4" id="SwU-Ai-DiZ"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>

--- a/iOS/Add/Add.storyboard
+++ b/iOS/Add/Add.storyboard
@@ -259,7 +259,7 @@
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lZK-wx-jbo">
                                                     <rect key="frame" x="20" y="4" width="335" height="35.666666666666664"/>
                                                     <nil key="textColor"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
                                             </subviews>
@@ -289,7 +289,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mxj-Bw-Jfx">
-                                                    <rect key="frame" x="325" y="15" width="42" height="14"/>
+                                                    <rect key="frame" x="313" y="11.666666666666666" width="42" height="20.333333333333336"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -297,10 +297,9 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="YRf-I7-nkL" firstAttribute="top" secondItem="y2g-dW-fPZ" secondAttribute="top" constant="4" id="7ey-y0-Aef"/>
-                                                <constraint firstItem="mxj-Bw-Jfx" firstAttribute="trailing" secondItem="y2g-dW-fPZ" secondAttribute="trailingMargin" constant="8" id="Aip-HI-gf6"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="mxj-Bw-Jfx" secondAttribute="bottom" constant="4" id="KY1-7G-Jh8"/>
+                                                <constraint firstItem="mxj-Bw-Jfx" firstAttribute="centerY" secondItem="YRf-I7-nkL" secondAttribute="centerY" id="FDk-71-7yD"/>
+                                                <constraint firstAttribute="trailing" secondItem="mxj-Bw-Jfx" secondAttribute="trailing" constant="20" symbolic="YES" id="fIA-Rb-SEi"/>
                                                 <constraint firstAttribute="bottom" secondItem="YRf-I7-nkL" secondAttribute="bottom" constant="4" id="fcs-rL-KrO"/>
-                                                <constraint firstItem="mxj-Bw-Jfx" firstAttribute="top" secondItem="y2g-dW-fPZ" secondAttribute="topMargin" constant="4" id="pHr-Ke-jZ0"/>
                                                 <constraint firstItem="YRf-I7-nkL" firstAttribute="leading" secondItem="y2g-dW-fPZ" secondAttribute="leading" constant="20" symbolic="YES" id="xBK-tz-P2j"/>
                                             </constraints>
                                         </tableViewCellContentView>

--- a/iOS/Add/Add.storyboard
+++ b/iOS/Add/Add.storyboard
@@ -28,10 +28,10 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="URL" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eRp-AP-WFq">
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="URL" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eRp-AP-WFq">
                                                     <rect key="frame" x="20" y="4" width="335" height="35.666666666666664"/>
                                                     <nil key="textColor"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="URL"/>
                                                 </textField>
                                             </subviews>
@@ -50,10 +50,10 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Title (Optional)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u7n-VL-Ho9">
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Title (Optional)" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u7n-VL-Ho9">
                                                     <rect key="frame" x="20" y="4" width="335" height="35.666666666666664"/>
                                                     <nil key="textColor"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
                                             </subviews>
@@ -76,15 +76,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Folder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="grZ-g6-qfm">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Folder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="grZ-g6-qfm">
                                                     <rect key="frame" x="19.999999999999996" y="4" width="48.666666666666657" height="35.666666666666664"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vaV-kY-CaE">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vaV-kY-CaE">
                                                     <rect key="frame" x="313" y="11.666666666666666" width="42" height="20.333333333333336"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -255,10 +255,10 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lZK-wx-jbo">
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Name" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lZK-wx-jbo">
                                                     <rect key="frame" x="20" y="4" width="335" height="35.666666666666664"/>
                                                     <nil key="textColor"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
                                             </subviews>
@@ -281,15 +281,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YRf-I7-nkL">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YRf-I7-nkL">
                                                     <rect key="frame" x="20" y="4" width="64" height="35.666666666666664"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mxj-Bw-Jfx">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mxj-Bw-Jfx">
                                                     <rect key="frame" x="313" y="11.666666666666666" width="42" height="20.333333333333336"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>

--- a/iOS/Add/Add.storyboard
+++ b/iOS/Add/Add.storyboard
@@ -14,7 +14,7 @@
         <scene sceneID="2Tc-JN-edX">
             <objects>
                 <tableViewController storyboardIdentifier="AddFeedViewController" id="7aE-6a-iP7" customClass="AddFeedViewController" customModule="NetNewsWire" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="1" sectionFooterHeight="5" id="D0S-TM-mtm">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="grouped" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="1" sectionFooterHeight="5" id="D0S-TM-mtm">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
@@ -100,15 +100,15 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="200" id="PiN-2i-6Dj">
-                                        <rect key="frame" x="0.0" y="173" width="375" height="200"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="140" id="PiN-2i-6Dj">
+                                        <rect key="frame" x="0.0" y="173" width="375" height="140"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PiN-2i-6Dj" id="sZ4-hj-gua">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="199.66666666666666"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="139.66666666666666"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="v2n-nX-8jq">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="199.66666666666666"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="139.66666666666666"/>
                                                 </pickerView>
                                             </subviews>
                                             <constraints>
@@ -242,7 +242,7 @@
         <scene sceneID="m7L-uI-ghq">
             <objects>
                 <tableViewController storyboardIdentifier="AddFolderViewController" id="3dI-34-ljo" customClass="AddFolderViewController" customModule="NetNewsWire" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="1" sectionFooterHeight="5" id="7xa-gZ-zHA">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="grouped" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="1" sectionFooterHeight="5" id="7xa-gZ-zHA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
@@ -305,15 +305,15 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="200" id="zRi-p6-4KU">
-                                        <rect key="frame" x="0.0" y="129" width="375" height="200"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="140" id="zRi-p6-4KU">
+                                        <rect key="frame" x="0.0" y="129" width="375" height="140"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zRi-p6-4KU" id="wek-Qh-OXr">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="199.66666666666666"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="139.66666666666666"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eGY-V8-gzJ">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="199.66666666666666"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="139.66666666666666"/>
                                                 </pickerView>
                                             </subviews>
                                             <constraints>

--- a/iOS/Add/Add.storyboard
+++ b/iOS/Add/Add.storyboard
@@ -299,6 +299,7 @@
                                                 <constraint firstItem="mxj-Bw-Jfx" firstAttribute="centerY" secondItem="YRf-I7-nkL" secondAttribute="centerY" id="FDk-71-7yD"/>
                                                 <constraint firstAttribute="trailing" secondItem="mxj-Bw-Jfx" secondAttribute="trailing" constant="20" symbolic="YES" id="fIA-Rb-SEi"/>
                                                 <constraint firstAttribute="bottom" secondItem="YRf-I7-nkL" secondAttribute="bottom" constant="4" id="fcs-rL-KrO"/>
+                                                <constraint firstItem="mxj-Bw-Jfx" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YRf-I7-nkL" secondAttribute="trailing" constant="8" id="rQ8-3l-2gz"/>
                                                 <constraint firstItem="YRf-I7-nkL" firstAttribute="leading" secondItem="y2g-dW-fPZ" secondAttribute="leading" constant="20" symbolic="YES" id="xBK-tz-P2j"/>
                                             </constraints>
                                         </tableViewCellContentView>

--- a/iOS/Add/AddContainerViewController.swift
+++ b/iOS/Add/AddContainerViewController.swift
@@ -23,6 +23,8 @@ protocol AddContainerViewControllerChildDelegate: UIViewController {
 
 class AddContainerViewController: UIViewController {
 
+	static let preferredContentSizeForFormSheetDisplay = CGSize(width: 360.0, height: 400.0)
+	
 	@IBOutlet weak var cancelButton: UIBarButtonItem!
 	@IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
 	@IBOutlet weak var addButton: UIBarButtonItem!

--- a/iOS/Add/AddContainerViewController.swift
+++ b/iOS/Add/AddContainerViewController.swift
@@ -23,7 +23,7 @@ protocol AddContainerViewControllerChildDelegate: UIViewController {
 
 class AddContainerViewController: UIViewController {
 
-	static let preferredContentSizeForFormSheetDisplay = CGSize(width: 360.0, height: 400.0)
+	static let preferredContentSizeForFormSheetDisplay = CGSize(width: 460.0, height: 400.0)
 	
 	@IBOutlet weak var cancelButton: UIBarButtonItem!
 	@IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!

--- a/iOS/Add/AddFeedViewController.swift
+++ b/iOS/Add/AddFeedViewController.swift
@@ -126,11 +126,12 @@ class AddFeedViewController: UITableViewController, AddContainerViewControllerCh
 	}
 	
 	override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-		if section == 1 {
-			return shouldDisplayPicker ? 2 : 1
+		let defaultNumberOfRows = super.tableView(tableView, numberOfRowsInSection: section)
+		if section == 1 && !shouldDisplayPicker {
+			return defaultNumberOfRows - 1
 		}
 		
-		return super.tableView(tableView, numberOfRowsInSection: section)
+		return defaultNumberOfRows
 	}
 	
 	

--- a/iOS/Add/AddFeedViewController.swift
+++ b/iOS/Add/AddFeedViewController.swift
@@ -14,12 +14,15 @@ import RSParser
 
 class AddFeedViewController: UITableViewController, AddContainerViewControllerChild {
 	
-	@IBOutlet weak var urlTextField: UITextField!
-	@IBOutlet weak var nameTextField: UITextField!
-	@IBOutlet weak var folderPickerView: UIPickerView!
-	@IBOutlet weak var folderLabel: UILabel!
+	@IBOutlet private weak var urlTextField: UITextField!
+	@IBOutlet private weak var nameTextField: UITextField!
+	@IBOutlet private weak var folderPickerView: UIPickerView!
+	@IBOutlet private weak var folderLabel: UILabel!
 	
-	private var pickerData: AddFeedFolderPickerData!
+	private lazy var pickerData: AddFeedFolderPickerData = AddFeedFolderPickerData()
+	private var shouldDisplayPicker: Bool {
+		return pickerData.containerNames.count > 1
+	}
 	
 	private var userCancelled = false
 
@@ -42,13 +45,16 @@ class AddFeedViewController: UITableViewController, AddContainerViewControllerCh
 		
 		nameTextField.text = initialFeedName
 		nameTextField.delegate = self
+		folderLabel.text = pickerData.containerNames.first
 		
-		pickerData = AddFeedFolderPickerData()
-		folderPickerView.dataSource = self
-		folderPickerView.delegate = self
-		folderPickerView.showsSelectionIndicator = true
-		folderLabel.text = pickerData.containerNames[0]
-
+		if shouldDisplayPicker {
+			folderPickerView.dataSource = self
+			folderPickerView.delegate = self
+			folderPickerView.showsSelectionIndicator = true
+		} else {
+			folderPickerView.isHidden = true
+		}
+		
 		// I couldn't figure out the gap at the top of the UITableView, so I took a hammer to it.
 		tableView.contentInset = UIEdgeInsets(top: -28, left: 0, bottom: 0, right: 0)
 		
@@ -118,6 +124,15 @@ class AddFeedViewController: UITableViewController, AddContainerViewControllerCh
 	@objc func textDidChange(_ note: Notification) {
 		delegate?.readyToAdd(state: urlTextField.text?.rs_stringMayBeURL() ?? false)
 	}
+	
+	override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+		if section == 1 {
+			return shouldDisplayPicker ? 2 : 1
+		}
+		
+		return super.tableView(tableView, numberOfRowsInSection: section)
+	}
+	
 	
 }
 

--- a/iOS/Add/AddFeedViewController.swift
+++ b/iOS/Add/AddFeedViewController.swift
@@ -34,12 +34,14 @@ class AddFeedViewController: UITableViewController, AddContainerViewControllerCh
 		urlTextField.autocorrectionType = .no
 		urlTextField.autocapitalizationType = .none
 		urlTextField.text = initialFeed
+		urlTextField.delegate = self
 		
 		if initialFeed != nil {
 			delegate?.readyToAdd(state: true)
 		}
 		
 		nameTextField.text = initialFeedName
+		nameTextField.delegate = self
 		
 		pickerData = AddFeedFolderPickerData()
 		folderPickerView.dataSource = self
@@ -197,6 +199,15 @@ private extension AddFeedViewController {
 			}
 		}
 		
+	}
+	
+}
+
+extension AddFeedViewController: UITextFieldDelegate {
+	
+	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+		textField.resignFirstResponder()
+		return true
 	}
 	
 }

--- a/iOS/Add/AddFolderViewController.swift
+++ b/iOS/Add/AddFolderViewController.swift
@@ -64,11 +64,12 @@ class AddFolderViewController: UITableViewController, AddContainerViewController
 	}
 	
 	override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+		let defaultNumberOfRows = super.tableView(tableView, numberOfRowsInSection: section)
 		if section == 1 && !shouldDisplayPicker {
-			return 1
+			return defaultNumberOfRows - 1
 		}
 		
-		return super.tableView(tableView, numberOfRowsInSection: section)
+		return defaultNumberOfRows	
 	}
 }
 

--- a/iOS/Add/AddFolderViewController.swift
+++ b/iOS/Add/AddFolderViewController.swift
@@ -12,9 +12,13 @@ import RSCore
 
 class AddFolderViewController: UITableViewController, AddContainerViewControllerChild {
 
-	@IBOutlet weak var nameTextField: UITextField!
-	@IBOutlet weak var accountLabel: UILabel!
-	@IBOutlet weak var accountPickerView: UIPickerView!
+	@IBOutlet private weak var nameTextField: UITextField!
+	@IBOutlet private weak var accountLabel: UILabel!
+	@IBOutlet private weak var accountPickerView: UIPickerView!
+	
+	private var shouldDisplayPicker: Bool {
+		return accounts.count > 1
+	}
 	
 	private var accounts: [Account]!
 	
@@ -25,10 +29,16 @@ class AddFolderViewController: UITableViewController, AddContainerViewController
 		super.viewDidLoad()
 		
 		accounts = AccountManager.shared.sortedActiveAccounts
+		
+		nameTextField.delegate = self
 		accountLabel.text = (accounts[0] as DisplayNameProvider).nameForDisplay
 		
-		accountPickerView.dataSource = self
-		accountPickerView.delegate = self
+		if shouldDisplayPicker {
+			accountPickerView.dataSource = self
+			accountPickerView.delegate = self
+		} else {
+			accountPickerView.isHidden = true
+		}
 		
 		// I couldn't figure out the gap at the top of the UITableView, so I took a hammer to it.
 		tableView.contentInset = UIEdgeInsets(top: -28, left: 0, bottom: 0, right: 0)
@@ -53,6 +63,13 @@ class AddFolderViewController: UITableViewController, AddContainerViewController
 		delegate?.readyToAdd(state: !(nameTextField.text?.isEmpty ?? false))
 	}
 	
+	override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+		if section == 1 && !shouldDisplayPicker {
+			return 1
+		}
+		
+		return super.tableView(tableView, numberOfRowsInSection: section)
+	}
 }
 
 extension AddFolderViewController: UIPickerViewDataSource, UIPickerViewDelegate {
@@ -71,6 +88,15 @@ extension AddFolderViewController: UIPickerViewDataSource, UIPickerViewDelegate 
 	
 	func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
 		accountLabel.text = (accounts[row] as DisplayNameProvider).nameForDisplay
+	}
+	
+}
+
+extension AddFolderViewController: UITextFieldDelegate {
+	
+	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+		textField.resignFirstResponder()
+		return true
 	}
 	
 }

--- a/iOS/Base.lproj/Main.storyboard
+++ b/iOS/Base.lproj/Main.storyboard
@@ -259,6 +259,7 @@
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="addNewItemButton" destination="yo6-w4-SfI" id="NbL-RH-N4J"/>
                         <outlet property="markAllAsReadButton" destination="ddj-Ya-Wol" id="jjr-OK-4zl"/>
                     </connections>
                 </tableViewController>

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -49,7 +49,7 @@ class MasterFeedViewController: ProgressTableViewController, UndoableCommandRunn
 	}
 
 	override func viewWillAppear(_ animated: Bool) {
-		clearsSelectionOnViewWillAppear = splitViewController!.isCollapsed
+		clearsSelectionOnViewWillAppear = true
 		navigationController?.title = NSLocalizedString("Feeds", comment: "Feeds")
 		super.viewWillAppear(animated)
 	}

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -434,8 +434,10 @@ class MasterFeedViewController: ProgressTableViewController, UndoableCommandRunn
 	
 	@IBAction func add(_ sender: UIBarButtonItem) {
 		let addViewController = UIStoryboard.add.instantiateInitialViewController()!
-		addViewController.modalPresentationStyle = .popover
+		addViewController.modalPresentationStyle = .formSheet
+		addViewController.preferredContentSize = AddContainerViewController.preferredContentSizeForFormSheetDisplay
 		addViewController.popoverPresentationController?.barButtonItem = sender
+		
 		self.present(addViewController, animated: true)
 	}
 	

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -14,7 +14,8 @@ import RSTree
 
 class MasterFeedViewController: ProgressTableViewController, UndoableCommandRunner {
 
-	@IBOutlet weak var markAllAsReadButton: UIBarButtonItem!
+	@IBOutlet private weak var markAllAsReadButton: UIBarButtonItem!
+	@IBOutlet private weak var addNewItemButton: UIBarButtonItem!
 	
 	var undoableCommands = [UndoableCommand]()
 	
@@ -596,6 +597,7 @@ private extension MasterFeedViewController {
 	
 	func updateUI() {
 		markAllAsReadButton.isEnabled = navState.isAnyUnreadAvailable
+		addNewItemButton.isEnabled = !AccountManager.shared.activeAccounts.isEmpty
 	}
 
 	func configureCellsForRepresentedObject(_ representedObject: AnyObject) {

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -36,7 +36,9 @@ class MasterFeedViewController: ProgressTableViewController, UndoableCommandRunn
 		NotificationCenter.default.addObserver(self, selector: #selector(faviconDidBecomeAvailable(_:)), name: .FaviconDidBecomeAvailable, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(feedSettingDidChange(_:)), name: .FeedSettingDidChange, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(userDidAddFeed(_:)), name: .UserDidAddFeed, object: nil)
-
+		NotificationCenter.default.addObserver(self, selector: #selector(accountsDidChange(_:)), name: .AccountsDidChange, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(accountStateDidChange(_:)), name: .AccountStateDidChange, object: nil)
+		
 		NotificationCenter.default.addObserver(self, selector: #selector(backingStoresDidRebuild(_:)), name: .BackingStoresDidRebuild, object: navState)
 		NotificationCenter.default.addObserver(self, selector: #selector(masterSelectionDidChange(_:)), name: .MasterSelectionDidChange, object: navState)
 		NotificationCenter.default.addObserver(self, selector: #selector(contentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
@@ -141,7 +143,15 @@ class MasterFeedViewController: ProgressTableViewController, UndoableCommandRunn
 		}
 
 	}
-
+	
+	@objc func accountsDidChange(_ notification: Notification) {
+		updateUI()
+	}
+	
+	@objc func accountStateDidChange(_ notification: Notification) {
+		updateUI()
+	}
+	
 	@objc func masterSelectionDidChange(_ note: Notification) {
 		if let indexPath = navState.currentMasterIndexPath {
 			if tableView.indexPathForSelectedRow != indexPath {

--- a/iOS/Settings/AddAccountViewController.swift
+++ b/iOS/Settings/AddAccountViewController.swift
@@ -6,10 +6,19 @@
 //  Copyright © 2019 Ranchero Software. All rights reserved.
 //
 
+import Account
 import UIKit
 
 class AddAccountViewController: UITableViewController {
 
+	@IBOutlet private weak var localAccountNameLabel: UILabel!
+	
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		
+		localAccountNameLabel.text = Account.defaultLocalAccountName
+	}
+	
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		switch indexPath.row {
 		case 0:

--- a/iOS/Settings/AddLocalAccountViewController.swift
+++ b/iOS/Settings/AddLocalAccountViewController.swift
@@ -11,8 +11,16 @@ import Account
 
 class AddLocalAccountViewController: UIViewController {
 
+	@IBOutlet private weak var localAccountNameLabel: UILabel!
 	@IBOutlet weak var nameTextField: UITextField!
-
+	
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		
+		localAccountNameLabel.text = Account.defaultLocalAccountName
+		nameTextField.delegate = self
+	}
+	
 	@IBAction func cancel(_ sender: Any) {
 		dismiss(animated: true)
 	}
@@ -21,6 +29,15 @@ class AddLocalAccountViewController: UIViewController {
 		let account = AccountManager.shared.createAccount(type: .onMyMac)
 		account.name = nameTextField.text
 		dismiss(animated: true)
+	}
+	
+}
+
+extension AddLocalAccountViewController: UITextFieldDelegate {
+	
+	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+		textField.resignFirstResponder()
+		return true
 	}
 	
 }

--- a/iOS/Settings/DetailAccountViewController.swift
+++ b/iOS/Settings/DetailAccountViewController.swift
@@ -51,6 +51,14 @@ extension DetailAccountViewController {
 		return cell
 	}
 
+	override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+		if indexPath.section == 1 {
+			return true
+		}
+		
+		return false
+	}
+	
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		if indexPath.section == 1 {
 			deleteAccount()

--- a/iOS/Settings/DetailAccountViewController.swift
+++ b/iOS/Settings/DetailAccountViewController.swift
@@ -36,7 +36,7 @@ class DetailAccountViewController: UITableViewController {
 extension DetailAccountViewController: UITextFieldDelegate {
 		
 	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-		nameTextField.resignFirstResponder()
+		textField.resignFirstResponder()
 		return true
 	}
 	

--- a/iOS/Settings/DetailAccountViewController.swift
+++ b/iOS/Settings/DetailAccountViewController.swift
@@ -21,6 +21,7 @@ class DetailAccountViewController: UITableViewController {
 		
 		guard let account = account else { return }
 		nameTextField.text = account.name
+		nameTextField.delegate = self
 		activeSwitch.isOn = account.isActive
 		
     }
@@ -29,5 +30,14 @@ class DetailAccountViewController: UITableViewController {
 		account?.name = nameTextField.text
 		account?.isActive = activeSwitch.isOn
 	}
+	
+}
 
+extension DetailAccountViewController: UITextFieldDelegate {
+		
+	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+		nameTextField.resignFirstResponder()
+		return true
+	}
+	
 }

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -337,7 +337,7 @@
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8Xs-17-Ubp">
+                                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8Xs-17-Ubp">
                                                             <rect key="frame" x="64" y="0.0" width="310" height="21"/>
                                                             <nil key="textColor"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -376,14 +376,6 @@
                                                 <constraint firstItem="J5R-kl-pYE" firstAttribute="centerY" secondItem="h3v-g9-biw" secondAttribute="centerY" id="Qrx-J1-99r"/>
                                                 <constraint firstItem="pvF-Ge-m4M" firstAttribute="centerY" secondItem="h3v-g9-biw" secondAttribute="centerY" id="Rq1-zD-1X7"/>
                                             </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="VzJ-7V-Jfa">
-                                        <rect key="frame" x="0.0" y="123" width="414" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VzJ-7V-Jfa" id="GyY-75-Dmv">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
@@ -425,7 +417,7 @@
                                                     <rect key="frame" x="90.5" y="4" width="233" height="46.5"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="tb2-dO-AhR">
-                                                            <rect key="frame" x="0.0" y="7.5" width="32" height="32.000000000000028"/>
+                                                            <rect key="frame" x="0.0" y="7.5" width="32" height="32"/>
                                                             <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="32" id="0GF-vU-aEc"/>
@@ -509,7 +501,7 @@
                                 <rect key="frame" x="90.5" y="108" width="233" height="36"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="74E-kl-vU9">
-                                        <rect key="frame" x="0.0" y="2" width="32" height="32.000000000000028"/>
+                                        <rect key="frame" x="0.0" y="2" width="32" height="32"/>
                                         <color key="tintColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="32" id="E7T-ps-KgX"/>

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -484,6 +484,9 @@
                             <outlet property="delegate" destination="b00-4A-bV6" id="FKM-rN-deu"/>
                         </connections>
                     </tableView>
+                    <connections>
+                        <outlet property="localAccountNameLabel" destination="116-rt-msI" id="h6M-5V-392"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="kmn-Q7-rga" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -548,6 +551,7 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="localAccountNameLabel" destination="Tdm-Ge-uc6" id="48O-IT-xXw"/>
                         <outlet property="nameTextField" destination="2dx-hK-hxL" id="t5V-3x-3vu"/>
                     </connections>
                 </viewController>

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -314,7 +314,7 @@
         <scene sceneID="TQp-8g-7td">
             <objects>
                 <tableViewController storyboardIdentifier="DetailAccountViewController" id="SLc-SS-bhp" customClass="DetailAccountViewController" customModule="NetNewsWire" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="DfF-oG-mSd">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="DfF-oG-mSd">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
@@ -425,7 +425,7 @@
                                                     <rect key="frame" x="90.5" y="4" width="233" height="46.5"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="tb2-dO-AhR">
-                                                            <rect key="frame" x="0.0" y="7.5" width="32" height="32"/>
+                                                            <rect key="frame" x="0.0" y="7.5" width="32" height="32.000000000000028"/>
                                                             <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="32" id="0GF-vU-aEc"/>
@@ -509,7 +509,7 @@
                                 <rect key="frame" x="90.5" y="108" width="233" height="36"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="74E-kl-vU9">
-                                        <rect key="frame" x="0.0" y="2" width="32" height="32"/>
+                                        <rect key="frame" x="0.0" y="2" width="32" height="32.000000000000028"/>
                                         <color key="tintColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="32" id="E7T-ps-KgX"/>

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -314,7 +314,7 @@
         <scene sceneID="TQp-8g-7td">
             <objects>
                 <tableViewController storyboardIdentifier="DetailAccountViewController" id="SLc-SS-bhp" customClass="DetailAccountViewController" customModule="NetNewsWire" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="DfF-oG-mSd">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="DfF-oG-mSd">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -127,12 +127,29 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="dXN-Mw-yf2" style="IBUITableViewCellStyleDefault" id="F0L-Ut-reX">
+                                        <rect key="frame" x="0.0" y="375.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="F0L-Ut-reX" id="5SX-M2-2jR">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Add NetNewsWire News Feed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="dXN-Mw-yf2">
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Contribute" id="eai-B1-uYA">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="4GG-r8-1Pi" style="IBUITableViewCellStyleDefault" id="NqU-08-VRI">
-                                        <rect key="frame" x="0.0" y="431.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="475.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="NqU-08-VRI" id="jzn-xS-PHJ">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -153,7 +170,7 @@
                             <tableViewSection headerTitle="TIMELINE" id="9Pk-Y8-JVJ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="MpA-w1-Wwh">
-                                        <rect key="frame" x="0.0" y="531.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="575.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MpA-w1-Wwh" id="GhU-ib-Mz8">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -183,7 +200,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="B5l-Qp-6Gm" detailTextLabel="u7B-tj-cw8" style="IBUITableViewCellStyleValue1" id="air-4O-D7p">
-                                        <rect key="frame" x="0.0" y="575.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="619.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="air-4O-D7p" id="76S-R5-xwM">
                                             <rect key="frame" x="0.0" y="0.0" width="376" height="43.5"/>
@@ -211,7 +228,7 @@
                             <tableViewSection headerTitle="DATABASE" id="hAC-uA-RbS">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="qur-cL-wrM" detailTextLabel="qIl-N6-6wQ" style="IBUITableViewCellStyleValue1" id="z1J-VF-St0">
-                                        <rect key="frame" x="0.0" y="675.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="719.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="z1J-VF-St0" id="Y8U-Ka-GeZ">
                                             <rect key="frame" x="0.0" y="0.0" width="376" height="43.5"/>
@@ -226,23 +243,6 @@
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="qIl-N6-6wQ">
                                                     <rect key="frame" x="332" y="12" width="44" height="20.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="dXN-Mw-yf2" style="IBUITableViewCellStyleDefault" id="F0L-Ut-reX">
-                                        <rect key="frame" x="0.0" y="719.5" width="414" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="F0L-Ut-reX" id="5SX-M2-2jR">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Add NetNewsWire News Feed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="dXN-Mw-yf2">
-                                                    <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>

--- a/iOS/Settings/SettingsViewController.swift
+++ b/iOS/Settings/SettingsViewController.swift
@@ -227,6 +227,7 @@ private extension SettingsViewController {
 		let addNavViewController = UIStoryboard.add.instantiateInitialViewController() as! UINavigationController
 		let addViewController = addNavViewController.topViewController as! AddContainerViewController
 		addNavViewController.modalPresentationStyle = .formSheet
+		addNavViewController.preferredContentSize = AddContainerViewController.preferredContentSizeForFormSheetDisplay
 		addViewController.initialFeed = appNewsURLString
 		addViewController.initialFeedName = "NetNewsWire News"
 		

--- a/iOS/Settings/SettingsViewController.swift
+++ b/iOS/Settings/SettingsViewController.swift
@@ -58,6 +58,13 @@ class SettingsViewController: UITableViewController {
 		switch section {
 		case 0:
 			return AccountManager.shared.accounts.count + 1
+		case 1:
+			let defaultNumberOfRows = super.tableView(tableView, numberOfRowsInSection: section)
+			if AccountManager.shared.activeAccounts.isEmpty {
+				// Hide the add NetNewsWire feed row if they don't have any active accounts
+				return defaultNumberOfRows - 1
+			}
+			return defaultNumberOfRows
 		default:
 			return super.tableView(tableView, numberOfRowsInSection: section)
 		}
@@ -116,8 +123,12 @@ class SettingsViewController: UITableViewController {
 				UIApplication.shared.open(URL(string: "https://github.com/brentsimmons/NetNewsWire")!, options: [:])
 			case 3:
 				UIApplication.shared.open(URL(string: "https://github.com/brentsimmons/NetNewsWire/issues")!, options: [:])
-			default:
+			case 4:
 				UIApplication.shared.open(URL(string: "https://github.com/brentsimmons/NetNewsWire/tree/master/Technotes")!, options: [:])
+			case 5:
+				addFeed()
+			default:
+				UIApplication.shared.open(URL(string: "https://ranchero.com/netnewswire/")!, options: [:])
 			}
 		case 2:
 			UIApplication.shared.open(URL(string: "https://appcamp4girls.com/contribute/")!, options: [:])
@@ -132,10 +143,8 @@ class SettingsViewController: UITableViewController {
 				let timeline = UIStoryboard.settings.instantiateController(ofType: RefreshIntervalViewController.self)
 				self.navigationController?.pushViewController(timeline, animated: true)
 			case 1:
-				addFeed()
-			case 2:
 				importOPML()
-			case 3:
+			case 2:
 				exportOPML()
 			default:
 				print("export")


### PR DESCRIPTION
#### Description

Improved size and layout of add feed / folder popover on iPad. Also fixed a bunch of iOS issues I noticed along the way.

#### Details

* In addition to improving the sizing of the popover, I also cleaned up the margins and added support for dynamic type. Also, for both the add feed and folders UI, if the related picker only had 1 item to display, I hid the picker entirely.
* Disabled the add feed / folder button when there are no active accounts
* In the settings screen, I moved the "Add NetNewsWire News Feed" to the about section, and hid it when no active accounts.
* Fixed an issue on iOS where it always referred to local accounts as "On My iPhone", and standardized the "On My..." localized strings across the whole app.
* Updated a bunch of places that have text fields to dismiss the keyboard when return is tapped.
* Updated a few table views to allow allow certain cells to be selectable (e.g., the delete button in `DetailAccountViewController` is selectable, but the rest of the cells are that screen are not selectable).

Fixes #649 