### PR TITLE
[iOS] UI improvements to the add / edit account flows

### DIFF
--- a/iOS/Settings/AddAccountViewController.swift
+++ b/iOS/Settings/AddAccountViewController.swift
@@ -29,19 +29,19 @@ class AddAccountViewController: UITableViewController, AddAccountDismissDelegate
 			let navController = UIStoryboard.settings.instantiateViewController(withIdentifier: "AddLocalAccountNavigationViewController") as! UINavigationController
 			let addViewController = navController.topViewController as! AddLocalAccountViewController
 			addViewController.delegate = self
-			present(navController, animated: true)
+			navigationController?.pushViewController(addViewController, animated: true)
 		case 1:
 			let navController = UIStoryboard.settings.instantiateViewController(withIdentifier: "FeedbinAccountNavigationViewController") as! UINavigationController
 			let addViewController = navController.topViewController as! FeedbinAccountViewController
 			addViewController.delegate = self
-			present(navController, animated: true)
+			navigationController?.pushViewController(addViewController, animated: true)
 		default:
 			break
 		}
 	}
 	
 	func dismiss() {
-		navigationController?.popViewController(animated: false)
+		navigationController?.popToRootViewController(animated: true)
 	}
 	
 }

--- a/iOS/Settings/AddAccountViewController.swift
+++ b/iOS/Settings/AddAccountViewController.swift
@@ -24,14 +24,14 @@ class AddAccountViewController: UITableViewController, AddAccountDismissDelegate
 	}
 	
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		let storyboard = UIStoryboard.settings
 		switch indexPath.row {
 		case 0:
-			let addViewController = UIStoryboard.settings.instantiateViewController(withIdentifier: "AddLocalAccountViewController") as! AddLocalAccountViewController
+			let addViewController = storyboard.instantiateViewController(withIdentifier: "AddLocalAccountViewController") as! AddLocalAccountViewController
 			addViewController.delegate = self
 			navigationController?.pushViewController(addViewController, animated: true)
 		case 1:
-			let navController = UIStoryboard.settings.instantiateViewController(withIdentifier: "FeedbinAccountNavigationViewController") as! UINavigationController
-			let addViewController = navController.topViewController as! FeedbinAccountViewController
+			let addViewController = storyboard.instantiateViewController(withIdentifier: "FeedbinAccountViewController") as! FeedbinAccountViewController
 			addViewController.delegate = self
 			navigationController?.pushViewController(addViewController, animated: true)
 		default:

--- a/iOS/Settings/AddAccountViewController.swift
+++ b/iOS/Settings/AddAccountViewController.swift
@@ -26,8 +26,7 @@ class AddAccountViewController: UITableViewController, AddAccountDismissDelegate
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		switch indexPath.row {
 		case 0:
-			let navController = UIStoryboard.settings.instantiateViewController(withIdentifier: "AddLocalAccountNavigationViewController") as! UINavigationController
-			let addViewController = navController.topViewController as! AddLocalAccountViewController
+			let addViewController = UIStoryboard.settings.instantiateViewController(withIdentifier: "AddLocalAccountViewController") as! AddLocalAccountViewController
 			addViewController.delegate = self
 			navigationController?.pushViewController(addViewController, animated: true)
 		case 1:

--- a/iOS/Settings/AddLocalAccountViewController.swift
+++ b/iOS/Settings/AddLocalAccountViewController.swift
@@ -23,14 +23,9 @@ class AddLocalAccountViewController: UIViewController {
 		nameTextField.delegate = self
 	}
 
-	@IBAction func cancel(_ sender: Any) {
-		dismiss(animated: true)
-	}
-	
-	@IBAction func done(_ sender: Any) {
+	@IBAction func addAccountTapped(_ sender: Any) {
 		let account = AccountManager.shared.createAccount(type: .onMyMac)
 		account.name = nameTextField.text
-		dismiss(animated: true)
 		delegate?.dismiss()
 	}
 	

--- a/iOS/Settings/DetailAccountViewController.swift
+++ b/iOS/Settings/DetailAccountViewController.swift
@@ -20,6 +20,8 @@ class DetailAccountViewController: UITableViewController {
         super.viewDidLoad()
 		
 		guard let account = account else { return }
+		
+		nameTextField.placeholder = account.defaultName
 		nameTextField.text = account.name
 		nameTextField.delegate = self
 		activeSwitch.isOn = account.isActive

--- a/iOS/Settings/FeedbinAccountViewController.swift
+++ b/iOS/Settings/FeedbinAccountViewController.swift
@@ -12,11 +12,12 @@ import RSWeb
 
 class FeedbinAccountViewController: UIViewController {
 
-	@IBOutlet weak var cancelBarButtonItem: UIBarButtonItem!
 	@IBOutlet weak var activityIndicator: UIActivityIndicatorView!
-	@IBOutlet weak var doneBarButtonItem: UIBarButtonItem!
+	
 	@IBOutlet weak var emailTextField: UITextField!
 	@IBOutlet weak var passwordTextField: UITextField!
+	@IBOutlet weak var addAccountButton: UIButton!
+	
 	@IBOutlet weak var errorMessageLabel: UILabel!
 	
 	weak var account: Account?
@@ -26,6 +27,8 @@ class FeedbinAccountViewController: UIViewController {
         super.viewDidLoad()
 
 		activityIndicator.isHidden = true
+		emailTextField.delegate = self
+		passwordTextField.delegate = self
 		
 		if let account = account, let credentials = try? account.retrieveBasicCredentials() {
 			if case .basic(let username, let password) = credentials {
@@ -35,39 +38,29 @@ class FeedbinAccountViewController: UIViewController {
 		}
 	}
 	
-	@IBAction func cancel(_ sender: Any) {
-		dismiss(animated: true)
-	}
-	
-	@IBAction func done(_ sender: Any) {
-
+	@IBAction func addAccountTapped(_ sender: Any) {
 		self.errorMessageLabel.text = nil
 		
 		guard emailTextField.text != nil && passwordTextField.text != nil else {
 			self.errorMessageLabel.text = NSLocalizedString("Username & password required.", comment: "Credentials Error")
 			return
 		}
+	
+		startAnimatingActivityIndicator()
+		disableNavigation()
 		
-		cancelBarButtonItem.isEnabled = false
-		doneBarButtonItem.isEnabled = false
-		activityIndicator.isHidden = false
-		activityIndicator.startAnimating()
-		
-		let credentials = Credentials.basic(username: emailTextField.text ?? "", password: passwordTextField.text ?? "")
+		// When you fill in the email address via auto-complete it adds extra whitespace
+		let emailAddress = emailTextField.text?.trimmingCharacters(in: .whitespaces)
+		let credentials = Credentials.basic(username: emailAddress ?? "", password: passwordTextField.text ?? "")
 		Account.validateCredentials(type: .feedbin, credentials: credentials) { [weak self] result in
-			
 			guard let self = self else { return }
 			
-			self.cancelBarButtonItem.isEnabled = true
-			self.doneBarButtonItem.isEnabled = true
-			self.activityIndicator.isHidden = true
-			self.activityIndicator.stopAnimating()
+			self.stopAnimtatingActivityIndicator()
+			self.enableNavigation()
 			
 			switch result {
 			case .success(let authenticated):
-				
 				if authenticated {
-					
 					var newAccount = false
 					if self.account == nil {
 						self.account = AccountManager.shared.createAccount(type: .feedbin)
@@ -80,24 +73,49 @@ class FeedbinAccountViewController: UIViewController {
 						if newAccount {
 							self.account?.refreshAll()
 						}
-						self.dismiss(animated: true)
+						
 						self.delegate?.dismiss()
 					} catch {
 						self.errorMessageLabel.text = NSLocalizedString("Keychain error while storing credentials.", comment: "Credentials Error")
 					}
-					
 				} else {
 					self.errorMessageLabel.text = NSLocalizedString("Invalid email/password combination.", comment: "Credentials Error")
 				}
-				
 			case .failure:
-				
-				self.errorMessageLabel.text = NSLocalizedString("Network error.  Try again later.", comment: "Credentials Error")
-				
+				self.errorMessageLabel.text = NSLocalizedString("Network error. Try again later.", comment: "Credentials Error")
 			}
 			
 		}
-		
 	}
+	
+	private func enableNavigation() {
+		self.navigationItem.backBarButtonItem?.isEnabled = true
+		self.addAccountButton.isEnabled = true
+		self.activityIndicator.isHidden = true
+	}
+	
+	private func disableNavigation() {
+		navigationItem.backBarButtonItem?.isEnabled = false
+		addAccountButton.isEnabled = false
+	}
+	
+	private func startAnimatingActivityIndicator() {
+		activityIndicator.isHidden = false
+		activityIndicator.startAnimating()
+	}
+	
+	private func stopAnimtatingActivityIndicator() {
+		self.activityIndicator.isHidden = true
+		self.activityIndicator.stopAnimating()
+	}
+	
+}
 
+extension FeedbinAccountViewController: UITextFieldDelegate {
+	
+	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+		textField.resignFirstResponder()
+		return true
+	}
+	
 }

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -438,7 +438,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="tb2-dO-AhR">
-                                                    <rect key="frame" x="20" y="11.5" width="32" height="32.000000000000028"/>
+                                                    <rect key="frame" x="20" y="11.5" width="32" height="32"/>
                                                     <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="32" id="0GF-vU-aEc"/>
@@ -517,10 +517,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="7zF-66-uRq">
-                                <rect key="frame" x="90.5" y="128" width="233" height="36"/>
+                                <rect key="frame" x="90.5" y="84" width="233" height="36"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="74E-kl-vU9">
-                                        <rect key="frame" x="0.0" y="2" width="32" height="32.000000000000028"/>
+                                        <rect key="frame" x="0.0" y="2" width="32" height="32"/>
                                         <color key="tintColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="32" id="E7T-ps-KgX"/>
@@ -536,7 +536,7 @@
                                 </subviews>
                             </stackView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Name (Optional)" textAlignment="center" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2dx-hK-hxL">
-                                <rect key="frame" x="0.0" y="184" width="414" height="48"/>
+                                <rect key="frame" x="0.0" y="140" width="414" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="48" id="Z7w-B0-LuW"/>
                                 </constraints>
@@ -545,7 +545,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5AS-Zb-zHP">
-                                <rect key="frame" x="0.0" y="252" width="414" height="48"/>
+                                <rect key="frame" x="0.0" y="208" width="414" height="48"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="48" id="IFC-SI-vcP"/>
@@ -580,7 +580,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="oPp-xq-kz9" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3214" y="145"/>
+            <point key="canvasLocation" x="2564" y="144"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="qOt-Py-TKw">
@@ -702,22 +702,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="l5n-Op-NE2" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="4642" y="144"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="ncU-rc-RwA">
-            <objects>
-                <navigationController storyboardIdentifier="AddLocalAccountNavigationViewController" id="GGt-T1-ndB" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="xT7-am-AeJ">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="lkT-rF-XV3" kind="relationship" relationship="rootViewController" id="Bkq-7x-eht"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="otA-e3-gdk" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2497" y="145"/>
         </scene>
         <!--Timeline Text-->
         <scene sceneID="07z-Vb-4Fm">

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -430,11 +430,11 @@
                         <sections>
                             <tableViewSection id="m3P-em-PgI">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="55" id="UFl-6I-ucw">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="55" id="UFl-6I-ucw">
                                         <rect key="frame" x="0.0" y="35" width="414" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UFl-6I-ucw" id="99i-Ge-guB">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="54.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="376" height="54.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="tb2-dO-AhR">
@@ -461,11 +461,11 @@
                                         </tableViewCellContentView>
                                         <inset key="separatorInset" minX="40" minY="0.0" maxX="0.0" maxY="0.0"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="56" id="te1-L9-osf">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="56" id="te1-L9-osf">
                                         <rect key="frame" x="0.0" y="90" width="414" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="te1-L9-osf" id="DgY-u7-DRO">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="376" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountFeedbin" translatesAutoresizingMaskIntoConstraints="NO" id="wyu-mZ-3zz">
@@ -668,21 +668,19 @@
                         <viewLayoutGuide key="safeArea" id="4Rm-PZ-VHc"/>
                     </view>
                     <navigationItem key="navigationItem" id="BFN-hJ-pWd">
-                        <rightBarButtonItems>
-                            <barButtonItem style="plain" id="L90-ti-E7I">
-                                <view key="customView" contentMode="scaleToFill" id="xpt-lr-f2h">
-                                    <rect key="frame" x="325.5" y="12" width="20" height="20"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <subviews>
-                                        <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Pl1-lc-sIl">
-                                            <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        </activityIndicatorView>
-                                    </subviews>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </view>
-                            </barButtonItem>
-                        </rightBarButtonItems>
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="L90-ti-E7I">
+                            <view key="customView" contentMode="scaleToFill" id="xpt-lr-f2h">
+                                <rect key="frame" x="325.5" y="12" width="20" height="20"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Pl1-lc-sIl">
+                                        <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="activityIndicator" destination="Pl1-lc-sIl" id="hqg-mX-Yns"/>

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -438,7 +438,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="tb2-dO-AhR">
-                                                    <rect key="frame" x="20" y="11.5" width="32" height="32"/>
+                                                    <rect key="frame" x="20" y="11.5" width="32" height="32.000000000000028"/>
                                                     <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="32" id="0GF-vU-aEc"/>
@@ -520,7 +520,7 @@
                                 <rect key="frame" x="90.5" y="84" width="233" height="36"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="74E-kl-vU9">
-                                        <rect key="frame" x="0.0" y="2" width="32" height="32"/>
+                                        <rect key="frame" x="0.0" y="2" width="32" height="32.000000000000028"/>
                                         <color key="tintColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="32" id="E7T-ps-KgX"/>
@@ -580,23 +580,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="oPp-xq-kz9" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2564" y="144"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="qOt-Py-TKw">
-            <objects>
-                <navigationController storyboardIdentifier="FeedbinAccountNavigationViewController" id="AGX-Ph-lE3" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="fpp-8U-JGs">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="byh-sg-6p5" kind="relationship" relationship="rootViewController" id="u92-3E-dIA"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="ieC-Y8-e5K" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="3919" y="145"/>
+            <point key="canvasLocation" x="2510" y="139"/>
         </scene>
         <!--Feedbin Account View Controller-->
         <scene sceneID="sCm-Gd-byr">
@@ -607,7 +591,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="vFL-2i-eRz">
-                                <rect key="frame" x="129" y="108" width="156" height="36"/>
+                                <rect key="frame" x="129" y="84" width="156" height="36"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountFeedbin" translatesAutoresizingMaskIntoConstraints="NO" id="9ht-ce-lQp">
                                         <rect key="frame" x="0.0" y="2" width="32" height="32"/>
@@ -626,55 +610,65 @@
                                 </subviews>
                             </stackView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UiV-th-dQb">
-                                <rect key="frame" x="107" y="160" width="200" height="30"/>
+                                <rect key="frame" x="0.0" y="140" width="414" height="48"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="200" id="ULv-Nf-M1O"/>
+                                    <constraint firstAttribute="height" constant="48" id="UjW-Pq-uNU"/>
                                 </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <textInputTraits key="textInputTraits" keyboardType="emailAddress" textContentType="email"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lDh-Kk-Kem">
-                                <rect key="frame" x="107" y="198" width="200" height="30"/>
+                                <rect key="frame" x="0.0" y="196" width="414" height="48"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="200" id="vMu-uR-0vC"/>
+                                    <constraint firstAttribute="height" constant="48" id="pKQ-Mm-Oc8"/>
                                 </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <textInputTraits key="textInputTraits" secureTextEntry="YES" textContentType="password"/>
                             </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9QD-Wz-fqW">
-                                <rect key="frame" x="207" y="244" width="0.0" height="0.0"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pv5-O6-P6Z">
+                                <rect key="frame" x="0.0" y="264" width="414" height="48"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="48" id="8Vt-l1-eL1"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <nil key="textColor"/>
+                                <state key="normal" title="Add Account"/>
+                                <connections>
+                                    <action selector="addAccountTapped:" destination="byh-sg-6p5" eventType="touchUpInside" id="BFR-MI-1qW"/>
+                                    <action selector="addAccountTapped:" destination="lkT-rF-XV3" eventType="touchUpInside" id="YKl-dE-pVK"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9QD-Wz-fqW">
+                                <rect key="frame" x="207" y="332" width="0.0" height="0.0"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <color key="textColor" name="systemRedColor" catalog="System" colorSpace="catalog"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" red="0.93735349178314209" green="0.93682962656021118" blue="0.95681577920913696" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="UiV-th-dQb" firstAttribute="top" secondItem="vFL-2i-eRz" secondAttribute="bottom" constant="16" id="BUG-5p-BDh"/>
+                            <constraint firstItem="UiV-th-dQb" firstAttribute="leading" secondItem="4Rm-PZ-VHc" secondAttribute="leading" id="1ok-W1-dkI"/>
+                            <constraint firstItem="UiV-th-dQb" firstAttribute="top" secondItem="vFL-2i-eRz" secondAttribute="bottom" constant="20" id="BUG-5p-BDh"/>
+                            <constraint firstItem="9QD-Wz-fqW" firstAttribute="top" secondItem="pv5-O6-P6Z" secondAttribute="bottom" constant="20" id="BxD-TQ-zRm"/>
+                            <constraint firstItem="4Rm-PZ-VHc" firstAttribute="trailing" secondItem="lDh-Kk-Kem" secondAttribute="trailing" id="CUI-hN-BsR"/>
+                            <constraint firstItem="pv5-O6-P6Z" firstAttribute="trailing" secondItem="4Rm-PZ-VHc" secondAttribute="trailing" id="DkX-t4-GH3"/>
+                            <constraint firstItem="pv5-O6-P6Z" firstAttribute="leading" secondItem="4Rm-PZ-VHc" secondAttribute="leading" id="Jhs-JE-qWd"/>
                             <constraint firstItem="lDh-Kk-Kem" firstAttribute="top" secondItem="UiV-th-dQb" secondAttribute="bottom" constant="8" id="N81-px-3YV"/>
                             <constraint firstItem="9QD-Wz-fqW" firstAttribute="centerX" secondItem="E6e-jd-9b6" secondAttribute="centerX" id="Sgr-tG-nT2"/>
-                            <constraint firstItem="vFL-2i-eRz" firstAttribute="top" secondItem="4Rm-PZ-VHc" secondAttribute="top" constant="20" id="khS-vK-fL0"/>
+                            <constraint firstItem="pv5-O6-P6Z" firstAttribute="top" secondItem="lDh-Kk-Kem" secondAttribute="bottom" constant="20" id="UUS-1q-Fn4"/>
+                            <constraint firstItem="4Rm-PZ-VHc" firstAttribute="trailing" secondItem="UiV-th-dQb" secondAttribute="trailing" id="hfB-Ql-twm"/>
+                            <constraint firstItem="vFL-2i-eRz" firstAttribute="top" secondItem="4Rm-PZ-VHc" secondAttribute="top" constant="40" id="khS-vK-fL0"/>
+                            <constraint firstItem="lDh-Kk-Kem" firstAttribute="leading" secondItem="4Rm-PZ-VHc" secondAttribute="leading" id="nHZ-XJ-CXN"/>
                             <constraint firstItem="vFL-2i-eRz" firstAttribute="centerX" secondItem="E6e-jd-9b6" secondAttribute="centerX" id="qew-4G-xhG"/>
-                            <constraint firstItem="9QD-Wz-fqW" firstAttribute="top" secondItem="lDh-Kk-Kem" secondAttribute="bottom" constant="16" id="u49-x7-qrR"/>
                             <constraint firstItem="UiV-th-dQb" firstAttribute="centerX" secondItem="E6e-jd-9b6" secondAttribute="centerX" id="vLa-hN-GpR"/>
                             <constraint firstItem="lDh-Kk-Kem" firstAttribute="centerX" secondItem="E6e-jd-9b6" secondAttribute="centerX" id="zjW-9v-aqJ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="4Rm-PZ-VHc"/>
                     </view>
                     <navigationItem key="navigationItem" id="BFN-hJ-pWd">
-                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="hLE-sO-Oak">
-                            <connections>
-                                <action selector="cancel:" destination="byh-sg-6p5" id="Ghd-hv-96w"/>
-                            </connections>
-                        </barButtonItem>
                         <rightBarButtonItems>
-                            <barButtonItem systemItem="done" id="2cL-39-uWX">
-                                <connections>
-                                    <action selector="done:" destination="byh-sg-6p5" id="p1d-pI-ioe"/>
-                                </connections>
-                            </barButtonItem>
                             <barButtonItem style="plain" id="L90-ti-E7I">
                                 <view key="customView" contentMode="scaleToFill" id="xpt-lr-f2h">
                                     <rect key="frame" x="325.5" y="12" width="20" height="20"/>
@@ -692,8 +686,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="activityIndicator" destination="Pl1-lc-sIl" id="hqg-mX-Yns"/>
-                        <outlet property="cancelBarButtonItem" destination="hLE-sO-Oak" id="hdM-yd-oDT"/>
-                        <outlet property="doneBarButtonItem" destination="2cL-39-uWX" id="wUU-LS-5k8"/>
+                        <outlet property="addAccountButton" destination="pv5-O6-P6Z" id="DEh-oq-rnD"/>
                         <outlet property="emailTextField" destination="UiV-th-dQb" id="fCb-hg-AXa"/>
                         <outlet property="errorMessageLabel" destination="9QD-Wz-fqW" id="Kjo-73-Pgh"/>
                         <outlet property="passwordTextField" destination="lDh-Kk-Kem" id="ew7-Ej-UpK"/>
@@ -701,7 +694,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="l5n-Op-NE2" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4642" y="144"/>
+            <point key="canvasLocation" x="3203" y="139"/>
         </scene>
         <!--Timeline Text-->
         <scene sceneID="07z-Vb-4Fm">

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -347,9 +347,9 @@
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="XJG-0j-coE" firstAttribute="leading" secondItem="edh-bL-MIR" secondAttribute="leading" constant="20" id="2lj-H8-Iux"/>
+                                                <constraint firstItem="XJG-0j-coE" firstAttribute="leading" secondItem="edh-bL-MIR" secondAttribute="leading" constant="20" symbolic="YES" id="2lj-H8-Iux"/>
                                                 <constraint firstItem="XJG-0j-coE" firstAttribute="centerY" secondItem="edh-bL-MIR" secondAttribute="centerY" id="ZDw-ch-uB6"/>
-                                                <constraint firstAttribute="trailing" secondItem="XJG-0j-coE" secondAttribute="trailing" constant="20" id="jih-VV-fBp"/>
+                                                <constraint firstAttribute="trailing" secondItem="XJG-0j-coE" secondAttribute="trailing" constant="20" symbolic="YES" id="jih-VV-fBp"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -360,9 +360,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pvF-Ge-m4M">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pvF-Ge-m4M">
                                                     <rect key="frame" x="20" y="11.5" width="48" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -372,7 +372,7 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstAttribute="trailing" secondItem="J5R-kl-pYE" secondAttribute="trailing" constant="20" id="0P4-Vq-dZp"/>
-                                                <constraint firstItem="pvF-Ge-m4M" firstAttribute="leading" secondItem="h3v-g9-biw" secondAttribute="leadingMargin" id="CIb-cr-t6V"/>
+                                                <constraint firstItem="pvF-Ge-m4M" firstAttribute="leading" secondItem="h3v-g9-biw" secondAttribute="leading" constant="20" symbolic="YES" id="CIb-cr-t6V"/>
                                                 <constraint firstItem="J5R-kl-pYE" firstAttribute="centerY" secondItem="h3v-g9-biw" secondAttribute="centerY" id="Qrx-J1-99r"/>
                                                 <constraint firstItem="pvF-Ge-m4M" firstAttribute="centerY" secondItem="h3v-g9-biw" secondAttribute="centerY" id="Rq1-zD-1X7"/>
                                             </constraints>

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -609,7 +609,7 @@
                                     </label>
                                 </subviews>
                             </stackView>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UiV-th-dQb">
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" textAlignment="center" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UiV-th-dQb">
                                 <rect key="frame" x="0.0" y="140" width="414" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="48" id="UjW-Pq-uNU"/>
@@ -618,7 +618,7 @@
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <textInputTraits key="textInputTraits" keyboardType="emailAddress" textContentType="email"/>
                             </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lDh-Kk-Kem">
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="center" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lDh-Kk-Kem">
                                 <rect key="frame" x="0.0" y="196" width="414" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="48" id="pKQ-Mm-Oc8"/>

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -337,7 +337,7 @@
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8Xs-17-Ubp">
+                                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="(Optional)" textAlignment="right" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8Xs-17-Ubp">
                                                             <rect key="frame" x="64" y="0.0" width="310" height="21"/>
                                                             <nil key="textColor"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -517,7 +517,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="7zF-66-uRq">
-                                <rect key="frame" x="90.5" y="108" width="233" height="36"/>
+                                <rect key="frame" x="90.5" y="128" width="233" height="36"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="74E-kl-vU9">
                                         <rect key="frame" x="0.0" y="2" width="32" height="32.000000000000028"/>
@@ -535,37 +535,44 @@
                                     </label>
                                 </subviews>
                             </stackView>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Name" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2dx-hK-hxL">
-                                <rect key="frame" x="107" y="160" width="200" height="30"/>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Name (Optional)" textAlignment="center" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2dx-hK-hxL">
+                                <rect key="frame" x="0.0" y="184" width="414" height="48"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="200" id="uYr-DR-Oil"/>
+                                    <constraint firstAttribute="height" constant="48" id="Z7w-B0-LuW"/>
                                 </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5AS-Zb-zHP">
+                                <rect key="frame" x="0.0" y="252" width="414" height="48"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="48" id="IFC-SI-vcP"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Add Account"/>
+                                <connections>
+                                    <action selector="addAccountTapped:" destination="lkT-rF-XV3" eventType="touchUpInside" id="bmf-nA-fJU"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" red="0.93735349178314209" green="0.93682962656021118" blue="0.95681577920913696" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="7zF-66-uRq" firstAttribute="top" secondItem="Z5L-XF-ZSa" secondAttribute="top" constant="20" id="Meu-uI-vga"/>
+                            <constraint firstItem="5AS-Zb-zHP" firstAttribute="leading" secondItem="Z5L-XF-ZSa" secondAttribute="leading" id="3Ov-dx-JBu"/>
+                            <constraint firstItem="5AS-Zb-zHP" firstAttribute="top" secondItem="2dx-hK-hxL" secondAttribute="bottom" constant="20" id="CZD-h0-H7B"/>
+                            <constraint firstItem="5AS-Zb-zHP" firstAttribute="centerX" secondItem="2dx-hK-hxL" secondAttribute="centerX" id="Duk-ML-7hE"/>
+                            <constraint firstItem="7zF-66-uRq" firstAttribute="top" secondItem="Z5L-XF-ZSa" secondAttribute="top" constant="40" id="Meu-uI-vga"/>
+                            <constraint firstItem="2dx-hK-hxL" firstAttribute="leading" secondItem="Z5L-XF-ZSa" secondAttribute="leading" id="N9Z-mx-C4J"/>
                             <constraint firstItem="2dx-hK-hxL" firstAttribute="centerX" secondItem="9rb-pV-gvI" secondAttribute="centerX" id="SCu-FD-r1u"/>
+                            <constraint firstItem="Z5L-XF-ZSa" firstAttribute="trailing" secondItem="2dx-hK-hxL" secondAttribute="trailing" id="SS2-gJ-f5W"/>
+                            <constraint firstItem="Z5L-XF-ZSa" firstAttribute="trailing" secondItem="5AS-Zb-zHP" secondAttribute="trailing" id="gVj-9g-QQL"/>
                             <constraint firstItem="7zF-66-uRq" firstAttribute="centerX" secondItem="9rb-pV-gvI" secondAttribute="centerX" id="u9U-ks-gUh"/>
-                            <constraint firstItem="2dx-hK-hxL" firstAttribute="top" secondItem="Tdm-Ge-uc6" secondAttribute="bottom" constant="16" id="wLk-OA-sWO"/>
+                            <constraint firstItem="2dx-hK-hxL" firstAttribute="top" secondItem="Tdm-Ge-uc6" secondAttribute="bottom" constant="20" id="wLk-OA-sWO"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Z5L-XF-ZSa"/>
                     </view>
-                    <navigationItem key="navigationItem" id="Otv-KQ-fsd">
-                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="e3g-mF-CWh">
-                            <connections>
-                                <action selector="cancel:" destination="lkT-rF-XV3" id="mzJ-wI-Paz"/>
-                            </connections>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="done" id="GP9-IT-RNj">
-                            <connections>
-                                <action selector="done:" destination="lkT-rF-XV3" id="TE0-YB-g6L"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" id="Otv-KQ-fsd"/>
                     <connections>
                         <outlet property="localAccountNameLabel" destination="Tdm-Ge-uc6" id="48O-IT-xXw"/>
                         <outlet property="nameTextField" destination="2dx-hK-hxL" id="t5V-3x-3vu"/>

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -437,30 +437,26 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="54.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hD4-MK-NWZ">
-                                                    <rect key="frame" x="90.5" y="4" width="233" height="46.5"/>
-                                                    <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="tb2-dO-AhR">
-                                                            <rect key="frame" x="0.0" y="7.5" width="32" height="32.000000000000028"/>
-                                                            <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="32" id="0GF-vU-aEc"/>
-                                                                <constraint firstAttribute="width" constant="32" id="xDy-t7-26A"/>
-                                                            </constraints>
-                                                        </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="On My iPhone" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="116-rt-msI">
-                                                            <rect key="frame" x="52" y="5.5" width="181" height="36"/>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                    </subviews>
-                                                </stackView>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountLocal" translatesAutoresizingMaskIntoConstraints="NO" id="tb2-dO-AhR">
+                                                    <rect key="frame" x="20" y="11.5" width="32" height="32.000000000000028"/>
+                                                    <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="32" id="0GF-vU-aEc"/>
+                                                        <constraint firstAttribute="width" constant="32" id="xDy-t7-26A"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="On My iPhone" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="116-rt-msI">
+                                                    <rect key="frame" x="68" y="11.5" width="157.5" height="31.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="hD4-MK-NWZ" firstAttribute="top" secondItem="99i-Ge-guB" secondAttribute="top" constant="4" id="6dt-CA-uPu"/>
-                                                <constraint firstItem="hD4-MK-NWZ" firstAttribute="centerX" secondItem="99i-Ge-guB" secondAttribute="centerX" id="MPN-GC-PVs"/>
-                                                <constraint firstAttribute="bottom" secondItem="hD4-MK-NWZ" secondAttribute="bottom" constant="4" id="vvU-3R-rgs"/>
+                                                <constraint firstItem="tb2-dO-AhR" firstAttribute="leading" secondItem="99i-Ge-guB" secondAttribute="leading" constant="20" symbolic="YES" id="8fv-hh-t9i"/>
+                                                <constraint firstItem="116-rt-msI" firstAttribute="leading" secondItem="tb2-dO-AhR" secondAttribute="trailing" constant="16" id="Frt-3l-XxP"/>
+                                                <constraint firstItem="tb2-dO-AhR" firstAttribute="centerY" secondItem="99i-Ge-guB" secondAttribute="centerY" id="Kvq-D1-FAa"/>
+                                                <constraint firstItem="116-rt-msI" firstAttribute="centerY" secondItem="tb2-dO-AhR" secondAttribute="centerY" id="Sfh-wA-Db0"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <inset key="separatorInset" minX="40" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -472,30 +468,26 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gQ5-ls-UhE">
-                                                    <rect key="frame" x="129" y="4" width="156" height="47.5"/>
-                                                    <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountFeedbin" translatesAutoresizingMaskIntoConstraints="NO" id="wyu-mZ-3zz">
-                                                            <rect key="frame" x="0.0" y="8" width="32" height="32"/>
-                                                            <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="32" id="LEr-1Z-N99"/>
-                                                                <constraint firstAttribute="width" constant="32" id="fZN-HH-heN"/>
-                                                            </constraints>
-                                                        </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Feedbin" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uiN-cA-Nc5">
-                                                            <rect key="frame" x="52" y="6" width="104" height="36"/>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                    </subviews>
-                                                </stackView>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountFeedbin" translatesAutoresizingMaskIntoConstraints="NO" id="wyu-mZ-3zz">
+                                                    <rect key="frame" x="20" y="12" width="32" height="32"/>
+                                                    <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="32" id="LEr-1Z-N99"/>
+                                                        <constraint firstAttribute="width" constant="32" id="fZN-HH-heN"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Feedbin" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uiN-cA-Nc5">
+                                                    <rect key="frame" x="68" y="12" width="90.5" height="31.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="gQ5-ls-UhE" secondAttribute="bottom" constant="4" id="4AG-Ro-8b5"/>
-                                                <constraint firstItem="gQ5-ls-UhE" firstAttribute="centerX" secondItem="DgY-u7-DRO" secondAttribute="centerX" id="l9o-tj-LgR"/>
-                                                <constraint firstItem="gQ5-ls-UhE" firstAttribute="top" secondItem="DgY-u7-DRO" secondAttribute="top" constant="4" id="vHj-SW-dhL"/>
+                                                <constraint firstItem="wyu-mZ-3zz" firstAttribute="centerY" secondItem="DgY-u7-DRO" secondAttribute="centerY" id="Bs4-T3-rb4"/>
+                                                <constraint firstItem="uiN-cA-Nc5" firstAttribute="leading" secondItem="wyu-mZ-3zz" secondAttribute="trailing" constant="16" id="Nlj-7T-lEX"/>
+                                                <constraint firstItem="uiN-cA-Nc5" firstAttribute="centerY" secondItem="wyu-mZ-3zz" secondAttribute="centerY" id="jn9-8X-QOA"/>
+                                                <constraint firstItem="wyu-mZ-3zz" firstAttribute="leading" secondItem="DgY-u7-DRO" secondAttribute="leading" constant="20" id="kBn-8H-bNV"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <inset key="separatorInset" minX="40" minY="0.0" maxX="0.0" maxY="0.0"/>


### PR DESCRIPTION
#### Description

Made some improvements to the user experience of adding new local / feedbin accounts on iOS.

#### Details

* Updated the UI style for both adding local and feedbin accounts, so that it matches the style of the settings screen. Also, made the margins consistent and added dynamic type support.
* Instead of presenting the add account screen modally, the add account view controllers gets pushed. When the account is added, you get popped back to the root settings screen.
* For the edit account screen, set the placeholder text to the default account name.