### PR TITLE
Set email text field content type to username so iOS offers to autofill passwords

### DIFF
--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -640,7 +640,7 @@
                                 </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <textInputTraits key="textInputTraits" keyboardType="emailAddress" textContentType="email"/>
+                                <textInputTraits key="textInputTraits" keyboardType="emailAddress" textContentType="username"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="center" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lDh-Kk-Kem">
                                 <rect key="frame" x="0.0" y="240" width="414" height="48"/>


### PR DESCRIPTION
This is what Apple says to do for email fields. https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_a_text_input_view

> For example, if your site uses email addresses as user names, set the input view’s textContentType property to .username, and set the keyboardType property to .UIKeyboardType.emailAddress.