### PR TITLE
Use 3 lines for timeline title + updated unread indicator layout

### DIFF
--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -64,7 +64,7 @@ struct AppDefaults {
 	}
 	
 	static func registerDefaults() {
-		let defaults: [String : Any] = [Key.timelineSortDirection: ComparisonResult.orderedDescending.rawValue, Key.refreshInterval: RefreshInterval.everyHour.rawValue, Key.timelineNumberOfLines: 2]
+		let defaults: [String : Any] = [Key.timelineSortDirection: ComparisonResult.orderedDescending.rawValue, Key.refreshInterval: RefreshInterval.everyHour.rawValue, Key.timelineNumberOfLines: 3]
 		UserDefaults.standard.register(defaults: defaults)
 	}
 

--- a/iOS/MasterTimeline/Cell/MasterTimelineCellLayout.swift
+++ b/iOS/MasterTimeline/Cell/MasterTimelineCellLayout.swift
@@ -28,7 +28,7 @@ extension MasterTimelineCellLayout {
 		var r = CGRect.zero
 		r.size = CGSize(width: MasterTimelineDefaultCellLayout.unreadCircleDimension, height: MasterTimelineDefaultCellLayout.unreadCircleDimension)
 		r.origin.x = point.x
-		r.origin.y = point.y + 9
+		r.origin.y = point.y + 8
 		return r
 	}
 	

--- a/iOS/MasterTimeline/Cell/MasterTimelineDefaultCellLayout.swift
+++ b/iOS/MasterTimeline/Cell/MasterTimelineDefaultCellLayout.swift
@@ -11,10 +11,10 @@ import RSCore
 
 struct MasterTimelineDefaultCellLayout: MasterTimelineCellLayout {
 
-	static let cellPadding = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
+	static let cellPadding = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 16)
 	
-	static let unreadCircleMarginLeft = CGFloat(integerLiteral: 8)
-	static let unreadCircleDimension = CGFloat(integerLiteral: 8)
+	static let unreadCircleMarginLeft = CGFloat(integerLiteral: 0)
+	static let unreadCircleDimension = CGFloat(integerLiteral: 12)
 	static let unreadCircleMarginRight = CGFloat(integerLiteral: 8)
 
 	static let starDimension = CGFloat(integerLiteral: 13)


### PR DESCRIPTION
* Updated the timeline cell title to default to using 3 lines instead of 2
* Updated the timeline cell unread indicator left margin to match Mail.app's left margin
* Updated the timeline cell unread indicator size to match Mail.app

Fixes #690 
Fixes #694 