### PR TITLE
Fix issue with 'Mark as Read' menu item in the Article menu.

### DIFF
--- a/Mac/Base.lproj/Main.storyboard
+++ b/Mac/Base.lproj/Main.storyboard
@@ -413,7 +413,7 @@
                                     <items>
                                         <menuItem title="Mark as Read" keyEquivalent="U" id="Fc9-c7-2AY">
                                             <connections>
-                                                <action selector="markRead:" target="Ady-hI-5gd" id="RQv-jl-2Nv"/>
+                                                <action selector="toggleRead:" target="Ady-hI-5gd" id="jLQ-ZF-xye"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Mark All as Read" keyEquivalent="k" id="HdN-Ks-cwh">


### PR DESCRIPTION
There were 2 issues: the title of the menu item did not toggle between 'Mark As Read' and 'Mark As Unread', and it was not invalidated where there is no article selected. All the code was already in place in `MainWindowController` as part of the interface item validation, but the menu item was using the wrong selector: `markRead` instead of `toggleRead`. Just changing the action in the menu item was needed to get the validation and menu item update happening correctly.