### PR TITLE
Adding CircleCI configuration for NetNewsWire (Mac only)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,58 @@
+# iOS CircleCI 2.0 configuration file
+#
+version: 2
+jobs:
+  build:
+
+    # Specify the Xcode version to use
+    macos:
+      xcode: "10.2.1"
+    # https://circleci.com/docs/2.0/configuration-reference/
+
+    # Mac/IOS specific examples and docs under the following links:
+    # https://circleci.com/docs/2.0/hello-world-macos/
+
+    steps:
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
+      # Commands will execute in macOS container
+      # with Xcode 10.2.1 installed
+      - run: xcodebuild -version
+      #- run:
+      #    name: get xcodebuild build options
+      #    command: xcodebuild -help
+      - run:
+          name: get xcodebuild build settings
+          command: xcodebuild -showBuildSettings
+
+      - run:
+          name: force wipe of any pre-existing derived data in CI
+          command: rm -rf /Users/distiller/Library/Developer/Xcode/DerivedData/NetNewsWire-*
+
+      # Build the app and run tests
+      - run:
+          name: Build Mac
+          command: xcodebuild -workspace NetNewsWire.xcworkspace -scheme NetNewsWire -configuration Debug -showBuildTimingSummary
+      # NOTE(heckj):
+      # the -configuration Release build invokes a shell script specifically
+      # codesigning the Sparkle pieces with the developer 'Brent Simmons',
+      # so we don't try and invoke that in CI
+      #
+
+      # the stuff below is from example that was using fastlane
+      # (and we're not using that...) so it's placeholder tidbits
+      # to clue me in to where I can get things for test log output
+      # for the CircleCI UI exposure...
+
+      # Collect XML test results data to show in the UI,
+      # and save the same XML files under test-results folder
+      # in the Artifacts tab
+      #- store_test_results:
+      #    path: test_output/report.xml
+      #- store_artifacts:
+      #    path: /tmp/test-results
+      #    destination: scan-test-results
+      #- store_artifacts:
+      #    path: ~/Library/Logs/scan
+      #    destination: scan-logs


### PR DESCRIPTION
This adds CircleCI configuration to setup NetNewsWire with CI. This really only applies for the Mac side of things right now, as the IOS side is requiring Xcode11 - and the latest XCode we can get on CircleCI is 10.2.1.

I've additionally tried to expand the CLI build with testing, but the tests are primarily osascript based, and the compilation for those tests is failing for me locally.

We *could* potentially add a similar CI configuration to each of the submodules and set up/extend testing there if that was desired.

In it's current configuration, this CI setup really only gives you a "it's compiled cleanly" (or not) indicator - not really anything about testing, coverage metrics, etc.

Current builds with this configuration can be seen under  https://circleci.com/gh/heckj/NetNewsWire, following the merge we'll get this set up under Brent's account linked to GH.
