### PR TITLE
Make read/starred read/write via AppleScript

### DIFF
--- a/Mac/Resources/NetNewsWire.sdef
+++ b/Mac/Resources/NetNewsWire.sdef
@@ -202,10 +202,10 @@
             <property name="modified date" code="MDat" type="date" access="r" description="date the article was last modified">
                 <cocoa key="dateModified"/>
             </property>
-            <property name="read" code="Read" type="boolean" access="r" description="has the article been read">
+            <property name="read" code="Read" type="boolean" access="rw" description="has the article been read">
                 <cocoa key="read"/>
             </property>
-            <property name="starred" code="Star" type="boolean" access="r" description="has the article been marked with a star">
+            <property name="starred" code="Star" type="boolean" access="rw" description="has the article been marked with a star">
                 <cocoa key="starred"/>
             </property>
             <property name="deleted" code="Delt" type="boolean" access="r" description="has the article been deleted by the user">

--- a/Mac/Scriptability/Article+Scriptability.swift
+++ b/Mac/Scriptability/Article+Scriptability.swift
@@ -107,12 +107,22 @@ class ScriptableArticle: NSObject, UniqueIdScriptingObject, ScriptingObjectConta
 
     @objc(read)
     var read:Bool  {
-        return article.status.boolStatus(forKey:.read)
+		get {
+			return article.status.boolStatus(forKey:.read)
+		}
+		set {
+			markArticles([self.article], statusKey: .read, flag: newValue)
+		}
     }
 
     @objc(starred)
     var starred:Bool  {
-        return article.status.boolStatus(forKey:.starred)
+		get {
+			return article.status.boolStatus(forKey:.starred)
+		}
+		set {
+			markArticles([self.article], statusKey: .starred, flag: newValue)
+		}
     }
 
     @objc(deleted)


### PR DESCRIPTION
Fixes #744.

Script used for testing (assumes feed exists; focus "innesential" in the UI to see toggling):

```applescript
tell application "NetNewsWire"
	set theArticle to first article of feed "inessential" of account id "OnMyMac"
	set read of theArticle to not read of theArticle
end tell
```