### PR TITLE
adding technote and readme update for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NetNewsWire
 
+[![CircleCI](https://circleci.com/gh/brentsimmons/NetNewsWire.svg?style=svg)](https://circleci.com/gh/brentsimmons/NetNewsWire)
+
 It’s a free and open source feed reader for macOS.
 
 It’s not in beta just yet. Getting close! While NetNewsWire 5.0 is feature-complete as of May 25, 2019, it has known bugs — and, surely, plenty of unknown bugs.

--- a/Technotes/ContinuousIntegration.md
+++ b/Technotes/ContinuousIntegration.md
@@ -21,10 +21,10 @@ project repository for the current and complete list of submodules, but for quic
 
 - [RSCore](https://github.com/brentsimmons/RSCore) [![CircleCI](https://circleci.com/gh/brentsimmons/RSCore.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSCore)
 
-- [RSCore](https://github.com/brentsimmons/RSWeb) [![CircleCI](https://circleci.com/gh/brentsimmons/RSWeb.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSWeb)
+- [RSWeb](https://github.com/brentsimmons/RSWeb) [![CircleCI](https://circleci.com/gh/brentsimmons/RSWeb.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSWeb)
 
-- [RSCore](https://github.com/brentsimmons/RSParser) [![CircleCI](https://circleci.com/gh/brentsimmons/RSParser.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSParser)
+- [RSParser](https://github.com/brentsimmons/RSParser) [![CircleCI](https://circleci.com/gh/brentsimmons/RSParser.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSParser)
 
-- [RSCore](https://github.com/brentsimmons/RSTree) [![CircleCI](https://circleci.com/gh/brentsimmons/RSTree.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSTree)
+- [RSTree](https://github.com/brentsimmons/RSTree) [![CircleCI](https://circleci.com/gh/brentsimmons/RSTree.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSTree)
 
-- [RSCore](https://github.com/brentsimmons/RSDatabase) [![CircleCI](https://circleci.com/gh/brentsimmons/RSDatabase.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSDatabase)
+- [RSDatabase](https://github.com/brentsimmons/RSDatabase) [![CircleCI](https://circleci.com/gh/brentsimmons/RSDatabase.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSDatabase)

--- a/Technotes/ContinuousIntegration.md
+++ b/Technotes/ContinuousIntegration.md
@@ -1,0 +1,40 @@
+# NetNewsWire Continuous Integration
+
+CI for NetNewsWire is enabled through CircleCI, hosted at
+<https://circleci.com/gh/brentsimmons/NetNewsWire>. The CI configuration (hosted in
+[`.circleci/config.yml`](https://github.com/brentsimmons/NetNewsWire/blob/master/.circleci/config.yml)
+uses `xcodebuild` to build the project after syncing the repository and
+the various submodules.
+
+As of June 2019, CircleCI offered Xcode 10.2.1, so IOS 13 and Catalina support are not available
+via CI as yet.
+
+The build itself focuses on the scheme NetNewsWire and leverages the
+`NetNewsWire.xcworkspace` configuration.
+
+Each submodule also has it's own CI configuration, which are set up and built from
+their own repositories. The submodule CI systems are entirely independent so that
+those libraries can grow and change, getting CI verification, indepdent of NetNewsWire.
+
+The submodule CI are typically set to run a build and any available tests. Refer to the
+project repository for the current and complete list of submodules, but for quick reference:
+
+- [RSCore](https://github.com/brentsimmons/RSCore)
+
+[![CircleCI](https://circleci.com/gh/brentsimmons/RSCore.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSCore)
+
+- [RSCore](https://github.com/brentsimmons/RSWeb)
+
+[![CircleCI](https://circleci.com/gh/brentsimmons/RSWeb.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSWeb)
+
+- [RSCore](https://github.com/brentsimmons/RSParser)
+
+[![CircleCI](https://circleci.com/gh/brentsimmons/RSParser.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSParser)
+
+- [RSCore](https://github.com/brentsimmons/RSTree)
+
+[![CircleCI](https://circleci.com/gh/brentsimmons/RSTree.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSTree)
+
+- [RSCore](https://github.com/brentsimmons/RSDatabase)
+
+[![CircleCI](https://circleci.com/gh/brentsimmons/RSDatabase.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSDatabase)

--- a/Technotes/ContinuousIntegration.md
+++ b/Technotes/ContinuousIntegration.md
@@ -19,22 +19,12 @@ those libraries can grow and change, getting CI verification, indepdent of NetNe
 The submodule CI are typically set to run a build and any available tests. Refer to the
 project repository for the current and complete list of submodules, but for quick reference:
 
-- [RSCore](https://github.com/brentsimmons/RSCore)
+- [RSCore](https://github.com/brentsimmons/RSCore) [![CircleCI](https://circleci.com/gh/brentsimmons/RSCore.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSCore)
 
-[![CircleCI](https://circleci.com/gh/brentsimmons/RSCore.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSCore)
+- [RSCore](https://github.com/brentsimmons/RSWeb) [![CircleCI](https://circleci.com/gh/brentsimmons/RSWeb.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSWeb)
 
-- [RSCore](https://github.com/brentsimmons/RSWeb)
+- [RSCore](https://github.com/brentsimmons/RSParser) [![CircleCI](https://circleci.com/gh/brentsimmons/RSParser.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSParser)
 
-[![CircleCI](https://circleci.com/gh/brentsimmons/RSWeb.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSWeb)
+- [RSCore](https://github.com/brentsimmons/RSTree) [![CircleCI](https://circleci.com/gh/brentsimmons/RSTree.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSTree)
 
-- [RSCore](https://github.com/brentsimmons/RSParser)
-
-[![CircleCI](https://circleci.com/gh/brentsimmons/RSParser.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSParser)
-
-- [RSCore](https://github.com/brentsimmons/RSTree)
-
-[![CircleCI](https://circleci.com/gh/brentsimmons/RSTree.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSTree)
-
-- [RSCore](https://github.com/brentsimmons/RSDatabase)
-
-[![CircleCI](https://circleci.com/gh/brentsimmons/RSDatabase.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSDatabase)
+- [RSCore](https://github.com/brentsimmons/RSDatabase) [![CircleCI](https://circleci.com/gh/brentsimmons/RSDatabase.svg?style=svg)](https://circleci.com/gh/brentsimmons/RSDatabase)


### PR DESCRIPTION
- noting where and how CI is configured
- added current build status to the README for NNW
- referenced submodule builds for a complete view of the current builds
  in the technote

<img width="602" alt="Screen Shot 2019-06-13 at 7 54 22 AM" src="https://user-images.githubusercontent.com/43388/59443449-d9d6bc00-8db0-11e9-8786-d086d27200b6.png">

<img width="627" alt="Screen Shot 2019-06-13 at 7 57 00 AM" src="https://user-images.githubusercontent.com/43388/59443455-dd6a4300-8db0-11e9-86a9-5b328f3379e8.png">
