### PR TITLE
Fixes the link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here’s [How to Support NetNewsWire](Technotes/HowToSupportNetNewsWire.markdown
 
 [Join the Slack group](https://join.slack.com/t/netnewswire/shared_invite/enQtNjM4MDA1MjQzMDkzLTNlNjBhOWVhYzdhYjA4ZWFhMzQ1MTUxYjU0NTE5ZGY0YzYwZWJhNjYwNTNmNTg2NjIwYWY4YzhlYzk5NmU3ZTc) to talk with other NetNewsWire users — and to help out, if you’d like to, by testing, coding, writing, providing feedback, or just helping us think things through. Everybody is welcome and encouraged to join.
 
-Every community member is expected to abide by the code of conduct which is included in the [Contributing](Contributing.md) page.
+Every community member is expected to abide by the code of conduct which is included in the [Contributing](CONTRIBUTING.md) page.
 
 #### Pull Requests
 


### PR DESCRIPTION
The link to CONTRIBUTING.md in the README was cased incorrectly and therefore 404'd.