### PR TITLE
UI Housekeeping

### DIFF
--- a/iOS/AppAssets.swift
+++ b/iOS/AppAssets.swift
@@ -53,7 +53,7 @@ struct AppAssets {
 	}()
 
 	static var masterFolderImage: RSImage = {
-		let image = RSImage(named: "folderImage")!
+		let image = RSImage(systemName: "tag")!
 		return image.maskWithColor(color: AppAssets.masterFolderColor.cgColor)!
 	}()
 	

--- a/iOS/AppAssets.swift
+++ b/iOS/AppAssets.swift
@@ -53,7 +53,7 @@ struct AppAssets {
 	}()
 
 	static var masterFolderImage: RSImage = {
-		let image = RSImage(systemName: "tag")!
+		let image = RSImage(systemName: "folder.fill")!
 		return image.maskWithColor(color: AppAssets.masterFolderColor.cgColor)!
 	}()
 	

--- a/iOS/MasterFeed/Cell/MasterFeedTableViewSectionHeader.swift
+++ b/iOS/MasterFeed/Cell/MasterFeedTableViewSectionHeader.swift
@@ -113,6 +113,7 @@ private extension MasterFeedTableViewSectionHeader {
 		addSubviewAtInit(titleView)
 		updateDisclosureImage()
 		addSubviewAtInit(disclosureView)
+		addBackgroundView()
 	}
 	
 	func updateDisclosureImage() {
@@ -132,6 +133,11 @@ private extension MasterFeedTableViewSectionHeader {
 		titleView.setFrameIfNotEqual(layout.titleRect)
 		unreadCountView.setFrameIfNotEqual(layout.unreadCountRect)
 		disclosureView.setFrameIfNotEqual(layout.disclosureButtonRect)
+	}
+	
+	func addBackgroundView() {
+		self.backgroundView = UIView(frame: self.bounds)
+		self.backgroundView?.backgroundColor = UIColor.systemGroupedBackground
 	}
 	
 }


### PR DESCRIPTION
Fixes #771 — adds a background view to section headers and colours appropriately to support light/dark mode. This stops collapsing section from animating under the section header.

Converts folder image to use SFSymbol's `folder.fill`. 