### PR TITLE
Two new AppleScripts for mac-candidate

### DIFF
--- a/AppleScript/Mail-CreateOutgoingMessage.applescript
+++ b/AppleScript/Mail-CreateOutgoingMessage.applescript
@@ -1,0 +1,85 @@
+-- This script grabs the current article in NetNewsWire and copies relevant information about it 
+--    to a new outgoing message in Mail
+-- the intended use is that the user wants to send email about the current article, and 
+--    would fill in the recipient and then send the message
+
+-- sometimes, an article has contents, and sometimes it has html contents
+-- this function getContentsOrHtml() gets the contents as text, despite the representation
+-- first it checks to see if there are plain text contents
+-- if not, it looks for html contents, and converts those to plain text using a shell script that invokes textutil
+-- if it can't find either plain text or html, it returns "couldn't find article text"
+to getContentsOrHtml()
+	tell application "NetNewsWire"
+		set textContents to the contents of the current article
+		if textContents is not "" then
+			return textContents
+		else
+			set htmlContents to html of the current article
+			if htmlContents is not "" then
+				set shellScript to " echo '" & htmlContents & "' | /usr/bin/textutil -stdin -stdout -format html -convert txt"
+				set pureText to do shell script shellScript
+				return pureText
+			end if
+		end if
+	end tell
+	return "couldn't find article text"
+end getContentsOrHtml
+
+
+-- given a list of author names, generate a happily formatted list like "Jean MacDonald and James Dempsey"
+-- if the list is more than two names, use Oxford comma structure: "Brent Simmons, Jean MacDonald, and James Dempsey"
+
+to formatListOfNames(listOfNames)
+	set c to count listOfNames
+	if c is 1 then
+		set formattedList to item 1 of listOfNames
+	else if c is 2 then
+		set formattedList to item 1 of listOfNames & " and " & item 2 of listOfNames
+	else
+		set frontOfList to items 1 thru (c - 1) of listOfNames
+		set lastName to item c of listOfNames
+		set tid to AppleScript's text item delimiters
+		set AppleScript's text item delimiters to ", "
+		set t1 to frontOfList as text
+		set formattedList to t1 & ", and " & lastName
+		set AppleScript's text item delimiters to tid
+	end if
+	return formattedList
+end formatListOfNames
+
+
+-- sometimes, an article has an author, sometimes it has more than one, sometimes there's no author
+-- this function getAuthorStub() returns a string like " from Jean MacDonald "  that can be used in crafting a message
+-- about the current article.  If there are no authors, it just returns a single space.
+to getAuthorStub(authorNames)
+	try
+		if ((count authorNames) is greater than 0) then
+			return " from " & formatListOfNames(authorNames) & " "
+		end if
+	end try
+	return " "
+end getAuthorStub
+
+
+
+-- Here's where the script starts
+
+-- first, get some relevant info out for NetNewsWire
+tell application "NetNewsWire"
+	set articleUrl to the url of the current article
+	set articleTitle to the title of the current article
+	set authorNames to name of authors of the current article
+end tell
+
+
+-- then, prepare the message subject and message contents
+set messageSubject to "From NetNewsWire to you: " & articleTitle
+set myIntro to "Here's something" & getAuthorStub(authorNames) & "that I was reading on NetNewsWire: "
+set messageContents to myIntro & return & return & articleUrl & return & return & getContentsOrHtml()
+
+
+-- lastly, make a new outgoing message in Mail with the given subject and contents
+tell application "Mail"
+	set m1 to make new outgoing message with properties {subject:messageSubject}
+	set content of m1 to messageContents
+end tell

--- a/AppleScript/Safari-OpenAllStarredArticles.applescript
+++ b/AppleScript/Safari-OpenAllStarredArticles.applescript
@@ -1,0 +1,49 @@
+-- This script creates a new Safari window with all the starred articles in a NetNewsWire instance, each in its own tab
+
+-- declare the safariWindow property here so we can use is throughout the whole script
+
+property safariWindow : missing value
+
+-- the openTabInSafari() function opens a new tab in the appropriate window
+
+to openTabInSafari(theUrl)
+	tell application "Safari"
+		-- test if this is the first call to openTabInSafari()
+		if (my safariWindow is missing value) then
+			-- first time through, make a new window with the given url in the only tab
+			set newdoc to make new document at front with properties {URL:theUrl}
+			-- because we created the doucument "at front", we know it is window 1
+			set safariWindow to window 1
+		else
+			-- after the first time, make a new tab in the wndow we created the first tim
+			tell safariWindow
+				make new tab with properties {URL:theUrl}
+			end tell
+		end if
+	end tell
+end openTabInSafari
+
+
+-- the script starts here
+-- First, initialize safariWindow to be missing value, so that the first time through 
+-- openTabInSafari() we'll make a new window to hold all our articles
+
+set safariWindow to missing value
+
+
+-- Then we loop though all the feeds of all the accounts
+-- for each feed, we find all the starred articles
+--for each one of those, open a new tab in Safari
+
+tell application "NetNewsWire"
+	set allAccounts to every account
+	repeat with nthAccount in allAccounts
+		set allFeeds to every feed of nthAccount
+		repeat with nthFeed in allFeeds
+			set starredArticles to (get every article of nthFeed where starred is true)
+			repeat with nthArticle in starredArticles
+				my openTabInSafari(url of nthArticle)
+			end repeat
+		end repeat
+	end repeat
+end tell


### PR DESCRIPTION
first, merge the existing AppleScript targeting Mail from master branch
second, an AppleScript targeting Safari that opens a new Safari window with a tab for each of the starred articles in a NetNewsWire instance.