### PR TITLE
Work around PRODUCT_NAME bug, disable failing AppleScript test

### DIFF
--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -845,7 +845,7 @@
 		849A97971ED9EFAA007D329B /* Node-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Node-Extensions.swift"; sourceTree = "<group>"; };
 		849A979E1ED9F130007D329B /* SidebarCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarCell.swift; sourceTree = "<group>"; };
 		849A97A11ED9F180007D329B /* FolderTreeControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FolderTreeControllerDelegate.swift; sourceTree = "<group>"; };
-		849C64601ED37A5D003D8FC0 /* NetNewsWire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = NetNewsWire.app; path = .app; sourceTree = BUILT_PRODUCTS_DIR; };
+		849C64601ED37A5D003D8FC0 /* NetNewsWire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NetNewsWire.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		849C64671ED37A5D003D8FC0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		849C64711ED37A5D003D8FC0 /* NetNewsWireTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NetNewsWireTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		849EE70E203919360082A1EA /* AppAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAssets.swift; sourceTree = "<group>"; };
@@ -2801,6 +2801,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 51121AA12265430A00BC0EC1 /* NetNewsWire_iOSapp_target.xcconfig */;
 			buildSettings = {
+				PRODUCT_NAME = NetNewsWire;
 			};
 			name = Debug;
 		};
@@ -2808,6 +2809,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 51121AA12265430A00BC0EC1 /* NetNewsWire_iOSapp_target.xcconfig */;
 			buildSettings = {
+				PRODUCT_NAME = NetNewsWire;
 			};
 			name = Release;
 		};
@@ -2829,6 +2831,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D5907CE02002F0FA005947E5 /* NetNewsWire_macapp_target.xcconfig */;
 			buildSettings = {
+				PRODUCT_NAME = NetNewsWire;
 			};
 			name = Debug;
 		};
@@ -2836,6 +2839,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D5907CE02002F0FA005947E5 /* NetNewsWire_macapp_target.xcconfig */;
 			buildSettings = {
+				PRODUCT_NAME = NetNewsWire;
 			};
 			name = Release;
 		};

--- a/NetNewsWire.xcodeproj/xcshareddata/xcschemes/NetNewsWire.xcscheme
+++ b/NetNewsWire.xcodeproj/xcshareddata/xcschemes/NetNewsWire.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "849C645F1ED37A5D003D8FC0"
-               BuildableName = ".app"
+               BuildableName = "NetNewsWire.app"
                BlueprintName = "NetNewsWire"
                ReferencedContainer = "container:NetNewsWire.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "849C645F1ED37A5D003D8FC0"
-            BuildableName = ".app"
+            BuildableName = "NetNewsWire.app"
             BlueprintName = "NetNewsWire"
             ReferencedContainer = "container:NetNewsWire.xcodeproj">
          </BuildableReference>
@@ -69,7 +69,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "849C645F1ED37A5D003D8FC0"
-            BuildableName = ".app"
+            BuildableName = "NetNewsWire.app"
             BlueprintName = "NetNewsWire"
             ReferencedContainer = "container:NetNewsWire.xcodeproj">
          </BuildableReference>
@@ -86,7 +86,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "849C645F1ED37A5D003D8FC0"
-            BuildableName = ".app"
+            BuildableName = "NetNewsWire.app"
             BlueprintName = "NetNewsWire"
             ReferencedContainer = "container:NetNewsWire.xcodeproj">
          </BuildableReference>

--- a/Tests/NetNewsWireTests/ScriptingTests/ScriptingTests.swift
+++ b/Tests/NetNewsWireTests/ScriptingTests/ScriptingTests.swift
@@ -81,8 +81,16 @@ class ScriptingTests: AppleScriptXCTestCase {
               actions and the keystrokes aren't delivered to the app right away, so the ui
               isn't updated in time for 'current article' to be set.  But, breaking them up
               in this way seems to work.
+              
+              July 30, 2019:  There's an issue where in order for a script to send keystrokes,
+			  The app has to be allowed to interact with the SystemEvents.app in
+			  System Preferences -> Security & Privacy -> Privacy -> Accessibility
+			  and this premission needs to be renewed every time the app is recompiled unless
+			  the app is codesigned.  Until we figure out how to get around this limitation,
+			  this test is disabled.
 */
-    func testCurrentArticleScripts() {
+    func disabledTestCurrentArticleScripts() {
+        
         doIndividualScriptWithExpectation(filename: "uiScriptingTestSetup")
         doIndividualScriptWithExpectation(filename: "establishMainWindowStartingState")
         doIndividualScriptWithExpectation(filename: "selectAFeed")


### PR DESCRIPTION
Xcode 11 beta 4 seems to have a bug where the PRODUCT_NAME setting in an .xcconfig file is not respected.  Add this build setting back to the iOS App and mac app targets in the .pbxproj file so Xcode builds the right thing.

Also, disable the testCurrentArticleScripts XCTest, because it seems to require extra permissions for each build for NetNewsWire to control SystemEvents.app via AppleEvents.  Added explanation of what the issue is. This is a medium term resolution for issue #817 