### PR TITLE
Support opening multiple selected articles in the browser at once

### DIFF
--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -183,7 +183,7 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 	public func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
 		
 		if item.action == #selector(openArticleInBrowser(_:)) {
-			return currentLink != nil
+			return currentLinks != nil
 		}
 		
 		if item.action == #selector(nextUnread(_:)) {
@@ -244,9 +244,11 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 	}
 
 	@IBAction func openArticleInBrowser(_ sender: Any?) {
-		if let link = currentLink {
-			Browser.open(link)
-		}		
+		if let links = currentLinks {
+			for link in links {
+				Browser.open(link)
+			}
+		}
 	}
 
 	@IBAction func openInBrowser(_ sender: Any?) {
@@ -580,9 +582,12 @@ private extension MainWindowController {
 		}
 		return nil
 	}
-
-	var currentLink: String? {
-		return oneSelectedArticle?.preferredLink
+	
+	var currentLinks: [String]? {
+		if let articles = selectedArticles {
+			return articles.compactMap { $0.preferredLink }
+		}
+		return nil
 	}
 
 	// MARK: - Command Validation

--- a/Mac/MainWindow/Timeline/TimelineViewController+ContextualMenus.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController+ContextualMenus.swift
@@ -99,10 +99,13 @@ extension TimelineViewController {
 	
 	@objc func openInBrowserFromContextualMenu(_ sender: Any?) {
 
-		guard let menuItem = sender as? NSMenuItem, let urlString = menuItem.representedObject as? String else {
+		guard let menuItem = sender as? NSMenuItem, let urlStrings = menuItem.representedObject as? [String] else {
 			return
 		}
-		Browser.open(urlString, inBackground: false)
+		
+		for urlString in urlStrings {
+			Browser.open(urlString, inBackground: false)
+		}
 	}
 
 	@objc func performShareServiceFromContextualMenu(_ sender: Any?) {
@@ -181,9 +184,11 @@ private extension TimelineViewController {
 			}
 		}
 		
-		if articles.count == 1, let link = articles.first!.preferredLink {
+		if articles.count > 0 {
 			menu.addSeparatorIfNeeded()
-			menu.addItem(openInBrowserMenuItem(link))
+			
+			let links = articles.compactMap { $0.preferredLink }
+			menu.addItem(openInBrowserMenuItem(links))
 		}
 
 		if let sharingMenu = shareMenu(for: articles) {
@@ -266,9 +271,9 @@ private extension TimelineViewController {
 		return menuItem(menuText, #selector(markAllInFeedAsRead(_:)), articles)
 	}
 	
-	func openInBrowserMenuItem(_ urlString: String) -> NSMenuItem {
+	func openInBrowserMenuItem(_ urlStrings: [String]) -> NSMenuItem {
 
-		return menuItem(NSLocalizedString("Open in Browser", comment: "Command"), #selector(openInBrowserFromContextualMenu(_:)), urlString)
+		return menuItem(NSLocalizedString("Open in Browser", comment: "Command"), #selector(openInBrowserFromContextualMenu(_:)), urlStrings)
 	}
 
 	func menuItem(_ title: String, _ action: Selector, _ representedObject: Any) -> NSMenuItem {

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -244,8 +244,9 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 	// MARK: - Actions
 
 	@objc func openArticleInBrowser(_ sender: Any?) {
+		let links = selectedArticles.compactMap { $0.preferredLink }
 		
-		if let link = oneSelectedArticle?.preferredLink {
+		for link in links {
 			Browser.open(link)
 		}
 	}


### PR DESCRIPTION
This pull request implements #857. 

My approach was to look for all interactions open an article in the browser, and replace that with an implementation supporting multiple. Since a collection can contain a single item, this enabled the new functionality while preserving the existing. 

All these interactions start with the user selecting one or more articles in the `TimelineView`. Then one of the following things can be done:
- Press `Article` in the menu bar, and select `Open in Browser`.
- Press `⌘ + →`.
- Press enter.
- Right-click and select `Open in Browser` from the context menu.
- Press the globe icon in the right corner of the application.
- Double-click on *one* of the selected articles. I was uncertain whether this should open all selected items or only the one that is double-clicked. To make a decision I looked at how the built-in applications behave – they do the former (see for example Mail.app or Finder).

Before I consider this implementation to be done I need some advice about when to consider an article to be read. Today when an article is selected it is shown in the `DetailView` and therefore marked as read. When multiple articlesare selected, only the first one (that was shown in the `DetailView` before it says "Multiple selection") is marked as read. 

**Do we consider an article opened in the browser to be read?** Today's "Open in Browser" functionality does **not** care about read status at all – which leads to it to for example be possible to right click an article, open it in the browser and it will still be marked as unread in the app. 

Selecting and opening multiple articles in the browser makes this behaviour more prominent in more interactions, and I think it would be wise to make a decision on how it should be handled for future implementations involving this too. 

