### PR TITLE
Add download count badge to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ![Icon](Technotes/Images/icon.png) NetNewsWire
 
 [![CircleCI](https://circleci.com/gh/brentsimmons/NetNewsWire.svg?style=svg)](https://circleci.com/gh/brentsimmons/NetNewsWire)
+[![GitHub All Releases](https://img.shields.io/github/downloads/brentsimmons/netnewswire/total)](https://github.com/brentsimmons/NetNewsWire/releases)
 
 It’s a free and open source feed reader for macOS.
 


### PR DESCRIPTION
Not sure if this is something you actually want or not, but I've seen this used a lot to indicate a rough number of downloads.

You can also get a more accurate number from through the GitHub API at https://api.github.com/repos/brentsimmons/NetNewsWire/releases if you are curious.