### PR TITLE
Use noContentHTML rather than noSelectionHTML for prepared web views.

### DIFF
--- a/Shared/Article Rendering/ArticleRenderer.swift
+++ b/Shared/Article Rendering/ArticleRenderer.swift
@@ -41,6 +41,11 @@ struct ArticleRenderer {
 		let renderer = ArticleRenderer(article: nil, style: style)
 		return renderer.noSelectionHTML
 	}
+	
+	static func noContentHTML(style: ArticleStyle) -> String {
+		let renderer = ArticleRenderer(article: nil, style: style)
+		return renderer.noContentHTML
+	}
 }
 
 // MARK: - Private
@@ -60,6 +65,10 @@ private extension ArticleRenderer {
 	private var noSelectionHTML: String {
 		let body = "<h3 class='systemMessage'>No selection</h3>"
 		return renderHTML(withBody: body)
+	}
+
+	private var noContentHTML: String {
+		return renderHTML(withBody: "")
 	}
 
 	static var faviconImgTagCache = [Feed: String]()

--- a/iOS/Detail/DetailViewController.swift
+++ b/iOS/Detail/DetailViewController.swift
@@ -270,7 +270,7 @@ class DetailViewControllerWebViewProvider {
 		webView.uiDelegate = nil
 		webView.navigationDelegate = nil
 
-		let html = ArticleRenderer.noSelectionHTML(style: .defaultStyle)
+		let html = ArticleRenderer.noContentHTML(style: .defaultStyle)
 		webView.loadHTMLString(html, baseURL: nil)
 
 		queue.insert(webView, at: 0)


### PR DESCRIPTION
Added a noContentHTML to ArticleRenderer. Use that for the initial content
for queued web views so that we don't see a temporary flash of "No
Selection" when pushing to an article that doesn't load instantly.