### PR TITLE
Fix for issue #948 — bad highlight state for table cell views in light mode.

### DIFF
--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		51F85BFD2275DCA800C787DC /* SingleLineUILabelSizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F85BFC2275DCA800C787DC /* SingleLineUILabelSizer.swift */; };
 		55E15BCB229D65A900D6602A /* AccountsReaderAPI.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55E15BC1229D65A900D6602A /* AccountsReaderAPI.xib */; };
 		55E15BCC229D65A900D6602A /* AccountsReaderAPIWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E15BCA229D65A900D6602A /* AccountsReaderAPIWindowController.swift */; };
+		5F323809231DF9F000706F6B /* NNWTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F323808231DF9F000706F6B /* NNWTableViewCell.swift */; };
 		6581C73820CED60100F4AD34 /* SafariExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581C73720CED60100F4AD34 /* SafariExtensionHandler.swift */; };
 		6581C73A20CED60100F4AD34 /* SafariExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581C73920CED60100F4AD34 /* SafariExtensionViewController.swift */; };
 		6581C73D20CED60100F4AD34 /* SafariExtensionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6581C73B20CED60100F4AD34 /* SafariExtensionViewController.xib */; };
@@ -773,6 +774,7 @@
 		557EE1A522B6F4E1004206FA /* SettingsReaderAPIAccountView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsReaderAPIAccountView.swift; sourceTree = "<group>"; };
 		55E15BC1229D65A900D6602A /* AccountsReaderAPI.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AccountsReaderAPI.xib; sourceTree = "<group>"; };
 		55E15BCA229D65A900D6602A /* AccountsReaderAPIWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsReaderAPIWindowController.swift; sourceTree = "<group>"; };
+		5F323808231DF9F000706F6B /* NNWTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NNWTableViewCell.swift; sourceTree = "<group>"; };
 		6581C73320CED60000F4AD34 /* Subscribe to Feed.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Subscribe to Feed.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6581C73420CED60100F4AD34 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		6581C73720CED60100F4AD34 /* SafariExtensionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariExtensionHandler.swift; sourceTree = "<group>"; };
@@ -1242,6 +1244,14 @@
 				51EF0F7B2277919E0050506E /* TimelineNumberOfLinesViewController.swift */,
 			);
 			path = UIKit;
+			sourceTree = "<group>";
+		};
+		5F3237FF231DF9D000706F6B /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				5F323808231DF9F000706F6B /* NNWTableViewCell.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		6581C73620CED60100F4AD34 /* SafariExtension */ = {
@@ -1766,6 +1776,7 @@
 				5183CCEB227117C70010922C /* Settings */,
 				5183CCDB226F1EEB0010922C /* Progress */,
 				51C45245226506C800C03939 /* Extensions */,
+				5F3237FF231DF9D000706F6B /* Views */,
 				5194B5E222B693EC00144881 /* Wrappers */,
 				84C9FC9A2262A1A900D921D6 /* Resources */,
 			);
@@ -2018,11 +2029,11 @@
 				TargetAttributes = {
 					6581C73220CED60000F4AD34 = {
 						DevelopmentTeam = SHJK2V3AJG;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					840D617B2029031C009BC708 = {
 						CreatedOnToolsVersion = 9.3;
-						DevelopmentTeam = SHJK2V3AJG;
+						DevelopmentTeam = DY2XQRVWN9;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -2033,7 +2044,7 @@
 					849C645F1ED37A5D003D8FC0 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = SHJK2V3AJG;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.HardenedRuntime = {
 								enabled = 1;
@@ -2042,7 +2053,7 @@
 					};
 					849C64701ED37A5D003D8FC0 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = SHJK2V3AJG;
+						DevelopmentTeam = 9C84TZ7Q6Z;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 849C645F1ED37A5D003D8FC0;
 					};
@@ -2431,6 +2442,7 @@
 				51C452A622650A3500C03939 /* Node-Extensions.swift in Sources */,
 				5183CCDF226F1FCC0010922C /* UINavigationController+Progress.swift in Sources */,
 				51C45294226509C800C03939 /* SearchFeedDelegate.swift in Sources */,
+				5F323809231DF9F000706F6B /* NNWTableViewCell.swift in Sources */,
 				512E09352268B25900BDCFDD /* UISplitViewController-Extensions.swift in Sources */,
 				51C452A022650A1900C03939 /* FeedIconDownloader.swift in Sources */,
 				51F85BE7227245FC00C787DC /* AboutViewController.swift in Sources */,

--- a/iOS/AppAssets.swift
+++ b/iOS/AppAssets.swift
@@ -96,10 +96,6 @@ struct AppAssets {
 		return UIImage(systemName: "safari")!
 	}()
 	
-	static var selectedTextColor: UIColor = {
-		return UIColor(named: "selectedTextColor")!
-	}()
-
 	static var settingsImage: UIImage = {
 		return UIImage(named: "settingsImage")!
 	}()
@@ -128,6 +124,10 @@ struct AppAssets {
 		return UIImage(systemName: "star")!
 	}()
 	
+	static var tableViewCellHighlightedTextColor: UIColor = {
+		return UIColor(named: "tableViewCellHighlightedTextColor")!
+	}()
+
 	static var tableViewCellSelectionColor: UIColor = {
 		return UIColor(named: "tableViewCellSelectionColor")!
 	}()

--- a/iOS/AppAssets.swift
+++ b/iOS/AppAssets.swift
@@ -128,6 +128,10 @@ struct AppAssets {
 		return UIImage(systemName: "star")!
 	}()
 	
+	static var tableViewCellSelectionColor: UIColor = {
+		return UIColor(named: "tableViewCellSelectionColor")!
+	}()
+
 	static var timelineStarImage: UIImage = {
 		let image = UIImage(systemName: "star.fill")!
 		return image.withTintColor(AppAssets.starColor, renderingMode: .alwaysOriginal)

--- a/iOS/MasterFeed/Cell/MasterFeedTableViewCell.swift
+++ b/iOS/MasterFeed/Cell/MasterFeedTableViewCell.swift
@@ -104,11 +104,24 @@ class MasterFeedTableViewCell : NNWTableViewCell {
 		super.init(coder: coder)
 		commonInit()
 	}
+	
+	override func applyThemeProperties() {
+		super.applyThemeProperties()
+		titleView.highlightedTextColor = AppAssets.tableViewCellHighlightedTextColor
+	}
+
+	override func setHighlighted(_ highlighted: Bool, animated: Bool) {
+		super.setHighlighted(highlighted, animated: animated)
+
+		let tintColor = isHighlighted || isSelected ? AppAssets.tableViewCellHighlightedTextColor : AppAssets.netNewsWireBlueColor
+		faviconImageView.tintColor = tintColor
+	}
 
 	override func setSelected(_ selected: Bool, animated: Bool) {
-		titleView.textColor = selected ? AppAssets.selectedTextColor : UIColor.label
-		faviconImageView.tintColor = selected ? AppAssets.selectedTextColor : AppAssets.netNewsWireBlueColor
 		super.setSelected(selected, animated: animated)
+
+		let tintColor = isHighlighted || isSelected ? AppAssets.tableViewCellHighlightedTextColor : AppAssets.netNewsWireBlueColor
+		faviconImageView.tintColor = tintColor
 	}
 	
 	override func willTransition(to state: UITableViewCell.StateMask) {

--- a/iOS/MasterFeed/Cell/MasterFeedTableViewCell.swift
+++ b/iOS/MasterFeed/Cell/MasterFeedTableViewCell.swift
@@ -15,7 +15,7 @@ protocol MasterFeedTableViewCellDelegate: class {
 	func disclosureSelected(_ sender: MasterFeedTableViewCell, expanding: Bool)
 }
 
-class MasterFeedTableViewCell : UITableViewCell {
+class MasterFeedTableViewCell : NNWTableViewCell {
 
 	weak var delegate: MasterFeedTableViewCellDelegate?
 	var allowDisclosureSelection = false
@@ -141,17 +141,10 @@ class MasterFeedTableViewCell : UITableViewCell {
 private extension MasterFeedTableViewCell {
 
 	func commonInit() {
-		theme()
 		addSubviewAtInit(unreadCountView)
 		addSubviewAtInit(faviconImageView)
 		addSubviewAtInit(titleView)
 		addDisclosureView()
-	}
-
-	func theme() {
-		let bgView = UIView()
-		bgView.backgroundColor = AppAssets.netNewsWireBlueColor
-		selectedBackgroundView = bgView
 	}
 
 	func addDisclosureView() {

--- a/iOS/MasterTimeline/Cell/MasterTimelineTableViewCell.swift
+++ b/iOS/MasterTimeline/Cell/MasterTimelineTableViewCell.swift
@@ -9,7 +9,7 @@
 import UIKit
 import RSCore
 
-class MasterTimelineTableViewCell: UITableViewCell {
+class MasterTimelineTableViewCell: NNWTableViewCell {
 	
 	private let titleView = MasterTimelineTableViewCell.multiLineUILabel()
 	private let summaryView = MasterTimelineTableViewCell.multiLineUILabel()
@@ -124,7 +124,6 @@ private extension MasterTimelineTableViewCell {
 	
 	func commonInit() {
 		
-		theme()
 		addAccessoryView()
 		addSubviewAtInit(titleView, hidden: false)
 		addSubviewAtInit(summaryView, hidden: true)
@@ -136,12 +135,6 @@ private extension MasterTimelineTableViewCell {
 		
 	}
 	
-	func theme() {
-		let bgView = UIView()
-		bgView.backgroundColor = AppAssets.netNewsWireBlueColor
-		selectedBackgroundView = bgView
-	}
-
 	func addAccessoryView() {
 		accessoryView = UIImageView(image: AppAssets.chevronRightImage)
 	}

--- a/iOS/MasterTimeline/Cell/MasterTimelineTableViewCell.swift
+++ b/iOS/MasterTimeline/Cell/MasterTimelineTableViewCell.swift
@@ -38,21 +38,31 @@ class MasterTimelineTableViewCell: NNWTableViewCell {
 		commonInit()
 	}
 	
+	override func applyThemeProperties() {
+		super.applyThemeProperties()
+
+		let highlightedTextColor = AppAssets.tableViewCellHighlightedTextColor
+		
+		titleView.highlightedTextColor = highlightedTextColor
+		summaryView.highlightedTextColor = highlightedTextColor
+		dateView.highlightedTextColor = highlightedTextColor
+		feedNameView.highlightedTextColor = highlightedTextColor
+	}
+	
 	override var frame: CGRect {
 		didSet {
 			setNeedsLayout()
 		}
 	}
 	
+	override func setHighlighted(_ highlighted: Bool, animated: Bool) {
+		super.setHighlighted(highlighted, animated: animated)
+		unreadIndicatorView.isSelected = isHighlighted || isSelected
+	}
+
 	override func setSelected(_ selected: Bool, animated: Bool) {
-		let selectedTextColor = selected ? AppAssets.selectedTextColor : UIColor.label
-		titleView.textColor = selectedTextColor
-		summaryView.textColor = selectedTextColor
-		dateView.textColor = selectedTextColor
-		feedNameView.textColor = selectedTextColor
-		unreadIndicatorView.isSelected = selected
-		
 		super.setSelected(selected, animated: animated)
+		unreadIndicatorView.isSelected = isHighlighted || isSelected
 	}
 
 	override func sizeThatFits(_ size: CGSize) -> CGSize {

--- a/iOS/MasterTimeline/Cell/MasterUnreadIndicatorView.swift
+++ b/iOS/MasterTimeline/Cell/MasterUnreadIndicatorView.swift
@@ -32,11 +32,8 @@ class MasterUnreadIndicatorView: UIView {
 	}()
 	
     override func draw(_ dirtyRect: CGRect) {
-		if isSelected {
-			AppAssets.selectedTextColor.setFill()
-		} else {
-			AppAssets.timelineUnreadCircleColor.setFill()
-		}
+		let color = isSelected ? AppAssets.tableViewCellHighlightedTextColor : AppAssets.timelineUnreadCircleColor
+		color.setFill()
 		MasterUnreadIndicatorView.bezierPath.fill()
     }
     

--- a/iOS/Resources/Assets.xcassets/tableViewCellHighlightedTextColor.colorset/Contents.json
+++ b/iOS/Resources/Assets.xcassets/tableViewCellHighlightedTextColor.colorset/Contents.json
@@ -15,6 +15,19 @@
           "green" : "1.000"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "platform" : "ios",
+        "reference" : "labelColor"
+      }
     }
   ]
 }

--- a/iOS/Resources/Assets.xcassets/tableViewCellSelectionColor.colorset/Contents.json
+++ b/iOS/Resources/Assets.xcassets/tableViewCellSelectionColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.031",
+          "alpha" : "1.000",
+          "blue" : "0.933",
+          "green" : "0.416"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.267",
+          "alpha" : "1.000",
+          "blue" : "0.886",
+          "green" : "0.565"
+        }
+      }
+    }
+  ]
+}

--- a/iOS/Views/NNWTableViewCell.swift
+++ b/iOS/Views/NNWTableViewCell.swift
@@ -1,0 +1,32 @@
+//
+//  NNWTableViewCell.swift
+//  NetNewsWire-iOS
+//
+//  Created by Jim Correia on 9/2/19.
+//  Copyright © 2019 Ranchero Software. All rights reserved.
+//
+
+import UIKit
+
+class NNWTableViewCell: UITableViewCell {
+	override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+		super.init(style: style, reuseIdentifier: reuseIdentifier)
+		commonInit()
+	}
+	
+	required init?(coder: NSCoder) {
+		super.init(coder: coder)
+		commonInit()
+	}
+	
+	private func commonInit() {
+		applyThemeProperties()
+	}
+	
+	/// Subclass overrides should call super
+	func applyThemeProperties() {
+		let selectedBackgroundView = UIView(frame: .zero)
+		selectedBackgroundView.backgroundColor = AppAssets.tableViewCellSelectionColor
+		self.selectedBackgroundView = selectedBackgroundView
+	}
+}


### PR DESCRIPTION
Added NNWTableViewCell; a base class for cells with the NNW selection color.

Defined a semantic color for the selection color which is identical to
netNewsWireBlue.

MasterFeedTableViewCell and MasterTimelineTableViewCell now subclass
NNWTableViewCell and no longer directly customize their selected background
view.

Simplified/corrected highlighted/selected appearance of feed and timeline cells.

- Set the highlighted text color on labels in table cells. This will be used
  for both the highlight and selected states automatically. (And since it is
  used for both states, we avoid anachronistic state where we have black
  text on a dark blue background in light mode as we transition from none ->
  highlighted -> selected.)

- Keep the selected/highlighted overrides to adjust colors for non-UIControl
  subelements.
