### PR TITLE
Fix for bug #959 — Detail stylesheet doesn't account for figures

### DIFF
--- a/Mac/MainWindow/Detail/styleSheet.css
+++ b/Mac/MainWindow/Detail/styleSheet.css
@@ -122,9 +122,15 @@ code, pre {
 pre  {
 	white-space: pre-wrap;
 }
-img, video {
+img, figure, video {
 	max-width: 100%;
 	height: auto;
+	margin: 0 auto;
+}
+
+figcaption {
+	font-size: 14px;
+	padding: 0;
 }
 
 /*Block ads and junk*/

--- a/Mac/MainWindow/Detail/styleSheet.css
+++ b/Mac/MainWindow/Detail/styleSheet.css
@@ -130,7 +130,7 @@ img, figure, video {
 
 figcaption {
 	font-size: 14px;
-	padding: 0;
+	line-height: 1.3em;
 }
 
 /*Block ads and junk*/

--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -125,9 +125,15 @@ code, pre {
 pre  {
 	white-space: pre-wrap;
 }
-img, video {
+img, figure, video {
 	max-width: 100%;
 	height: auto;
+	margin: 0 auto;
+}
+
+figcaption {
+	font-size: 14px;
+	line-height: 1.3em;
 }
 
 /*Block ads and junk*/


### PR DESCRIPTION
This PR fixes the issue I laid out in #959. I've updated the stylesheets on both the Mac and iOS targets to properly account for `figure`s and their `figcaption`s.

Here's what it looks like on iOS:

![nnw-ios-figures-before-after](https://user-images.githubusercontent.com/1939143/64283282-0e40bb00-cf4f-11e9-8fbb-dbfaf70e55de.png)

And here it is on macOS:

![nnw-mac-figures-before-after](https://user-images.githubusercontent.com/1939143/64283817-151bfd80-cf50-11e9-859c-fcbb05d2f39a.png)

It essentially comes down to just including the `figure` tag on the existing `img, video` selector. I've added the `margin: 0 auto;` because certain images (I noticed on The Points Guy and The New York Times) weren't being centered correctly. The `figcaption` just sets the caption to be a slightly smaller size, so it doesn't look like the rest of the paragraphs below.

This is the new CSS on iOS and Mac:

```css
img, figure, video {
	max-width: 100%;
	height: auto;
	margin: 0 auto;
}
	
figcaption {
	font-size: 14px;
	line-height: 1.3em;
}
```