### PR TITLE
Enforces auto-height for images to fix improper resizing

### DIFF
--- a/Mac/MainWindow/Detail/styleSheet.css
+++ b/Mac/MainWindow/Detail/styleSheet.css
@@ -124,7 +124,7 @@ pre  {
 }
 img, figure, video, iframe {
 	max-width: 100%;
-	height: auto;
+	height: auto !important;
 	margin: 0 auto;
 }
 


### PR DESCRIPTION
This pull request is to fix issue #975.

The issue stems from any images in feeds that have explicit height & width set in the style tag. Sometimes this is fine, but when the browser is narrower than the explicit width, then the css for "max-width" takes over in the template stylesheet. It adjusts the width, but the height is still explicit.

By using "height: auto !important" we can enforce the proportional sizing and keep things looking pretty ship shape.