### PR TITLE
Add command arrow key shortcuts to sidebar shortcuts plist

### DIFF
--- a/Mac/MainWindow/Sidebar/Keyboard/SidebarKeyboardShortcuts.plist
+++ b/Mac/MainWindow/Sidebar/Keyboard/SidebarKeyboardShortcuts.plist
@@ -70,5 +70,25 @@
 		<key>action</key>
 		<string>delete:</string>
 	</dict>
+	<dict>
+		<key>title</key>
+		<string>Expand Selected Row</string>
+		<key>key</key>
+		<string>[rightarrow]</string>
+		<key>action</key>
+		<string>expandSelectedRows:</string>
+		<key>commandModifier</key>
+		<true/>
+	</dict>
+	<dict>
+		<key>title</key>
+		<string>Collapse Selected Row</string>
+		<key>key</key>
+		<string>[leftarrow]</string>
+		<key>action</key>
+		<string>collapseSelectedRows:</string>
+		<key>commandModifier</key>
+		<true/>
+	</dict>
 </array>
 </plist>


### PR DESCRIPTION
This adds the <kbd>⌘</kbd> + <kbd>→</kbd> and <kbd>⌘</kbd> + <kbd>←</kbd> keyboard shortcuts to expand/collapse folders in the sidebar.

Merging this will complete #967.