### PR TITLE
Enable inspector

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -36,6 +36,8 @@ struct AppDefaults {
 		static let timelineShowsSeparators = "CorreiaSeparators"
 		static let showTitleOnMainWindow = "KafasisTitleMode"
 		static let hideDockUnreadCount = "JustinMillerHideDockUnreadCount"
+
+		static let webInspectorEnabled = "WebInspectorEnabled"
 	}
 
 	private static let smallestFontSizeRawValue = FontSize.small.rawValue
@@ -136,6 +138,15 @@ struct AppDefaults {
 
 	static var hideDockUnreadCount: Bool {
 		return bool(for: Key.hideDockUnreadCount)
+	}
+
+	static var webInspectorEnabled: Bool {
+		get {
+			return bool(for: Key.webInspectorEnabled)
+		}
+		set {
+			setBool(for: Key.webInspectorEnabled, newValue)
+		}
 	}
 
 	static var timelineSortDirection: ComparisonResult {

--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -38,6 +38,7 @@ struct AppDefaults {
 		static let hideDockUnreadCount = "JustinMillerHideDockUnreadCount"
 
 		static let webInspectorEnabled = "WebInspectorEnabled"
+		static let webInspectorStartsAttached = "__WebInspectorPageGroupLevel1__.WebKit2InspectorStartsAttached"
 	}
 
 	private static let smallestFontSizeRawValue = FontSize.small.rawValue
@@ -146,6 +147,15 @@ struct AppDefaults {
 		}
 		set {
 			setBool(for: Key.webInspectorEnabled, newValue)
+		}
+	}
+
+	static var webInspectorStartsAttached: Bool {
+		get {
+			return bool(for: Key.webInspectorStartsAttached)
+		}
+		set {
+			setBool(for: Key.webInspectorStartsAttached, newValue)
 		}
 	}
 

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -309,6 +309,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 		if item.action == #selector(showAddFeedWindow(_:)) || item.action == #selector(showAddFolderWindow(_:)) {
 			return !isDisplayingSheet && !AccountManager.shared.activeAccounts.isEmpty
 		}
+		if item.action == #selector(toggleWebInspectorEnabled(_:)) {
+			(item as! NSMenuItem).state = AppDefaults.webInspectorEnabled ? .on : .off
+		}
 		return true
 	}
 
@@ -524,6 +527,15 @@ extension AppDelegate {
 
 	@IBAction func debugSearch(_ sender: Any?) {
 		AccountManager.shared.defaultAccount.debugRunSearch()
+	}
+
+	@IBAction func toggleWebInspectorEnabled(_ sender: Any?) {
+		let newValue = !AppDefaults.webInspectorEnabled
+		AppDefaults.webInspectorEnabled = newValue
+		// An attached inspector can display incorrectly on certain setups (like mine); default to displaying in a separate window,
+		// And reset to a separate window when the preference is toggled off and on again in case the inspector is accidentally reattached.
+		UserDefaults.standard.set(false, forKey: "__WebInspectorPageGroupLevel1__.WebKit2InspectorStartsAttached")
+		NotificationCenter.default.post(name: .WebInspectorEnabledDidChange, object: newValue)
 	}
 }
 

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -533,7 +533,7 @@ extension AppDelegate {
 		let newValue = !AppDefaults.webInspectorEnabled
 		AppDefaults.webInspectorEnabled = newValue
 		// An attached inspector can display incorrectly on certain setups (like mine); default to displaying in a separate window,
-		// And reset to a separate window when the preference is toggled off and on again in case the inspector is accidentally reattached.
+		// and reset to a separate window when the preference is toggled off and on again in case the inspector is accidentally reattached.
 		UserDefaults.standard.set(false, forKey: "__WebInspectorPageGroupLevel1__.WebKit2InspectorStartsAttached")
 		NotificationCenter.default.post(name: .WebInspectorEnabledDidChange, object: newValue)
 	}

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -534,7 +534,7 @@ extension AppDelegate {
 		AppDefaults.webInspectorEnabled = newValue
 		// An attached inspector can display incorrectly on certain setups (like mine); default to displaying in a separate window,
 		// and reset to a separate window when the preference is toggled off and on again in case the inspector is accidentally reattached.
-		UserDefaults.standard.set(false, forKey: "__WebInspectorPageGroupLevel1__.WebKit2InspectorStartsAttached")
+		AppDefaults.webInspectorStartsAttached = false
 		NotificationCenter.default.post(name: .WebInspectorEnabledDidChange, object: newValue)
 	}
 }

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -532,8 +532,11 @@ extension AppDelegate {
 	@IBAction func toggleWebInspectorEnabled(_ sender: Any?) {
 		let newValue = !AppDefaults.webInspectorEnabled
 		AppDefaults.webInspectorEnabled = newValue
+
 		// An attached inspector can display incorrectly on certain setups (like mine); default to displaying in a separate window,
-		// and reset to a separate window when the preference is toggled off and on again in case the inspector is accidentally reattached.
+		// and reset the default to a separate window when the preference is toggled off and on again in case the inspector is
+		// accidentally reattached.
+		
 		AppDefaults.webInspectorStartsAttached = false
 		NotificationCenter.default.post(name: .WebInspectorEnabledDidChange, object: newValue)
 	}

--- a/Mac/Base.lproj/Main.storyboard
+++ b/Mac/Base.lproj/Main.storyboard
@@ -469,6 +469,13 @@
                                                 <action selector="debugSearch:" target="Ady-hI-5gd" id="HvM-F7-u7s"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="OOI-Hk-eqi"/>
+                                        <menuItem title="Enable Web Inspector" id="EwI-z4-ZA3">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleWebInspectorEnabled:" target="Voe-Tx-rLC" id="nsd-PV-Tz2"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                 </menu>
                             </menuItem>

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -30,17 +30,10 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 
 	private var webInspectorEnabled: Bool {
 		get {
-			if let webView = webView {
-				let val: NSNumber? = webView.configuration.preferences.value(forKey: "developerExtrasEnabled") as? NSNumber
-				return val != nil ? val!.boolValue : false
-			}
-
-			return false
+			return webView.configuration.preferences._developerExtrasEnabled
 		}
 		set {
-			if let webView = webView {
-				webView.configuration.preferences.setValue(newValue, forKey: "developerExtrasEnabled")
-			}
+			webView.configuration.preferences._developerExtrasEnabled = newValue
 		}
 	}
 	

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -27,6 +27,22 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 			}
 		}
 	}
+
+	private var webInspectorEnabled: Bool {
+		get {
+			if let webView = webView {
+				let val: NSNumber? = webView.configuration.preferences.value(forKey: "developerExtrasEnabled") as? NSNumber
+				return val != nil ? val!.boolValue : false
+			}
+
+			return false
+		}
+		set {
+			if let webView = webView {
+				webView.configuration.preferences.setValue(newValue, forKey: "developerExtrasEnabled")
+			}
+		}
+	}
 	
 	private var waitingForFirstReload = false
 	private let keyboardDelegate = DetailKeyboardDelegate()
@@ -86,6 +102,12 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 		// See bug #901.
 		webView.isHidden = true
 		waitingForFirstReload = true
+
+		webInspectorEnabled = AppDefaults.webInspectorEnabled
+
+		NotificationCenter.default.addObserver(forName: .WebInspectorEnabledDidChange, object: nil, queue: OperationQueue.main) { (notification) in
+			self.webInspectorEnabled = notification.object! as! Bool
+		}
 
 		reloadHTML()
 	}

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -105,9 +105,7 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 
 		webInspectorEnabled = AppDefaults.webInspectorEnabled
 
-		NotificationCenter.default.addObserver(forName: .WebInspectorEnabledDidChange, object: nil, queue: OperationQueue.main) { (notification) in
-			self.webInspectorEnabled = notification.object! as! Bool
-		}
+		NotificationCenter.default.addObserver(self, selector: #selector(webInspectorEnabledDidChange(_:)), name: .WebInspectorEnabledDidChange, object: nil)
 
 		reloadHTML()
 	}
@@ -206,6 +204,10 @@ private extension DetailWebViewController {
 			let scrollInfo = ScrollInfo(contentHeight: contentHeight, viewHeight: self.webView.frame.height, offsetY: offsetY)
 			callback(scrollInfo)
 		}
+	}
+
+	@objc func webInspectorEnabledDidChange(_ notification: Notification) {
+		self.webInspectorEnabled = notification.object! as! Bool
 	}
 }
 

--- a/Mac/NetNewsWire-Bridging-Header.h
+++ b/Mac/NetNewsWire-Bridging-Header.h
@@ -1,0 +1,9 @@
+//
+//  NetNewsWire-Bridging-Header.h
+//  NetNewsWire
+//
+//  Created by Nate Weaver on 2019-09-17.
+//  Copyright © 2019 Ranchero Software. All rights reserved.
+//
+
+#import "WKPreferencesPrivate.h"

--- a/Mac/WKPreferencesPrivate.h
+++ b/Mac/WKPreferencesPrivate.h
@@ -1,0 +1,15 @@
+//
+//  WKPreferencesPrivate.h
+//  NetNewsWire
+//
+//  Created by Nate Weaver on 2019-09-17.
+//  Copyright © 2019 Ranchero Software. All rights reserved.
+//
+
+#import <WebKit/WebKit.h>
+
+@interface WKPreferences (Private)
+
+@property (nonatomic, setter=_setDeveloperExtrasEnabled:) BOOL _developerExtrasEnabled API_AVAILABLE(macos(10.11), ios(9.0));
+
+@end

--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -917,6 +917,8 @@
 		84F9EAE4213660A100CF2DE4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		84FB9A2D1EDCD6B8003D53B9 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Frameworks/Vendor/Sparkle.framework; sourceTree = SOURCE_ROOT; };
 		84FF69B01FC3793300DC198E /* FaviconURLFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconURLFinder.swift; sourceTree = "<group>"; };
+		B24EFD482330FF99006C6242 /* NetNewsWire-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NetNewsWire-Bridging-Header.h"; sourceTree = "<group>"; };
+		B24EFD5923310109006C6242 /* WKPreferencesPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKPreferencesPrivate.h; sourceTree = "<group>"; };
 		D553737C20186C1F006D8857 /* Article+Scriptability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Article+Scriptability.swift"; sourceTree = "<group>"; };
 		D57BE6DF204CD35F00D11AAC /* NSScriptCommand+NetNewsWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScriptCommand+NetNewsWire.swift"; sourceTree = "<group>"; };
 		D5907CDC2002F0BE005947E5 /* NetNewsWire_project_release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_project_release.xcconfig; sourceTree = "<group>"; };
@@ -1585,6 +1587,8 @@
 				6581C73620CED60100F4AD34 /* SafariExtension */,
 				84C9FC8322629E8F00D921D6 /* Resources */,
 				84FB9A2C1EDCD6A4003D53B9 /* Frameworks */,
+				B24EFD482330FF99006C6242 /* NetNewsWire-Bridging-Header.h */,
+				B24EFD5923310109006C6242 /* WKPreferencesPrivate.h */,
 			);
 			path = Mac;
 			sourceTree = "<group>";
@@ -3087,6 +3091,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.14.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ranchero.NetNewsWire-Evergreen";
 				PRODUCT_NAME = NetNewsWire;
+				SWIFT_OBJC_BRIDGING_HEADER = "Mac/NetNewsWire-Bridging-Header.h";
 			};
 			name = Debug;
 		};
@@ -3102,6 +3107,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.14.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ranchero.NetNewsWire-Evergreen";
 				PRODUCT_NAME = NetNewsWire;
+				SWIFT_OBJC_BRIDGING_HEADER = "Mac/NetNewsWire-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/Shared/AppNotifications.swift
+++ b/Shared/AppNotifications.swift
@@ -13,6 +13,7 @@ extension Notification.Name {
 	static let InspectableObjectsDidChange = Notification.Name("TimelineSelectionDidChangeNotification")
 	static let UserDidAddFeed = Notification.Name("UserDidAddFeedNotification")
 	static let UserDidRequestSidebarSelection = Notification.Name("UserDidRequestSidebarSelectionNotification")
+	static let WebInspectorEnabledDidChange = Notification.Name("WebInspectorEnabledDidChange")
 }
 
 typealias UserInfoDictionary = [AnyHashable: Any]


### PR DESCRIPTION
Fixes #1025.

Questions:

I'm setting the menu item state in `validateUserInterfaceItem()`. The current code sets the state for the sort order menu items manually. Should I change the implementation to follow that style?

A custom notification is currently sent when the setting is changed. Should it monitor `UserDefaults.didChangeNotification` instead?