### PR TITLE
Disable Web Inspector for App Store builds

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -37,8 +37,10 @@ struct AppDefaults {
 		static let showTitleOnMainWindow = "KafasisTitleMode"
 		static let hideDockUnreadCount = "JustinMillerHideDockUnreadCount"
 
-		static let webInspectorEnabled = "WebInspectorEnabled"
-		static let webInspectorStartsAttached = "__WebInspectorPageGroupLevel1__.WebKit2InspectorStartsAttached"
+		#if !MAC_APP_STORE
+			static let webInspectorEnabled = "WebInspectorEnabled"
+			static let webInspectorStartsAttached = "__WebInspectorPageGroupLevel1__.WebKit2InspectorStartsAttached"
+		#endif
 	}
 
 	private static let smallestFontSizeRawValue = FontSize.small.rawValue
@@ -141,23 +143,25 @@ struct AppDefaults {
 		return bool(for: Key.hideDockUnreadCount)
 	}
 
-	static var webInspectorEnabled: Bool {
-		get {
-			return bool(for: Key.webInspectorEnabled)
+	#if !MAC_APP_STORE
+		static var webInspectorEnabled: Bool {
+			get {
+				return bool(for: Key.webInspectorEnabled)
+			}
+			set {
+				setBool(for: Key.webInspectorEnabled, newValue)
+			}
 		}
-		set {
-			setBool(for: Key.webInspectorEnabled, newValue)
-		}
-	}
 
-	static var webInspectorStartsAttached: Bool {
-		get {
-			return bool(for: Key.webInspectorStartsAttached)
+		static var webInspectorStartsAttached: Bool {
+			get {
+				return bool(for: Key.webInspectorStartsAttached)
+			}
+			set {
+				setBool(for: Key.webInspectorStartsAttached, newValue)
+			}
 		}
-		set {
-			setBool(for: Key.webInspectorStartsAttached, newValue)
-		}
-	}
+	#endif
 
 	static var timelineSortDirection: ComparisonResult {
 		get {

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -42,7 +42,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 	@IBOutlet var sortByOldestArticleOnTopMenuItem: NSMenuItem!
 	@IBOutlet var sortByNewestArticleOnTopMenuItem: NSMenuItem!
 	@IBOutlet var checkForUpdatesMenuItem: NSMenuItem!
-	
+	@IBOutlet var enableWebInspectorMenuItem: NSMenuItem!
+
 	var unreadCount = 0 {
 		didSet {
 			if unreadCount != oldValue {
@@ -116,6 +117,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 
 		#if MAC_APP_STORE
 			checkForUpdatesMenuItem.isHidden = true
+			enableWebInspectorMenuItem.isHidden = true
 		#endif
 		
 		appName = (Bundle.main.infoDictionary!["CFBundleExecutable"]! as! String)
@@ -309,9 +311,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 		if item.action == #selector(showAddFeedWindow(_:)) || item.action == #selector(showAddFolderWindow(_:)) {
 			return !isDisplayingSheet && !AccountManager.shared.activeAccounts.isEmpty
 		}
+		#if MAC_APP_STORE
 		if item.action == #selector(toggleWebInspectorEnabled(_:)) {
 			(item as! NSMenuItem).state = AppDefaults.webInspectorEnabled ? .on : .off
 		}
+		#endif
 		return true
 	}
 
@@ -530,15 +534,17 @@ extension AppDelegate {
 	}
 
 	@IBAction func toggleWebInspectorEnabled(_ sender: Any?) {
-		let newValue = !AppDefaults.webInspectorEnabled
-		AppDefaults.webInspectorEnabled = newValue
+		#if MAC_APP_STORE
+			let newValue = !AppDefaults.webInspectorEnabled
+			AppDefaults.webInspectorEnabled = newValue
 
-		// An attached inspector can display incorrectly on certain setups (like mine); default to displaying in a separate window,
-		// and reset the default to a separate window when the preference is toggled off and on again in case the inspector is
-		// accidentally reattached.
-		
-		AppDefaults.webInspectorStartsAttached = false
-		NotificationCenter.default.post(name: .WebInspectorEnabledDidChange, object: newValue)
+			// An attached inspector can display incorrectly on certain setups (like mine); default to displaying in a separate window,
+			// and reset the default to a separate window when the preference is toggled off and on again in case the inspector is
+			// accidentally reattached.
+
+			AppDefaults.webInspectorStartsAttached = false
+			NotificationCenter.default.post(name: .WebInspectorEnabledDidChange, object: newValue)
+		#endif
 	}
 }
 

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -42,7 +42,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 	@IBOutlet var sortByOldestArticleOnTopMenuItem: NSMenuItem!
 	@IBOutlet var sortByNewestArticleOnTopMenuItem: NSMenuItem!
 	@IBOutlet var checkForUpdatesMenuItem: NSMenuItem!
-	@IBOutlet var enableWebInspectorMenuItem: NSMenuItem!
 
 	var unreadCount = 0 {
 		didSet {
@@ -117,7 +116,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 
 		#if MAC_APP_STORE
 			checkForUpdatesMenuItem.isHidden = true
-			enableWebInspectorMenuItem.isHidden = true
 		#endif
 		
 		appName = (Bundle.main.infoDictionary!["CFBundleExecutable"]! as! String)

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -311,7 +311,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 		if item.action == #selector(showAddFeedWindow(_:)) || item.action == #selector(showAddFolderWindow(_:)) {
 			return !isDisplayingSheet && !AccountManager.shared.activeAccounts.isEmpty
 		}
-		#if MAC_APP_STORE
+		#if !MAC_APP_STORE
 		if item.action == #selector(toggleWebInspectorEnabled(_:)) {
 			(item as! NSMenuItem).state = AppDefaults.webInspectorEnabled ? .on : .off
 		}
@@ -534,7 +534,7 @@ extension AppDelegate {
 	}
 
 	@IBAction func toggleWebInspectorEnabled(_ sender: Any?) {
-		#if MAC_APP_STORE
+		#if !MAC_APP_STORE
 			let newValue = !AppDefaults.webInspectorEnabled
 			AppDefaults.webInspectorEnabled = newValue
 

--- a/Mac/Base.lproj/Main.storyboard
+++ b/Mac/Base.lproj/Main.storyboard
@@ -473,7 +473,7 @@
                                         <menuItem title="Enable Web Inspector" id="EwI-z4-ZA3">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="toggleWebInspectorEnabled:" target="Voe-Tx-rLC" id="nsd-PV-Tz2"/>
+                                                <action selector="toggleWebInspectorEnabled:" target="Voe-Tx-rLC" id="SNL-zh-XIE"/>
                                             </connections>
                                         </menuItem>
                                     </items>
@@ -588,6 +588,7 @@
                     <connections>
                         <outlet property="checkForUpdatesMenuItem" destination="1nF-7O-aKU" id="JmT-jc-DJ8"/>
                         <outlet property="debugMenuItem" destination="UqE-mp-gtV" id="OnR-lr-Zlt"/>
+                        <outlet property="enableWebInspectorMenuItem" destination="EwI-z4-ZA3" id="EGp-lP-f91"/>
                         <outlet property="sortByNewestArticleOnTopMenuItem" destination="TNS-TV-n0U" id="gix-Nd-9k4"/>
                         <outlet property="sortByOldestArticleOnTopMenuItem" destination="iii-kP-qoF" id="fTe-Tf-EWG"/>
                     </connections>

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -28,14 +28,16 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 		}
 	}
 
-	private var webInspectorEnabled: Bool {
-		get {
-			return webView.configuration.preferences._developerExtrasEnabled
+	#if !MAC_APP_STORE
+		private var webInspectorEnabled: Bool {
+			get {
+				return webView.configuration.preferences._developerExtrasEnabled
+			}
+			set {
+				webView.configuration.preferences._developerExtrasEnabled = newValue
+			}
 		}
-		set {
-			webView.configuration.preferences._developerExtrasEnabled = newValue
-		}
-	}
+	#endif
 	
 	private var waitingForFirstReload = false
 	private let keyboardDelegate = DetailKeyboardDelegate()
@@ -96,9 +98,11 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 		webView.isHidden = true
 		waitingForFirstReload = true
 
-		webInspectorEnabled = AppDefaults.webInspectorEnabled
+		#if !MAC_APP_STORE
+			webInspectorEnabled = AppDefaults.webInspectorEnabled
 
-		NotificationCenter.default.addObserver(self, selector: #selector(webInspectorEnabledDidChange(_:)), name: .WebInspectorEnabledDidChange, object: nil)
+			NotificationCenter.default.addObserver(self, selector: #selector(webInspectorEnabledDidChange(_:)), name: .WebInspectorEnabledDidChange, object: nil)
+		#endif
 
 		reloadHTML()
 	}
@@ -199,9 +203,11 @@ private extension DetailWebViewController {
 		}
 	}
 
-	@objc func webInspectorEnabledDidChange(_ notification: Notification) {
-		self.webInspectorEnabled = notification.object! as! Bool
-	}
+	#if !MAC_APP_STORE
+		@objc func webInspectorEnabledDidChange(_ notification: Notification) {
+			self.webInspectorEnabled = notification.object! as! Bool
+		}
+	#endif
 }
 
 // MARK: - ScrollInfo

--- a/Shared/AppNotifications.swift
+++ b/Shared/AppNotifications.swift
@@ -13,7 +13,10 @@ extension Notification.Name {
 	static let InspectableObjectsDidChange = Notification.Name("TimelineSelectionDidChangeNotification")
 	static let UserDidAddFeed = Notification.Name("UserDidAddFeedNotification")
 	static let UserDidRequestSidebarSelection = Notification.Name("UserDidRequestSidebarSelectionNotification")
-	static let WebInspectorEnabledDidChange = Notification.Name("WebInspectorEnabledDidChange")
+
+	#if !MAC_APP_STORE
+		static let WebInspectorEnabledDidChange = Notification.Name("WebInspectorEnabledDidChange")
+	#endif
 }
 
 typealias UserInfoDictionary = [AnyHashable: Any]


### PR DESCRIPTION
- Hide the "Enable Web Inspector" menu item.
- #if-out notifications/defaults/etc.
- Make toggleWebInspectorEnabled(_) a no-op.