### PR TITLE
Fixed incorrect articles being restored as part of state restoration

### DIFF
--- a/Shared/Activity/ActivityManager.swift
+++ b/Shared/Activity/ActivityManager.swift
@@ -119,8 +119,8 @@ class ActivityManager {
 	}
 	
 	func invalidateReading() {
-		nextUnreadActivity?.invalidate()
-		nextUnreadActivity = nil
+		readingActivity?.invalidate()
+		readingActivity = nil
 	}
 	
 	static func cleanUp(_ account: Account) {


### PR DESCRIPTION
I've been seeing an issue where state restoration would always restore me back to the article detail screen even though that wasn't the last thing I looked at it in the app. It looks like `invalidateReading()` was invalidating the wrong user activity (We already have a separate function for `invalidateNextUnread()`).