### PR TITLE
Improve Feedly content consistency

### DIFF
--- a/Frameworks/Account/AccountTests/Feedly/AccountFeedlySyncTest.swift
+++ b/Frameworks/Account/AccountTests/Feedly/AccountFeedlySyncTest.swift
@@ -281,8 +281,9 @@ class AccountFeedlySyncTest: XCTestCase {
 	}
 	
 	func set(testFiles: TestFiles, with transport: TestTransport) {
+		// TestTransport blacklists certain query items to make mocking responses easier.
 		let endpoint = "https://sandbox7.feedly.com/v3"
-		let category = "\(endpoint)/streams/contents?unreadOnly=false&count=500&streamId=user/f2f031bd-f3e3-4893-a447-467a291c6d1e/category"
+		let category = "\(endpoint)/streams/contents?streamId=user/f2f031bd-f3e3-4893-a447-467a291c6d1e/category"
 		
 		switch testFiles {
 		case .initial:

--- a/Frameworks/Account/Feedly/FeedlyAccountDelegate.swift
+++ b/Frameworks/Account/Feedly/FeedlyAccountDelegate.swift
@@ -86,10 +86,8 @@ final class FeedlyAccountDelegate: AccountDelegate {
 		progress.addToNumberOfTasksAndRemaining(1)
 		syncStrategy?.startSync { result in
 			os_log(.debug, log: log, "Sync took %.3f seconds", -date.timeIntervalSinceNow)
-			DispatchQueue.main.async {
-				progress.completeTask()
-				completion(result)
-			}
+			progress.completeTask()
+			completion(result)
 		}
 	}
 	

--- a/Frameworks/Account/Feedly/Refresh/FeedlyGetCollectionStreamOperation.swift
+++ b/Frameworks/Account/Feedly/Refresh/FeedlyGetCollectionStreamOperation.swift
@@ -30,13 +30,15 @@ final class FeedlyGetCollectionStreamOperation: FeedlyOperation, FeedlyCollectio
 	
 	let account: Account
 	let caller: FeedlyAPICaller
-	let unreadOnly: Bool
+	let unreadOnly: Bool?
+	let newerThan: Date?
 	
-	init(account: Account, collection: FeedlyCollection, caller: FeedlyAPICaller, unreadOnly: Bool = false) {
+	init(account: Account, collection: FeedlyCollection, caller: FeedlyAPICaller, newerThan: Date?, unreadOnly: Bool? = nil) {
 		self.account = account
 		self.collection = collection
 		self.caller = caller
 		self.unreadOnly = unreadOnly
+		self.newerThan = newerThan
 	}
 	
 	override func main() {
@@ -45,8 +47,7 @@ final class FeedlyGetCollectionStreamOperation: FeedlyOperation, FeedlyCollectio
 			return
 		}
 		
-		//TODO: Use account metadata to get articles newer than some date.
-		caller.getStream(for: collection, unreadOnly: unreadOnly) { result in
+		caller.getStream(for: collection, newerThan: newerThan, unreadOnly: unreadOnly) { result in
 			switch result {
 			case .success(let stream):
 				self.storedStream = stream

--- a/Frameworks/Account/Feedly/Refresh/FeedlyRequestStreamsOperation.swift
+++ b/Frameworks/Account/Feedly/Refresh/FeedlyRequestStreamsOperation.swift
@@ -23,11 +23,15 @@ final class FeedlyRequestStreamsOperation: FeedlyOperation {
 	let caller: FeedlyAPICaller
 	let account: Account
 	let log: OSLog
+	let newerThan: Date?
+	let unreadOnly: Bool?
 		
-	init(account: Account, collectionsProvider: FeedlyCollectionProviding, caller: FeedlyAPICaller, log: OSLog) {
+	init(account: Account, collectionsProvider: FeedlyCollectionProviding, newerThan: Date?, unreadOnly: Bool?, caller: FeedlyAPICaller, log: OSLog) {
 		self.account = account
 		self.caller = caller
 		self.collectionsProvider = collectionsProvider
+		self.newerThan = newerThan
+		self.unreadOnly = unreadOnly
 		self.log = log
 	}
 	
@@ -41,7 +45,11 @@ final class FeedlyRequestStreamsOperation: FeedlyOperation {
 		// TODO: Prioritise the must read collection/category before others so the most important content for the user loads first.
 		
 		for collection in collectionsProvider.collections {
-			let operation = FeedlyGetCollectionStreamOperation(account: account, collection: collection, caller: caller)
+			let operation = FeedlyGetCollectionStreamOperation(account: account,
+															   collection: collection,
+															   caller: caller,
+															   newerThan: newerThan,
+															   unreadOnly: unreadOnly)
 			queueDelegate?.feedlyRequestStreamsOperation(self, enqueue: operation)
 		}
 		

--- a/Frameworks/Account/Feedly/Refresh/FeedlySyncStrategy.swift
+++ b/Frameworks/Account/Feedly/Refresh/FeedlySyncStrategy.swift
@@ -32,6 +32,14 @@ final class FeedlySyncStrategy {
 	
 	private var startSyncCompletionHandler: ((Result<Void, Error>) -> ())?
 	
+	private var newerThan: Date? {
+		if let date = account.metadata.lastArticleFetch {
+			return date
+		} else {
+			return Calendar.current.date(byAdding: .day, value: -31, to: Date())
+		}
+	}
+	
 	/// The truth is in the cloud.
 	func startSync(completionHandler: @escaping (Result<Void, Error>) -> ()) {
 		guard operationQueue.operationCount == 0 else {
@@ -63,6 +71,8 @@ final class FeedlySyncStrategy {
 		// Get the streams for each Collection. It will call back to enqueue more operations.
 		let getCollectionStreams = FeedlyRequestStreamsOperation(account: account,
 																 collectionsProvider: getCollections,
+																 newerThan: newerThan,
+																 unreadOnly: false,
 																 caller: caller,
 																 log: log)
 		getCollectionStreams.delegate = self
@@ -71,12 +81,16 @@ final class FeedlySyncStrategy {
 		
 		// Last operation to perform, which should be dependent on any other operation added to the queue.
 		let syncId = UUID().uuidString
+		let lastArticleFetchDate = Date()
 		let completionOperation = BlockOperation { [weak self] in
-			if let self = self {
-				os_log(.debug, log: self.log, "Sync completed: %@", syncId)
-				self.startSyncCompletionHandler = nil
+			DispatchQueue.main.async {
+				if let self = self {
+					self.account.metadata.lastArticleFetch = lastArticleFetchDate
+					os_log(.debug, log: self.log, "Sync completed: %@", syncId)
+					self.startSyncCompletionHandler = nil
+				}
+				completionHandler(.success(()))
 			}
-			completionHandler(.success(()))
 		}
 		
 		completionOperation.addDependency(getCollections)


### PR DESCRIPTION
Issue #1077 .

Initial sync seems to duplicate web content. The initial sync takes about 10 seconds but subsequent syncs in less than two when honouring the account's last sync date.

Adds query item blacklisting to the test transport class to make mocking responses easier.