### PR TITLE
iOS: Added a setting to suppress the mark all as read alert

### DIFF
--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		FF3ABF13232599810074C542 /* ArticleSorterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3ABF09232599450074C542 /* ArticleSorterTests.swift */; };
 		FF3ABF1523259DDB0074C542 /* ArticleSorter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3ABF1423259DDB0074C542 /* ArticleSorter.swift */; };
 		FF3ABF162325AF5D0074C542 /* ArticleSorter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3ABF1423259DDB0074C542 /* ArticleSorter.swift */; };
+		FFD43E412340F488009E5CA3 /* MarkArticlesReadAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD43E372340F320009E5CA3 /* MarkArticlesReadAlertController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1104,6 +1105,7 @@
 		DF999FF622B5AEFA0064B687 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		FF3ABF09232599450074C542 /* ArticleSorterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleSorterTests.swift; sourceTree = "<group>"; };
 		FF3ABF1423259DDB0074C542 /* ArticleSorter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleSorter.swift; sourceTree = "<group>"; };
+		FFD43E372340F320009E5CA3 /* MarkArticlesReadAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkArticlesReadAlertController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1348,6 +1350,7 @@
 		51C4525D226508F600C03939 /* MasterFeed */ = {
 			isa = PBXGroup;
 			children = (
+				FFD43E372340F320009E5CA3 /* MarkArticlesReadAlertController.swift */,
 				51C45264226508F600C03939 /* MasterFeedViewController.swift */,
 				51CC9B3D231720B2000E842F /* MasterFeedDataSource.swift */,
 				51C45260226508F600C03939 /* Cell */,
@@ -2892,6 +2895,7 @@
 				51C4529F22650A1900C03939 /* AuthorAvatarDownloader.swift in Sources */,
 				519E743D22C663F900A78E47 /* SceneDelegate.swift in Sources */,
 				51CC9B3E231720B2000E842F /* MasterFeedDataSource.swift in Sources */,
+				FFD43E412340F488009E5CA3 /* MarkArticlesReadAlertController.swift in Sources */,
 				51C452A322650A1E00C03939 /* HTMLMetadataDownloader.swift in Sources */,
 				51C4528D2265095F00C03939 /* AddFolderViewController.swift in Sources */,
 				51C452782265091600C03939 /* MasterTimelineCellData.swift in Sources */,

--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -18,6 +18,7 @@ struct AppDefaults {
 		static let timelineGroupByFeed = "timelineGroupByFeed"
 		static let timelineNumberOfLines = "timelineNumberOfLines"
 		static let timelineSortDirection = "timelineSortDirection"
+		static let askBeforeMarkAllAsRead = "askBeforeMarkAllAsRead"
 		static let refreshInterval = "refreshInterval"
 		static let lastRefresh = "lastRefresh"
 	}
@@ -66,6 +67,15 @@ struct AppDefaults {
 			setSortDirection(for: Key.timelineSortDirection, newValue)
 		}
 	}
+	
+	static var askBeforeMarkAllAsRead: Bool {
+		get {
+			return bool(for: Key.askBeforeMarkAllAsRead)
+		}
+		set {
+			setBool(for: Key.askBeforeMarkAllAsRead, newValue)
+		}
+	}
 
 	static var lastRefresh: Date? {
 		get {
@@ -90,6 +100,7 @@ struct AppDefaults {
 										Key.refreshInterval: RefreshInterval.everyHour.rawValue,
 										Key.timelineGroupByFeed: false,
 										Key.timelineNumberOfLines: 3,
+										Key.askBeforeMarkAllAsRead: true,
 										Key.timelineSortDirection: ComparisonResult.orderedDescending.rawValue]
 		AppDefaults.shared.register(defaults: defaults)
 	}

--- a/iOS/MasterFeed/MarkArticlesReadAlertController.swift
+++ b/iOS/MasterFeed/MarkArticlesReadAlertController.swift
@@ -1,0 +1,44 @@
+//
+//  MarkArticlesReadAlertControllerr.swift
+//  NetNewsWire
+//
+//  Created by Phil Viso on 9/29/19.
+//  Copyright © 2019 Ranchero Software. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+struct MarkArticlesReadAlertController {
+		
+	static func allArticlesAlert(handler: @escaping (UIAlertAction) -> Void) -> UIAlertController {
+		let message = NSLocalizedString("Mark all articles in all accounts as read?",
+										comment: "Mark all articles")
+		return markAllReadAlert(message: message, handler: handler)
+	}
+	
+	static func timelineArticlesAlert(handler:  @escaping (UIAlertAction) -> Void) -> UIAlertController {
+		let message = NSLocalizedString("Mark all articles in this timeline as read?",
+										comment: "Mark all articles")
+		return markAllReadAlert(message: message, handler: handler)
+	}
+	
+	// MARK: -
+	
+	private static func markAllReadAlert(message: String,
+										 handler: @escaping (UIAlertAction) -> Void) -> UIAlertController {
+		let title = NSLocalizedString("Mark All Read", comment: "Mark All Read")
+		let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel")
+		let markTitle = NSLocalizedString("Mark All Read", comment: "Mark All Read")
+		
+		let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+		let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel)
+		let markAction = UIAlertAction(title: markTitle, style: .default, handler: handler)
+		
+		alertController.addAction(cancelAction)
+		alertController.addAction(markAction)
+		
+		return alertController
+	}
+	
+}

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -344,24 +344,15 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 	}
 
 	@IBAction func markAllAsRead(_ sender: Any) {
-		
-		let title = NSLocalizedString("Mark All Read", comment: "Mark All Read")
-		let message = NSLocalizedString("Mark all articles in all accounts as read?", comment: "Mark all articles")
-		let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-		
-		let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel")
-		let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel)
-		alertController.addAction(cancelAction)
-		
-		let markTitle = NSLocalizedString("Mark All Read", comment: "Mark All Read")
-		let markAction = UIAlertAction(title: markTitle, style: .default) { [weak self] (action) in
-			self?.coordinator.markAllAsRead()
-		}
-		
-		alertController.addAction(markAction)
-		
-		present(alertController, animated: true)
-		
+		if coordinator.shouldWarnBeforeMarkAllAsRead {
+			let alertController = MarkArticlesReadAlertController.allArticlesAlert { [weak self] _ in
+				self?.coordinator.markAllAsRead()
+			}
+			
+			present(alertController, animated: true)
+		} else {
+			coordinator.markAllAsRead()
+		}		
 	}
 	
 	@IBAction func add(_ sender: UIBarButtonItem) {

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -344,7 +344,7 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 	}
 
 	@IBAction func markAllAsRead(_ sender: Any) {
-		if coordinator.shouldWarnBeforeMarkAllAsRead {
+		if coordinator.askBeforeMarkAllAsRead {
 			let alertController = MarkArticlesReadAlertController.allArticlesAlert { [weak self] _ in
 				self?.coordinator.markAllAsRead()
 			}

--- a/iOS/MasterTimeline/MasterTimelineViewController.swift
+++ b/iOS/MasterTimeline/MasterTimelineViewController.swift
@@ -89,7 +89,7 @@ class MasterTimelineViewController: UITableViewController, UndoableCommandRunner
 	// MARK: Actions
 
 	@IBAction func markAllAsRead(_ sender: Any) {
-		if coordinator.shouldWarnBeforeMarkAllAsRead {
+		if coordinator.askBeforeMarkAllAsRead {
 			let alertController = MarkArticlesReadAlertController.timelineArticlesAlert { [weak self] _ in
 				self?.coordinator.markAllAsReadInTimeline()
 			}

--- a/iOS/MasterTimeline/MasterTimelineViewController.swift
+++ b/iOS/MasterTimeline/MasterTimelineViewController.swift
@@ -89,24 +89,15 @@ class MasterTimelineViewController: UITableViewController, UndoableCommandRunner
 	// MARK: Actions
 
 	@IBAction func markAllAsRead(_ sender: Any) {
-		
-		let title = NSLocalizedString("Mark All Read", comment: "Mark All Read")
-		let message = NSLocalizedString("Mark all articles in this timeline as read?", comment: "Mark all articles")
-		let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-
-		let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel")
-		let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel)
-		alertController.addAction(cancelAction)
-		
-		let markTitle = NSLocalizedString("Mark All Read", comment: "Mark All Read")
-		let markAction = UIAlertAction(title: markTitle, style: .default) { [weak self] (action) in
-			self?.coordinator.markAllAsReadInTimeline()
+		if coordinator.shouldWarnBeforeMarkAllAsRead {
+			let alertController = MarkArticlesReadAlertController.timelineArticlesAlert { [weak self] _ in
+				self?.coordinator.markAllAsReadInTimeline()
+			}
+			
+			present(alertController, animated: true)
+		} else {
+			coordinator.markAllAsReadInTimeline()
 		}
-		
-		alertController.addAction(markAction)
-		
-		present(alertController, animated: true)
-		
 	}
 	
 	@IBAction func firstUnread(_ sender: Any) {

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -82,6 +82,8 @@ class SceneCoordinator: NSObject, UndoableCommandRunner, UnreadCountProvider {
 			}
 		}
 	}
+	
+	private(set) var shouldWarnBeforeMarkAllAsRead = false
 
 	private let treeControllerDelegate = FeedTreeControllerDelegate()
 	private lazy var treeController: TreeController = {

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -83,7 +83,7 @@ class SceneCoordinator: NSObject, UndoableCommandRunner, UnreadCountProvider {
 		}
 	}
 	
-	private(set) var shouldWarnBeforeMarkAllAsRead = false
+	private(set) var askBeforeMarkAllAsRead = AppDefaults.askBeforeMarkAllAsRead
 
 	private let treeControllerDelegate = FeedTreeControllerDelegate()
 	private lazy var treeController: TreeController = {
@@ -424,6 +424,7 @@ class SceneCoordinator: NSObject, UndoableCommandRunner, UnreadCountProvider {
 	@objc func userDefaultsDidChange(_ note: Notification) {
 		self.sortDirection = AppDefaults.timelineSortDirection
 		self.groupByFeed = AppDefaults.timelineGroupByFeed
+		self.askBeforeMarkAllAsRead = AppDefaults.askBeforeMarkAllAsRead
 	}
 	
 	@objc func accountDidDownloadArticles(_ note: Notification) {

--- a/iOS/Settings/SettingsView.swift
+++ b/iOS/Settings/SettingsView.swift
@@ -74,6 +74,9 @@ struct SettingsView : View {
 			Stepper(value: $viewModel.timelineNumberOfLines, in: 2...6) {
 				Text("Number of Text Lines: \(viewModel.timelineNumberOfLines)")
 			}
+			Toggle(isOn: $viewModel.askBeforeMarkAllAsRead) {
+				Text("Ask Before Mark All as Read")
+			}
 		}
 	}
 	
@@ -270,6 +273,16 @@ struct SettingsView : View {
 			set {
 				objectWillChange.send()
 				AppDefaults.timelineGroupByFeed = newValue
+			}
+		}
+		
+		var askBeforeMarkAllAsRead: Bool {
+			get {
+				return AppDefaults.askBeforeMarkAllAsRead
+			}
+			set {
+				objectWillChange.send()
+				AppDefaults.askBeforeMarkAllAsRead = newValue
 			}
 		}
 		


### PR DESCRIPTION
* Added a toggle to settings to suppress the alert that displays before marking all articles as read. The default value matches the current behavior, so the alert still displays every time you tap mark all as read.
* There were two different mark all as read alerts that were identical except for a small copy difference, so I unified them.