### PR TITLE
Fix leading for super and subscript in the article view

### DIFF
--- a/Mac/MainWindow/Detail/styleSheet.css
+++ b/Mac/MainWindow/Detail/styleSheet.css
@@ -140,6 +140,18 @@ figcaption {
 	line-height: 1.3em;
 }
 
+sup {
+	vertical-align: top;
+	position: relative;
+	bottom: 0.2rem;
+}
+
+sub {
+	vertical-align: bottom;
+	position: relative;
+	top: 0.2rem;
+}
+
 .iframeWrap {
 	position: relative;
 	display: block;


### PR DESCRIPTION
Fixes #1115.

### Problem

The default values of the `vertical-align` property for `<sub>` and `<sup>` affect the computed `line-height` for the element.

### Solution

This PR changes the `vertical-align` property for these elements to their nearest neighbors that don't affect `line-height`. Then, we adjust (in a zoomable way) to restore the original positions of these elements, but now in a way that doesn't affect `line-height`.