### PR TITLE
Use ORGANIZATION_IDENTIFIER for the bundle identifier

### DIFF
--- a/xcconfig/NetNewsWire_macapp_target.xcconfig
+++ b/xcconfig/NetNewsWire_macapp_target.xcconfig
@@ -37,6 +37,6 @@ ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon
 CODE_SIGN_ENTITLEMENTS = Mac/Resources/NetNewsWire.entitlements
 INFOPLIST_FILE = Mac/Resources/Info.plist
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks
-PRODUCT_BUNDLE_IDENTIFIER = com.ranchero.NetNewsWire-Evergreen
+PRODUCT_BUNDLE_IDENTIFIER = $(ORGANIZATION_IDENTIFIER).NetNewsWire-Evergreen
 PRODUCT_NAME = NetNewsWire
 SWIFT_OBJC_BRIDGING_HEADER = Mac/NetNewsWire-Bridging-Header.h

--- a/xcconfig/NetNewsWire_safariextension_target.xcconfig
+++ b/xcconfig/NetNewsWire_safariextension_target.xcconfig
@@ -34,7 +34,7 @@ PROVISIONING_PROFILE_SPECIFIER =
 CODE_SIGN_ENTITLEMENTS = Mac/SafariExtension/Subscribe_to_Feed.entitlements
 INFOPLIST_FILE = Mac/SafariExtension/Info.plist
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks
-PRODUCT_BUNDLE_IDENTIFIER = com.ranchero.NetNewsWire-Evergreen.Subscribe-to-Feed
+PRODUCT_BUNDLE_IDENTIFIER = $(ORGANIZATION_IDENTIFIER).NetNewsWire-Evergreen.Subscribe-to-Feed
 PRODUCT_NAME = $(TARGET_NAME)
 
 SDKROOT = macosx


### PR DESCRIPTION
The ORGANIZATION_IDENTIFIER was not being used on the Mac and Safari Extension. This made the bundle and provisioning profile be com.ranchero.XYZ. Xcode doesn't like this since they need to be unique or be on the same Apple Developer account.

Changing this to use the ORGANIZATION_IDENTIFIER lets developers have a unique ID without needing to edit the project config, using the identifier from the shared settings.