### PR TITLE
Feedly: Implement paging

### DIFF
--- a/Frameworks/Account/Feedly/FeedlyAPICaller.swift
+++ b/Frameworks/Account/Feedly/FeedlyAPICaller.swift
@@ -89,12 +89,7 @@ final class FeedlyAPICaller {
 		}
 	}
 	
-	func getStream(for collection: FeedlyCollection, newerThan: Date? = nil, unreadOnly: Bool? = nil, completionHandler: @escaping (Result<FeedlyStream, Error>) -> ()) {
-		let id = FeedlyCategoryResourceId(id: collection.id)
-		getStream(for: id, newerThan: newerThan, unreadOnly: unreadOnly, completionHandler: completionHandler)
-	}
-	
-	func getStream(for resource: FeedlyResourceId, newerThan: Date?, unreadOnly: Bool?, completionHandler: @escaping (Result<FeedlyStream, Error>) -> ()) {
+	func getStream(for resource: FeedlyResourceId, continuation: String? = nil, newerThan: Date?, unreadOnly: Bool?, completionHandler: @escaping (Result<FeedlyStream, Error>) -> ()) {
 		guard let accessToken = credentials?.secret else {
 			return DispatchQueue.main.async {
 				completionHandler(.failure(CredentialsError.incompleteCredentials))
@@ -103,7 +98,7 @@ final class FeedlyAPICaller {
 		
 		var components = baseUrlComponents
 		components.path = "/v3/streams/contents"
-		// If you change these, check AccountFeedlySyncTest.set(testFiles:with:).
+
 		var queryItems = [URLQueryItem]()
 		
 		if let date = newerThan {
@@ -115,6 +110,11 @@ final class FeedlyAPICaller {
 		if let flag = unreadOnly {
 			let value = flag ? "true" : "false"
 			let queryItem = URLQueryItem(name: "unreadOnly", value: value)
+			queryItems.append(queryItem)
+		}
+		
+		if let value = continuation, !value.isEmpty {
+			let queryItem = URLQueryItem(name: "continuation", value: value)
 			queryItems.append(queryItem)
 		}
 		

--- a/Frameworks/Account/Feedly/FeedlyOperation.swift
+++ b/Frameworks/Account/Feedly/FeedlyOperation.swift
@@ -19,11 +19,13 @@ class FeedlyOperation: Operation {
 	weak var delegate: FeedlyOperationDelegate?
 	
 	func didFinish() {
+		assert(Thread.isMainThread)
 		self.isExecutingOperation = false
 		self.isFinishedOperation = true
 	}
 	
 	func didFinish(_ error: Error) {
+		assert(Thread.isMainThread)
 		delegate?.feedlyOperation(self, didFailWith: error)
 		didFinish()
 	}

--- a/Frameworks/Account/Feedly/Refresh/FeedlyOrganiseParsedItemsByFeedOperation.swift
+++ b/Frameworks/Account/Feedly/Refresh/FeedlyOrganiseParsedItemsByFeedOperation.swift
@@ -12,8 +12,7 @@ import os.log
 
 protocol FeedlyParsedItemsByFeedProviding {
 	var providerName: String { get }
-	var allFeeds: Set<Feed> { get }
-	func parsedItems(for feed: Feed) -> Set<ParsedItem>?
+	var parsedItemsKeyedByFeedId: [String: Set<ParsedItem>] { get }
 }
 
 /// Single responsibility is to group articles by their feeds.
@@ -22,15 +21,9 @@ final class FeedlyOrganiseParsedItemsByFeedOperation: FeedlyOperation, FeedlyPar
 	private let entryProvider: FeedlyEntryProviding
 	private let log: OSLog
 	
-	var allFeeds: Set<Feed> {
+	var parsedItemsKeyedByFeedId: [String : Set<ParsedItem>] {
 		assert(Thread.isMainThread) // Needs to be on main thread because Feed is a main-thread-only model type.
-		let keys = Set(itemsKeyedByFeedId.keys)
-		return account.flattenedFeeds().filter { keys.contains($0.feedID) }
-	}
-	
-	func parsedItems(for feed: Feed) -> Set<ParsedItem>? {
-		assert(Thread.isMainThread) // Needs to be on main thread because Feed is a main-thread-only model type.
-		return itemsKeyedByFeedId[feed.feedID]
+		return itemsKeyedByFeedId
 	}
 	
 	var providerName: String {

--- a/Frameworks/Account/Feedly/Refresh/FeedlySyncStrategy.swift
+++ b/Frameworks/Account/Feedly/Refresh/FeedlySyncStrategy.swift
@@ -49,6 +49,11 @@ final class FeedlySyncStrategy {
 			return
 		}
 		
+		guard let credentials = caller.credentials else {
+			completionHandler(.failure(FeedlyAccountDelegateError.notLoggedIn))
+			return
+		}
+		
 		let sendArticleStatuses = FeedlySendArticleStatusesOperation(database: database, caller: caller, log: log)
 		sendArticleStatuses.delegate = self
 		
@@ -85,7 +90,7 @@ final class FeedlySyncStrategy {
 		getCollectionStreams.queueDelegate = self
 		getCollectionStreams.addDependency(getCollections)
 		
-		let syncStarred = FeedlySyncStarredArticlesOperation(account: account, caller: caller, log: log)
+		let syncStarred = FeedlySyncStarredArticlesOperation(account: account, credentials: credentials, caller: caller, log: log)
 		syncStarred.addDependency(getCollections)
 		syncStarred.addDependency(mirrorCollectionsAsFolders)
 		syncStarred.addDependency(createFeedsOperation)

--- a/Frameworks/Account/Feedly/Refresh/FeedlyUpdateAccountFeedsWithItemsOperation.swift
+++ b/Frameworks/Account/Feedly/Refresh/FeedlyUpdateAccountFeedsWithItemsOperation.swift
@@ -29,19 +29,10 @@ final class FeedlyUpdateAccountFeedsWithItemsOperation: FeedlyOperation {
 			return
 		}
 		
-		let allFeeds = organisedItemsProvider.allFeeds
+		let feedIDsAndItems = organisedItemsProvider.parsedItemsKeyedByFeedId
 		
-		os_log(.debug, log: log, "Begin updating %i feeds for \"%@\"", allFeeds.count, organisedItemsProvider.providerName)
-
-		var feedIDsAndItems = [String: Set<ParsedItem>]()
-		for feed in allFeeds {
-			guard let items = organisedItemsProvider.parsedItems(for: feed) else {
-				continue
-			}
-			feedIDsAndItems[feed.feedID] = items
-		}
 		account.update(feedIDsAndItems: feedIDsAndItems, defaultRead: true) {
-			os_log(.debug, log: self.log, "Finished updating feeds for \"%@\"", self.organisedItemsProvider.providerName)
+			os_log(.debug, log: self.log, "Updated %i feeds for \"%@\"", feedIDsAndItems.count, self.organisedItemsProvider.providerName)
 			self.didFinish()
 		}
 	}


### PR DESCRIPTION
Implements support for [Feedly's pagination](https://developer.feedly.com/cloud/#pagination) to ensure we get all content. This PR ensures we get all the starred/saved articles. A future PR will reworking the syncing in general to use this to ensure we get all the content the user is expecting. #1095 #1041 