### PR TITLE
Add missing xcconfig file for MAS version of Safari extension.

### DIFF
--- a/xcconfig/NetNewsWire_safariextension_target_macappstore.xcconfig
+++ b/xcconfig/NetNewsWire_safariextension_target_macappstore.xcconfig
@@ -1,0 +1,44 @@
+CODE_SIGN_IDENTITY[config=Release] = 3rd Party Mac Developer Application
+CODE_SIGN_IDENTITY[config=Debug] = -
+DEVELOPMENT_TEAM = M8L2WTLA8W
+CODE_SIGN_STYLE = Manual
+ORGANIZATION_IDENTIFIER = com.ranchero
+PROVISIONING_PROFILE_SPECIFIER = 
+
+// developers can locally override the Xcode settings for code signing
+// by creating a DeveloperSettings.xcconfig file locally at the appropriate path
+// This allows a pristine project to have code signing set up with the appropriate
+// developer ID and certificates, and for dev to be able to have local settings
+// without needing to check in anything into source control
+//
+// As an example, make a ../../SharedXcodeSettings/DeveloperSettings.xcconfig file and
+// give it the contents
+//
+//    CODE_SIGN_IDENTITY[sdk=macosx*] = Mac Developer
+//    CODE_SIGN_IDENTITY[sdk=iphoneos*] = iPhone Developer
+//    CODE_SIGN_IDENTITY[sdk=iphonesimulator*] = iPhone Developer
+//    DEVELOPMENT_TEAM = <Your Team ID>
+//    ORGANIZATION_IDENTIFIER = <Your Domain Name Reversed>
+//    CODE_SIGN_STYLE = Automatic
+//    PROVISIONING_PROFILE_SPECIFIER =
+//
+// And you should be able to build without code signing errors and without modifying
+// the NetNewsWire Xcode project.
+//
+// Example:  if your NetNewsWire Xcode project file is at
+//     /Users/Shared/git/NetNewsWire/NetNewsWire.xcodeproj
+// create your DeveloperSettings.xcconfig file at
+//     /Users/Shared/git/SharedXcodeSettings/DeveloperSettings.xcconfig
+//
+
+#include? "../../SharedXcodeSettings/DeveloperSettings.xcconfig"
+#include "./common/NetNewsWire_mac_target_common.xcconfig"
+
+CODE_SIGN_ENTITLEMENTS = Mac/SafariExtension/Subscribe_to_Feed.entitlements
+INFOPLIST_FILE = Mac/SafariExtension/Info.plist
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks
+PRODUCT_BUNDLE_IDENTIFIER = $(ORGANIZATION_IDENTIFIER).NetNewsWire-Evergreen.MAS.Subscribe-to-Feed
+PRODUCT_NAME = $(TARGET_NAME)
+OTHER_SWIFT_FLAGS = -DMAC_APP_STORE $(inherited)
+
+SDKROOT = macosx


### PR DESCRIPTION
I think this will fix #1154 