### PR TITLE
Delete account button should highlight red

### DIFF
--- a/iOS/Inspector/Inspector.storyboard
+++ b/iOS/Inspector/Inspector.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15508"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -118,6 +119,14 @@
                                                     <state key="normal" title="Delete Account">
                                                         <color key="titleColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
+                                                    <state key="highlighted">
+                                                        <color key="titleColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundHighlightColor">
+                                                            <color key="value" name="deleteBackgroundColor"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
                                                     <connections>
                                                         <action selector="deleteAccount:" destination="1m3-fZ-n7g" eventType="touchUpInside" id="gYt-Fi-Eqe"/>
                                                     </connections>
@@ -166,4 +175,9 @@
             <point key="canvasLocation" x="157" y="-591"/>
         </scene>
     </scenes>
+    <resources>
+        <namedColor name="deleteBackgroundColor">
+            <color red="0.22745098039215686" green="0.22745098039215686" blue="0.23529411764705882" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/iOS/Resources/Assets.xcassets/deleteBackgroundColor.colorset/Contents.json
+++ b/iOS/Resources/Assets.xcassets/deleteBackgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xD1",
+          "alpha" : "1.000",
+          "blue" : "0xD6",
+          "green" : "0xD1"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x3A",
+          "alpha" : "1.000",
+          "blue" : "0x3C",
+          "green" : "0x3A"
+        }
+      }
+    }
+  ]
+}

--- a/iOS/UIKit Extensions/VibrantButton.swift
+++ b/iOS/UIKit Extensions/VibrantButton.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 class VibrantButton: UIButton {
+	
+	@IBInspectable var backgroundHighlightColor: UIColor = AppAssets.secondaryAccentColor
 
 	override init(frame: CGRect) {
 		super.init(frame: frame)
@@ -25,7 +27,7 @@ class VibrantButton: UIButton {
 
 	override var isHighlighted: Bool {
 		didSet {
-			backgroundColor = isHighlighted ? AppAssets.secondaryAccentColor : nil
+			backgroundColor = isHighlighted ? backgroundHighlightColor : nil
 			titleLabel?.alpha = 1
 		}
 	}


### PR DESCRIPTION
I've added an IBInspectable attribute to let you set the background color for a VibrantButton. This should let us finish #1185.

I pulled the light grey colors (light/dark mode) that the Contacts app uses as a reference, but it can easily be switched to red if that is the preferred design.