### PR TITLE
Modifies SyncDatabase to synchronously create tables…

### DIFF
--- a/Frameworks/SyncDatabase/SyncDatabase.swift
+++ b/Frameworks/SyncDatabase/SyncDatabase.swift
@@ -18,7 +18,7 @@ public final class SyncDatabase {
 		let queue = RSDatabaseQueue(filepath: databaseFilePath, excludeFromBackup: false)
 		self.syncStatusTable = SyncStatusTable(queue: queue)
 		
-		queue.createTables(usingStatements: SyncDatabase.tableCreationStatements)
+		queue.createTables(usingStatementsSync: SyncDatabase.tableCreationStatements)
 		queue.vacuumIfNeeded()
 
 	}


### PR DESCRIPTION
… so clients can reliably use an instance immediately after initialisation. I suspect this should fix the error messages logged here and fix the failing tests on CI.

```
xctest[2371:12204] DB Error: 1 "no such table: syncStatus"
xctest[2371:12204] DB Query: delete from syncStatus where articleID in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
xctest[2371:12204] DB Path: /Users/runner/Library/Caches/6F96B9DB-3494-4BAC-A5A6-81FB787DBB5E-Sync.sqlite3
```