### PR TITLE
Refreshing Feedly accounts on creation + Feedly on iOS

### DIFF
--- a/Frameworks/Account/Feedly/OAuthAccountAuthorizationOperation.swift
+++ b/Frameworks/Account/Feedly/OAuthAccountAuthorizationOperation.swift
@@ -10,6 +10,7 @@ import Foundation
 import AuthenticationServices
 
 public protocol OAuthAccountAuthorizationOperationDelegate: class {
+	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didCreate account: Account)
 	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didFailWith error: Error)
 }
 
@@ -126,6 +127,8 @@ public final class OAuthAccountAuthorizationOperation: Operation, ASWebAuthentic
 			
 			// Now store the access token because we want the account delegate to use it.
 			try account.storeCredentials(grant.accessToken)
+			
+			delegate?.oauthAccountAuthorizationOperation(self, didCreate: account)
 						
 			didFinish()
 		} catch {

--- a/Mac/Preferences/Accounts/AccountsAddViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsAddViewController.swift
@@ -119,6 +119,17 @@ extension AccountsAddViewController: NSTableViewDelegate {
 
 extension AccountsAddViewController: OAuthAccountAuthorizationOperationDelegate {
 	
+	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didCreate account: Account) {
+		account.refreshAll { [weak self] result in
+			switch result {
+			case .success:
+				break
+			case .failure(let error):
+				self?.presentError(error)
+			}
+		}
+	}
+	
 	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didFailWith error: Error) {
 		view.window?.presentError(error)
 	}

--- a/iOS/Settings/AddAccountViewController.swift
+++ b/iOS/Settings/AddAccountViewController.swift
@@ -38,6 +38,11 @@ class AddAccountViewController: UITableViewController, AddAccountDismissDelegate
 			let addViewController = navController.topViewController as! FeedbinAccountViewController
 			addViewController.delegate = self
 			present(navController, animated: true)
+		case 2:
+			let addAccount = OAuthAccountAuthorizationOperation(accountType: .feedly)
+			addAccount.delegate = self
+			addAccount.presentationAnchor = self.view.window!
+			OperationQueue.main.addOperation(addAccount)
 		default:
 			break
 		}
@@ -47,4 +52,29 @@ class AddAccountViewController: UITableViewController, AddAccountDismissDelegate
 		navigationController?.popViewController(animated: false)
 	}
 	
+}
+
+extension AddAccountViewController: OAuthAccountAuthorizationOperationDelegate {
+	
+	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didCreate account: Account) {
+		let rootViewController = view.window?.rootViewController
+		
+		account.refreshAll { result in
+			switch result {
+			case .success:
+				break
+			case .failure(let error):
+				guard let viewController = rootViewController else {
+					return
+				}
+				viewController.presentError(error)
+			}
+		}
+		
+		dismiss()
+	}
+	
+	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didFailWith error: Error) {
+		presentError(error)
+	}
 }

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -424,6 +424,39 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="56" id="zcM-qz-glk" customClass="VibrantTableViewCell" customModule="NetNewsWire" customModuleProvider="target">
+                                        <rect key="frame" x="20" y="129" width="374" height="56"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zcM-qz-glk" id="3VG-Ax-7gi">
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="56"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="cXZ-17-bhe">
+                                                    <rect key="frame" x="20" y="12" width="128" height="32"/>
+                                                    <subviews>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accountFeedly" translatesAutoresizingMaskIntoConstraints="NO" id="fAO-P0-gtD">
+                                                            <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
+                                                            <color key="tintColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="32" id="581-u2-SxX"/>
+                                                                <constraint firstAttribute="height" constant="32" id="onv-oj-10a"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Feedly" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u2M-c5-ujy">
+                                                            <rect key="frame" x="48" y="0.0" width="80" height="32"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="cXZ-17-bhe" firstAttribute="leading" secondItem="3VG-Ax-7gi" secondAttribute="leading" constant="20" symbolic="YES" id="BYO-oH-a6T"/>
+                                                <constraint firstItem="cXZ-17-bhe" firstAttribute="centerY" secondItem="3VG-Ax-7gi" secondAttribute="centerY" id="r36-pZ-Siw"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -811,6 +844,7 @@
     </scenes>
     <resources>
         <image name="accountFeedbin" width="120" height="102"/>
+        <image name="accountFeedly" width="138" height="123"/>
         <image name="accountLocal" width="99" height="77"/>
         <namedColor name="primaryAccentColor">
             <color red="0.031372549019607843" green="0.41568627450980394" blue="0.93333333333333335" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
The PR adds:
- `OAuthAccountAuthorizationOperation` tells its delegate when it creates an account. The delegates ask the new account to refresh.
- `AddAccountViewController` on iOS can add Feedly accounts (these refresh on add, too!).