### PR TITLE
Enables accounts and their delegates to prepare to be deleted. 

### DIFF
--- a/Frameworks/Account/Account.swift
+++ b/Frameworks/Account/Account.swift
@@ -399,6 +399,10 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 		opmlFile.save()
 	}
 	
+	public func prepareForDeletion() {
+		delegate.accountWillBeDeleted(self)
+	}
+	
 	func loadOPMLItems(_ items: [RSOPMLItem], parentFolder: Folder?) {
 		var feedsToAdd = Set<Feed>()
 

--- a/Frameworks/Account/AccountDelegate.swift
+++ b/Frameworks/Account/AccountDelegate.swift
@@ -46,6 +46,8 @@ protocol AccountDelegate {
 
 	// Called at the end of account’s init method.
 	func accountDidInitialize(_ account: Account)
+	
+	func accountWillBeDeleted(_ account: Account)
 
 	static func validateCredentials(transport: Transport, credentials: Credentials, endpoint: URL?, completion: @escaping (Result<Credentials?, Error>) -> Void)
 	

--- a/Frameworks/Account/AccountManager.swift
+++ b/Frameworks/Account/AccountManager.swift
@@ -138,6 +138,8 @@ public final class AccountManager: UnreadCountProvider {
 			return
 		}
 		
+		account.prepareForDeletion()
+		
 		accountsDictionary.removeValue(forKey: account.accountID)
 		account.isDeleted = true
 		

--- a/Frameworks/Account/Feedbin/FeedbinAccountDelegate.swift
+++ b/Frameworks/Account/Feedbin/FeedbinAccountDelegate.swift
@@ -541,6 +541,9 @@ final class FeedbinAccountDelegate: AccountDelegate {
 		credentials = try? account.retrieveCredentials(type: .basic)
 	}
 	
+	func accountWillBeDeleted(_ account: Account) {
+	}
+	
 	static func validateCredentials(transport: Transport, credentials: Credentials, endpoint: URL? = nil, completion: @escaping (Result<Credentials?, Error>) -> Void) {
 		
 		let caller = FeedbinAPICaller(transport: transport)

--- a/Frameworks/Account/Feedly/FeedlyAccountDelegate.swift
+++ b/Frameworks/Account/Feedly/FeedlyAccountDelegate.swift
@@ -486,6 +486,10 @@ final class FeedlyAccountDelegate: AccountDelegate {
 		operationQueue.addOperation(refreshAccessToken)
 	}
 	
+	func accountWillBeDeleted(_ account: Account) {
+		
+	}
+	
 	static func validateCredentials(transport: Transport, credentials: Credentials, endpoint: URL?, completion: @escaping (Result<Credentials?, Error>) -> Void) {
 		assertionFailure("An `account` instance should enqueue an \(FeedlyRefreshAccessTokenOperation.self) instead.")
 		completion(.success(credentials))

--- a/Frameworks/Account/LocalAccount/LocalAccountDelegate.swift
+++ b/Frameworks/Account/LocalAccount/LocalAccountDelegate.swift
@@ -195,6 +195,9 @@ final class LocalAccountDelegate: AccountDelegate {
 
 	func accountDidInitialize(_ account: Account) {
 	}
+	
+	func accountWillBeDeleted(_ account: Account) {
+	}
 
 	static func validateCredentials(transport: Transport, credentials: Credentials, endpoint: URL? = nil, completion: (Result<Credentials?, Error>) -> Void) {
 		return completion(.success(nil))

--- a/Frameworks/Account/ReaderAPI/ReaderAPIAccountDelegate.swift
+++ b/Frameworks/Account/ReaderAPI/ReaderAPIAccountDelegate.swift
@@ -418,6 +418,9 @@ final class ReaderAPIAccountDelegate: AccountDelegate {
 		credentials = try? account.retrieveCredentials(type: .readerAPIKey)
 	}
 	
+	func accountWillBeDeleted(_ account: Account) {
+	}
+	
 	static func validateCredentials(transport: Transport, credentials: Credentials, endpoint: URL?, completion: @escaping (Result<Credentials?, Error>) -> Void) {
 		guard let endpoint = endpoint else {
 			completion(.failure(TransportError.noURL))

--- a/Mac/Preferences/Accounts/AccountsDetailViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsDetailViewController.swift
@@ -28,6 +28,19 @@ final class AccountsDetailViewController: NSViewController, NSTextFieldDelegate 
 		super.init(coder: coder)
 	}
 	
+	private var hidesCredentialsButton: Bool {
+		guard let account = account else {
+			return true
+		}
+		switch account.type {
+		case .onMyMac,
+			 .feedly:
+			return true
+		default:
+			return false
+		}
+	}
+	
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		
@@ -35,7 +48,7 @@ final class AccountsDetailViewController: NSViewController, NSTextFieldDelegate 
 		typeLabel.stringValue = account?.defaultName ?? ""
 		nameTextField.stringValue = account?.name ?? ""
 		activeButton.state = account?.isActive ?? false ? .on : .off
-		credentialsButton.isHidden = account?.type ?? .onMyMac == .onMyMac
+		credentialsButton.isHidden = hidesCredentialsButton
 	}
 	
 	func controlTextDidEndEditing(_ obj: Notification) {
@@ -66,8 +79,6 @@ final class AccountsDetailViewController: NSViewController, NSTextFieldDelegate 
 			accountsFreshRSSWindowController.account = account
 			accountsFreshRSSWindowController.runSheetOnWindow(self.view.window!)
 			accountsWindowController = accountsFreshRSSWindowController
-		case .feedly:
-			assertionFailure("Implement feedly logout window controller")
 			break
 		default:
 			break

--- a/iOS/Inspector/AccountInspectorViewController.swift
+++ b/iOS/Inspector/AccountInspectorViewController.swift
@@ -64,10 +64,20 @@ class AccountInspectorViewController: UITableViewController {
 	}
 	
 	@IBAction func deleteAccount(_ sender: Any) {
-		let title = NSLocalizedString("Delete Account", comment: "Delete Account")
-		let message = NSLocalizedString("Are you sure you want to delete this account?  This can not be undone.", comment: "Delete Account")
-		let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+		guard let account = account else {
+			return
+		}
 		
+		let title = NSLocalizedString("Delete Account", comment: "Delete Account")
+		let message: String = {
+			switch account.type {
+			case .feedly:
+				return NSLocalizedString("Are you sure you want to delete this account?  NetNewsWire will no longer be able to access articles and feeds unless the account is added again.", comment: "Log Out and Delete Account")
+			default:
+				return NSLocalizedString("Are you sure you want to delete this account?  This can not be undone.", comment: "Delete Account")
+			}
+		}()
+		let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
 		let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel")
 		let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel)
 		alertController.addAction(cancelAction)
@@ -86,19 +96,31 @@ class AccountInspectorViewController: UITableViewController {
 		
 		present(alertController, animated: true)
 	}
-	
 }
 
 // MARK: Table View
 
 extension AccountInspectorViewController {
+	
+	var hidesCredentialsSection: Bool {
+		guard let account = account else {
+			return true
+		}
+		switch account.type {
+		case .onMyMac,
+			 .feedly:
+			return true
+		default:
+			return false
+		}
+	}
 
 	override func numberOfSections(in tableView: UITableView) -> Int {
 		guard let account = account else { return 0 }
 		
 		if account == AccountManager.shared.defaultAccount {
 			return 1
-		} else if account.type == .onMyMac {
+		} else if hidesCredentialsSection {
 			return 2
 		} else {
 			return super.numberOfSections(in: tableView)
@@ -124,7 +146,7 @@ extension AccountInspectorViewController {
 	override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 		let cell: UITableViewCell
 		
-		if indexPath.section == 1, let account = account, account.type == .onMyMac {
+		if indexPath.section == 1, hidesCredentialsSection {
 			cell = super.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 2))
 		} else {
 			cell = super.tableView(tableView, cellForRowAt: indexPath)


### PR DESCRIPTION
I would like to get feedback about the approach I'm taking in this PR.

In this PR:
- Enables accounts and their delegates to prepare for deletion.
- Provides a variation of the Account Inspector on iOS for Feedly.

The use case I have in mind is this. When a Feedly account is just about to be deleted, the Feedly delegate can make a `logout` request to the API to revoke the access token issuing grant the user has previously given NetNewsWire. This way, the user is in control of what is accessing their content.

Mac PR in the works.