### PR TITLE
Fix successive favicon URL attempts

### DIFF
--- a/Shared/Favicons/FaviconDownloader.swift
+++ b/Shared/Favicons/FaviconDownloader.swift
@@ -136,6 +136,7 @@ final class FaviconDownloader {
 
 			if (!hasIcons) {
 				self.homePageURLsWithNoFaviconURLCache.insert(url)
+				self.homePageURLsWithNoFaviconURLCacheDirty = true
 			}
 		}
 
@@ -169,6 +170,7 @@ final class FaviconDownloader {
 		if let url = singleFaviconDownloader.homePageURL {
 			if self.homePageToFaviconURLCache[url] == nil {
 				self.homePageToFaviconURLCache[url] = singleFaviconDownloader.faviconURL
+				self.homePageToFaviconURLCacheDirty = true
 			}
 		}
 

--- a/Shared/Favicons/SingleFaviconDownloader.swift
+++ b/Shared/Favicons/SingleFaviconDownloader.swift
@@ -85,8 +85,9 @@ private extension SingleFaviconDownloader {
 
 				if let image = image {
 					self.iconImage = IconImage(image)
-					self.postDidLoadFaviconNotification()
 				}
+
+				self.postDidLoadFaviconNotification()
 				
 			}
 		}


### PR DESCRIPTION
The call to `self.postDidLoadFaviconNotification()` needs to be outside the brackets, otherwise `FaviconDownloader` won't try the rest of the favicon URLs on failure.