### PR TITLE
Enable ShowDebugMenu on master

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -34,6 +34,7 @@ struct AppDefaults {
 		static let exportOPMLAccountID = "exportOPMLAccountID"
 
 		// Hidden prefs
+		static let showDebugMenu = "ShowDebugMenu"
 		static let timelineShowsSeparators = "CorreiaSeparators"
 		static let showTitleOnMainWindow = "KafasisTitleMode"
 		static let hideDockUnreadCount = "JustinMillerHideDockUnreadCount"
@@ -149,6 +150,10 @@ struct AppDefaults {
 		return bool(for: Key.showTitleOnMainWindow)
 	}
 
+	static var showDebugMenu: Bool {
+ 		return bool(for: Key.showDebugMenu)
+ 	}
+
 	static var hideDockUnreadCount: Bool {
 		return bool(for: Key.hideDockUnreadCount)
 	}
@@ -215,6 +220,12 @@ struct AppDefaults {
 	}
 
 	static func registerDefaults() {
+		#if DEBUG
+ 		let showDebugMenu = true
+ 		#else
+ 		let showDebugMenu = false
+ 		#endif
+
 		let defaults: [String : Any] = [Key.lastImageCacheFlushDate: Date(),
 										Key.sidebarFontSize: FontSize.medium.rawValue,
 										Key.timelineFontSize: FontSize.medium.rawValue,
@@ -222,7 +233,8 @@ struct AppDefaults {
 										Key.timelineSortDirection: ComparisonResult.orderedDescending.rawValue,
 										Key.timelineGroupByFeed: false,
 										"NSScrollViewShouldScrollUnderTitlebar": false,
-										Key.refreshInterval: RefreshInterval.everyHour.rawValue]
+										Key.refreshInterval: RefreshInterval.everyHour.rawValue,
+										Key.showDebugMenu: showDebugMenu]
 
 		UserDefaults.standard.register(defaults: defaults)
 

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -220,18 +220,25 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 		UNUserNotificationCenter.current().delegate = self
 		userNotificationManager = UserNotificationManager()
 
-		#if RELEASE
+		if AppDefaults.showDebugMenu {
+ 			refreshTimer!.update()
+ 			syncTimer!.update()
+
+  			// The Web Inspector uses SPI and can never appear in a MAC_APP_STORE build.
+ 			#if MAC_APP_STORE
+ 			let debugMenu = debugMenuItem.submenu!
+ 			let toggleWebInspectorItemIndex = debugMenu.indexOfItem(withTarget: self, andAction: #selector(toggleWebInspectorEnabled(_:)))
+ 			if toggleWebInspectorItemIndex != -1 {
+ 				debugMenu.removeItem(at: toggleWebInspectorItemIndex)
+ 			}
+ 			#endif
+ 		} else {
 			debugMenuItem.menu?.removeItem(debugMenuItem)
 			DispatchQueue.main.async {
 				self.refreshTimer!.timedRefresh(nil)
 				self.syncTimer!.timedRefresh(nil)
 			}
-		#endif
-
-		#if DEBUG
-			refreshTimer!.update()
-			syncTimer!.update()
-		#endif
+		}
 
 		#if !MAC_APP_STORE
 			DispatchQueue.main.async {


### PR DESCRIPTION
`master` version of the patch for #1108 (which AFAICT is identical; `mac-release` patch was #1110).