### PR TITLE
Feedly: Optional feed titles

### DIFF
--- a/Frameworks/Account/Feedly/Models/FeedlyFeed.swift
+++ b/Frameworks/Account/Feedly/Models/FeedlyFeed.swift
@@ -11,7 +11,7 @@ import Foundation
 struct FeedlyFeed: Codable {
 	var feedId: String
 	var id: String
-	var title: String
+	var title: String?
 	var updated: Date?
 	var website: String?
 }

--- a/Frameworks/Account/Feedly/Models/FeedlyOrigin.swift
+++ b/Frameworks/Account/Feedly/Models/FeedlyOrigin.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct FeedlyOrigin: Decodable {
-	var title: String
+	var title: String?
 	var streamId: String
 	var htmlUrl: String
 }

--- a/Frameworks/Account/Feedly/OAuthAuthorizationClient+Feedly.swift
+++ b/Frameworks/Account/Feedly/OAuthAuthorizationClient+Feedly.swift
@@ -25,10 +25,11 @@ extension OAuthAuthorizationClient {
 		/// See https://developer.feedly.com/v3/sandbox/ for more information.
 		/// The return value models public sandbox API values found at:
 		/// https://groups.google.com/forum/#!topic/feedly-cloud/WwQWMgDmOuw
-		/// They are due to expire on November 30 2019.
+		/// They are due to expire on January 31 2020.
+		/// Verify the sandbox URL host in the FeedlyAPICaller.API.baseUrlComponents method, too.
 		return OAuthAuthorizationClient(id: "sandbox",
 										redirectUri: "urn:ietf:wg:oauth:2.0:oob",
 										state: nil,
-										secret: "ReVGXA6WekanCxbf")
+										secret: "nZmS4bqxgRQkdPks")
 	}
 }


### PR DESCRIPTION
It seems feed titles are optional, [contrary to the API documentation](https://developer.feedly.com/v3/feeds/#get-the-metadata-about-a-specific-feed).

This PR:
- makes the `title` property on `FeedlyFeed` optional.
- updates the [public](https://groups.google.com/forum/#!topic/feedly-cloud/3KAnjpDpmAQ) sandbox OAuth client secret.

Hopefully this should fix #1326. However, if there are other keys which I understand to be required but are in fact optional, this issue will persist. These (as this was) will be identified by using Console.app, connecting the iOS device and searching for "Feedly" in debug logs.