### PR TITLE
Ignore secrets-related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+/Shared/Secrets.swift
+*.py[cod]
+


### PR DESCRIPTION
These weren't ignored on `mac-release` yet.