### PR TITLE
Models the feed identifier of feedly articles as an optional…

### DIFF
--- a/Frameworks/Account/Feedly/Models/FeedlyEntryParser.swift
+++ b/Frameworks/Account/Feedly/Models/FeedlyEntryParser.swift
@@ -17,10 +17,10 @@ struct FeedlyEntryParser {
 		return entry.id
 	}
 	
-	var feedUrl: String {
+	var feedUrl: String? {
 		guard let id = entry.origin?.streamId else {
 			assertionFailure()
-			return ""
+			return nil
 		}
 		return id
 	}
@@ -82,7 +82,11 @@ struct FeedlyEntryParser {
 		return attachments.isEmpty ? nil : Set(attachments)
 	}
 	
-	var parsedItemRepresentation: ParsedItem {
+	var parsedItemRepresentation: ParsedItem? {
+		guard let feedUrl = feedUrl else {
+			return nil
+		}
+		
 		return ParsedItem(syncServiceID: id,
 						  uniqueID: id, // This value seems to get ignored or replaced.
 						  feedURL: feedUrl,

--- a/Frameworks/Account/Feedly/Models/FeedlyOrigin.swift
+++ b/Frameworks/Account/Feedly/Models/FeedlyOrigin.swift
@@ -10,6 +10,6 @@ import Foundation
 
 struct FeedlyOrigin: Decodable {
 	var title: String?
-	var streamId: String
+	var streamId: String?
 	var htmlUrl: String
 }

--- a/Frameworks/Account/Feedly/Operations/FeedlyGetStreamContentsOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyGetStreamContentsOperation.swift
@@ -50,7 +50,17 @@ final class FeedlyGetStreamContentsOperation: FeedlyOperation, FeedlyEntryProvid
 			return entries
 		}
 		
-		let parsed = Set(entries.map { FeedlyEntryParser(entry: $0).parsedItemRepresentation })
+		let parsed = Set(entries.compactMap {
+			FeedlyEntryParser(entry: $0).parsedItemRepresentation
+		})
+		
+		if parsed.count != entries.count {
+			let entryIds = Set(entries.map { $0.id })
+			let parsedIds = Set(parsed.map { $0.uniqueID })
+			let difference = entryIds.subtracting(parsedIds)
+			os_log(.debug, log: log, "Dropping articles with ids: %{public}@.", difference)
+		}
+		
 		storedParsedEntries = parsed
 		
 		return parsed


### PR DESCRIPTION
…since it seems the Feedly API will not always provide one ([despite the API documentation](https://developer.feedly.com/v3/entries/#get-the-content-of-an-entry)). 

This may result in NNW dropping articles since NNW requires articles to identify a subscribed-to feed. It seems to be with certain older starred articles.

A possibly complete fix for #1449.