### PR TITLE
Table overflow wrapper

### DIFF
--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -23,14 +23,13 @@ function convertImgSrc() {
 
 // Wrap tables in an overflow-x: auto; div
 function wrapTables() {
-	var tables = document.querySelectorAll("div.articleBody")[0].getElementsByTagName("table");
+	var tables = document.querySelector("div.articleBody").getElementsByTagName("table");
 
 	for (table of tables) {
 		var wrapper = document.createElement("div");
 		wrapper.className = "nnw-overflow";
-		var tableCopy = table.cloneNode(true);
-		wrapper.appendChild(tableCopy);
-		table.parentNode.replaceChild(wrapper, table);
+		table.parentNode.insertBefore(wrapper, table);
+		wrapper.appendChild(table);
 	}
 }
 

--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -65,7 +65,7 @@ var ElementUnwrapper = {
 };
 
 function flattenPreElements() {
-	ElementUnwrapper.unwrapAppropriateChildren(".articleBody td > pre");
+	ElementUnwrapper.unwrapAppropriateChildren("div.articleBody td > pre");
 }
 
 function reloadArticleImage() {

--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -46,7 +46,7 @@ var ElementUnwrapper = {
 
 		parent.removeChild(element);
 	},
-	// `elements` can be a selector string, a node, or a list of nodes
+	// `elements` can be a selector string, an element, or a list of elements
 	unwrapAppropriateChildren: function (elements) {
 		if (typeof elements[Symbol.iterator] !== 'function')
 			elements = [elements];

--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -21,6 +21,19 @@ function convertImgSrc() {
 	});
 }
 
+// Wrap tables in an overflow-x: auto; div
+function wrapTables() {
+	var tables = document.querySelectorAll("div.articleBody")[0].getElementsByTagName("table");
+
+	for (table of tables) {
+		var wrapper = document.createElement("div");
+		wrapper.className = "nnw-overflow";
+		var tableCopy = table.cloneNode(true);
+		wrapper.appendChild(tableCopy);
+		table.parentNode.replaceChild(wrapper, table);
+	}
+}
+
 function reloadArticleImage() {
 	var image = document.getElementById("nnwImageIcon");
 	image.src = "nnwImageIcon://";
@@ -39,6 +52,7 @@ function render(data, scrollY) {
 	wrapFrames()
 	stripStyles()
 	convertImgSrc()
+	wrapTables()
 	
 	postRenderProcessing()
 }

--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -50,9 +50,8 @@ function render(data, scrollY) {
 	window.scrollTo(0, scrollY);
 	
 	wrapFrames()
+	wrapTables()
 	stripStyles()
 	convertImgSrc()
-	wrapTables()
-	
 	postRenderProcessing()
 }

--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -34,6 +34,40 @@ function wrapTables() {
 	}
 }
 
+// Remove some children (currently just spans) from pre elements to work around a strange clipping issue
+var ElementUnwrapper = {
+	unwrapSelector: "span",
+	unwrapElement: function (element) {
+		var parent = element.parentNode;
+		var children = Array.from(element.childNodes);
+
+		for (child of children) {
+			parent.insertBefore(child, element);
+		}
+
+		parent.removeChild(element);
+	},
+	// `elements` can be a selector string, a node, or a list of nodes
+	unwrapAppropriateChildren: function (elements) {
+		if (typeof elements[Symbol.iterator] !== 'function')
+			elements = [elements];
+		else if (typeof elements === "string")
+			elements = document.querySelectorAll(elements);
+
+		for (element of elements) {
+			for (unwrap of element.querySelectorAll(this.unwrapSelector)) {
+				this.unwrapElement(unwrap);
+			}
+
+			element.normalize()
+		}
+	}
+};
+
+function flattenPreElements() {
+	ElementUnwrapper.unwrapAppropriateChildren(".articleBody td > pre");
+}
+
 function reloadArticleImage() {
 	var image = document.getElementById("nnwImageIcon");
 	image.src = "nnwImageIcon://";
@@ -53,5 +87,7 @@ function render(data, scrollY) {
 	wrapTables()
 	stripStyles()
 	convertImgSrc()
+	flattenPreElements()
+
 	postRenderProcessing()
 }

--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -134,9 +134,6 @@ pre {
 .nnw-overflow {
 	overflow-x: auto;
 }
-td > pre {
-	overflow-x: hidden;
-}
 code, pre {
 	font-family: "SF Mono", Menlo, "Courier New", Courier, monospace;
 	font-size: 14px;

--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -131,6 +131,12 @@ pre {
 	word-break: normal;
 	-webkit-hyphens: none;
 }
+.nnw-overflow {
+	overflow-x: auto;
+}
+td > pre {
+	overflow-x: hidden;
+}
 code, pre {
 	font-family: "SF Mono", Menlo, "Courier New", Courier, monospace;
 	font-size: 14px;


### PR DESCRIPTION
Wraps tables in an `overflow-x: auto`div and unwraps `span`s in embedded `pre` elements due to a weird clipping issue. The unwrapping functionality is wrapped up in an object for ease of use.

Second part of fix for #1459.