### PR TITLE
Only strip color/font inline styles 

### DIFF
--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -8,10 +8,18 @@ function wrapFrames() {
 	});
 }
 
-// Strip out all styling so that we have better control over layout
+// Strip out color and font styling
+
+function stripStylesFromElement(element, propertiesToStrip) {
+	for (name of propertiesToStrip) {
+		element.style.removeProperty(name);
+	}
+}
+
 function stripStyles() {
 	document.getElementsByTagName("body")[0].querySelectorAll("style, link[rel=stylesheet]").forEach(element => element.remove());
-	document.getElementsByTagName("body")[0].querySelectorAll("[style]").forEach(element => element.removeAttribute("style"));
+	// Removing "background" and "font" will also remove properties that would be reflected in them, e.g., "background-color" and "font-family"
+	document.getElementsByTagName("body")[0].querySelectorAll("[style]").forEach(element => stripStylesFromElement(element, ["color", "background", "font"]));
 }
 
 // Convert all image locations to be absolute

--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -221,12 +221,6 @@ img[src*="share-buttons"] {
 	display: none !important;
 }
 
-/* Site specific styles */
-.wp-smiley {
-	height: 1em;
-	max-height: 1em;
-}
-
 /* Newsfoot specific styles. Structural styles come first, theme styles second */
 .newsfoot-footnote-container {
 	position: relative;


### PR DESCRIPTION
As far as all the bugs I could find indicate, the `style` stripping was to make sure things didn't become unreadable in Dark Mode.

Resolves #1444.