### PR TITLE
Tweak blockquote margins for small viewports

### DIFF
--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -189,6 +189,11 @@ sub {
 	width: 100% !important;
 }
 
+blockquote {
+	margin-inline-start: 25px;
+	margin-inline-end: 0;
+}
+
 /*Block ads and junk*/
 
 iframe[src*="feedads"],


### PR DESCRIPTION
Implements the suggestions from #1502, but keeps the default margins if the device is rotated to landscape.

(60% of 40 is actually 24, but 25 felt better somehow.)