### PR TITLE
iPhone 8 Plus viewport is actually 414px wide

### DIFF
--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -189,7 +189,7 @@ sub {
 	width: 100% !important;
 }
 
-@media (max-width: 400px) {
+@media (max-width: 420px) {
 	blockquote {
 		margin-inline-start: 25px;
 		margin-inline-end: 0;


### PR DESCRIPTION
Mistakenly had the `body` selected instead of `html` when checking sizing.