### PR TITLE
Update Account tests for new async API

### DIFF
--- a/Frameworks/Account/AccountTests/Feedly/FeedlyAddNewFeedOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyAddNewFeedOperationTests.swift
@@ -120,7 +120,7 @@ class FeedlyAddNewFeedOperationTests: XCTestCase {
 		XCTAssert(progress.isComplete)
 	}
 	
-	func testAddNewFeedSuccess() {
+	func testAddNewFeedSuccess() throws {
 		guard let folder = getFolderByLoadingInitialContent() else {
 			return
 		}
@@ -163,7 +163,7 @@ class FeedlyAddNewFeedOperationTests: XCTestCase {
 		
 		XCTAssert(progress.isComplete)
 		
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "feedStream", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "feedStream", subdirectory: subdirectory)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds", subdirectory: subdirectory, testCase: self)
 	}
 	

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySendArticleStatusesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySendArticleStatusesOperationTests.swift
@@ -81,8 +81,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, 0)
 				selectPendingCountExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping database result: \(e)")
+			} catch {
+				XCTFail("Error unwrapping database result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -124,8 +124,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, statuses.count)
 				selectPendingCountExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping database result: \(e)")
+			} catch {
+				XCTFail("Error unwrapping database result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -167,8 +167,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, 0)
 				selectPendingCountExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping database result: \(e)")
+			} catch {
+				XCTFail("Error unwrapping database result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -210,8 +210,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, statuses.count)
 				selectPendingCountExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping database result: \(e)")
+			} catch {
+				XCTFail("Error unwrapping database result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -253,8 +253,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, 0)
 				selectPendingCountExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping database result: \(e)")
+			} catch {
+				XCTFail("Error unwrapping database result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -296,8 +296,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, statuses.count)
 				selectPendingCountExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping database result: \(e)")
+			} catch {
+				XCTFail("Error unwrapping database result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -339,8 +339,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, 0)
 				selectPendingCountExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping database result: \(e)")
+			} catch {
+				XCTFail("Error unwrapping database result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -382,8 +382,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 				let expectedCount = try result.get()
 				XCTAssertEqual(expectedCount, statuses.count)
 				selectPendingCountExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping database result: \(e)")
+			} catch {
+				XCTFail("Error unwrapping database result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -442,8 +442,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, 0)
 				selectPendingCountExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping database result: \(e)")
+			} catch {
+				XCTFail("Error unwrapping database result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -503,8 +503,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, statuses.count)
 				selectPendingCountExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping database result: \(e)")
+			} catch {
+				XCTFail("Error unwrapping database result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySendArticleStatusesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySendArticleStatusesOperationTests.swift
@@ -75,14 +75,17 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
+		let selectPendingCountExpectation = expectation(description: "Did Select Pending Count")
 		container.database.selectPendingCount { result in
 			do {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, 0)
+				selectPendingCountExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error unwrapping database result: \(e)")
 			}
 		}
+		waitForExpectations(timeout: 2)
 	}
 	
 	func testSendUnreadFailure() {
@@ -115,14 +118,17 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
+		let selectPendingCountExpectation = expectation(description: "Did Select Pending Count")
 		container.database.selectPendingCount { result in
 			do {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, statuses.count)
+				selectPendingCountExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error unwrapping database result: \(e)")
 			}
 		}
+		waitForExpectations(timeout: 2)
 	}
 	
 	func testSendReadSuccess() {
@@ -155,14 +161,17 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
+		let selectPendingCountExpectation = expectation(description: "Did Select Pending Count")
 		container.database.selectPendingCount { result in
 			do {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, 0)
+				selectPendingCountExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error unwrapping database result: \(e)")
 			}
 		}
+		waitForExpectations(timeout: 2)
 	}
 	
 	func testSendReadFailure() {
@@ -195,14 +204,17 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
+		let selectPendingCountExpectation = expectation(description: "Did Select Pending Count")
 		container.database.selectPendingCount { result in
 			do {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, statuses.count)
+				selectPendingCountExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error unwrapping database result: \(e)")
 			}
 		}
+		waitForExpectations(timeout: 2)
 	}
 	
 	func testSendStarredSuccess() {
@@ -235,14 +247,17 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
+		let selectPendingCountExpectation = expectation(description: "Did Select Pending Count")
 		container.database.selectPendingCount { result in
 			do {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, 0)
+				selectPendingCountExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error unwrapping database result: \(e)")
 			}
 		}
+		waitForExpectations(timeout: 2)
 	}
 	
 	func testSendStarredFailure() {
@@ -275,14 +290,17 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
+		let selectPendingCountExpectation = expectation(description: "Did Select Pending Count")
 		container.database.selectPendingCount { result in
 			do {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, statuses.count)
+				selectPendingCountExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error unwrapping database result: \(e)")
 			}
 		}
+		waitForExpectations(timeout: 2)
 	}
 	
 	func testSendUnstarredSuccess() {
@@ -315,14 +333,17 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
+		let selectPendingCountExpectation = expectation(description: "Did Select Pending Count")
 		container.database.selectPendingCount { result in
 			do {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, 0)
+				selectPendingCountExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error unwrapping database result: \(e)")
 			}
 		}
+		waitForExpectations(timeout: 2)
 	}
 	
 	func testSendUnstarredFailure() {
@@ -355,14 +376,17 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
+		let selectPendingCountExpectation = expectation(description: "Did Select Pending Count")
 		container.database.selectPendingCount { result in
 			do {
 				let expectedCount = try result.get()
 				XCTAssertEqual(expectedCount, statuses.count)
+				selectPendingCountExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error unwrapping database result: \(e)")
 			}
 		}
+		waitForExpectations(timeout: 2)
 	}
 	
 	func testSendAllSuccess() {
@@ -412,14 +436,17 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
+		let selectPendingCountExpectation = expectation(description: "Did Select Pending Count")
 		container.database.selectPendingCount { result in
 			do {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, 0)
+				selectPendingCountExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error unwrapping database result: \(e)")
 			}
 		}
+		waitForExpectations(timeout: 2)
 	}
 	
 	func testSendAllFailure() {
@@ -470,13 +497,16 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
+		let selectPendingCountExpectation = expectation(description: "Did Select Pending Count")
 		container.database.selectPendingCount { result in
 			do {
 				let statusCount = try result.get()
 				XCTAssertEqual(statusCount, statuses.count)
+				selectPendingCountExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error unwrapping database result: \(e)")
 			}
 		}
+		waitForExpectations(timeout: 2)
 	}
 }

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySendArticleStatusesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySendArticleStatusesOperationTests.swift
@@ -50,7 +50,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		let statuses = articleIds.map { SyncStatus(articleID: $0, key: .read, flag: false) }
 		
 		let insertExpectation = expectation(description: "Inserted Statuses")
-		container.database.insertStatuses(statuses) {
+		container.database.insertStatuses(statuses) { error in
+			XCTAssertNil(error)
 			insertExpectation.fulfill()
 		}
 		
@@ -74,7 +75,14 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
-		XCTAssertEqual(container.database.selectPendingCount(), 0)
+		container.database.selectPendingCount { result in
+			do {
+				let statusCount = try result.get()
+				XCTAssertEqual(statusCount, 0)
+			} catch let e {
+				XCTFail("Error unwrapping database result: \(e)")
+			}
+		}
 	}
 	
 	func testSendUnreadFailure() {
@@ -82,7 +90,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		let statuses = articleIds.map { SyncStatus(articleID: $0, key: .read, flag: false) }
 		
 		let insertExpectation = expectation(description: "Inserted Statuses")
-		container.database.insertStatuses(statuses) {
+		container.database.insertStatuses(statuses) { error in
+			XCTAssertNil(error)
 			insertExpectation.fulfill()
 		}
 		
@@ -106,7 +115,14 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
-		XCTAssertEqual(container.database.selectPendingCount(), statuses.count)
+		container.database.selectPendingCount { result in
+			do {
+				let statusCount = try result.get()
+				XCTAssertEqual(statusCount, statuses.count)
+			} catch let e {
+				XCTFail("Error unwrapping database result: \(e)")
+			}
+		}
 	}
 	
 	func testSendReadSuccess() {
@@ -114,7 +130,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		let statuses = articleIds.map { SyncStatus(articleID: $0, key: .read, flag: true) }
 		
 		let insertExpectation = expectation(description: "Inserted Statuses")
-		container.database.insertStatuses(statuses) {
+		container.database.insertStatuses(statuses) { error in
+			XCTAssertNil(error)
 			insertExpectation.fulfill()
 		}
 		
@@ -138,7 +155,14 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
-		XCTAssertEqual(container.database.selectPendingCount(), 0)
+		container.database.selectPendingCount { result in
+			do {
+				let statusCount = try result.get()
+				XCTAssertEqual(statusCount, 0)
+			} catch let e {
+				XCTFail("Error unwrapping database result: \(e)")
+			}
+		}
 	}
 	
 	func testSendReadFailure() {
@@ -146,7 +170,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		let statuses = articleIds.map { SyncStatus(articleID: $0, key: .read, flag: true) }
 		
 		let insertExpectation = expectation(description: "Inserted Statuses")
-		container.database.insertStatuses(statuses) {
+		container.database.insertStatuses(statuses) { error in
+			XCTAssertNil(error)
 			insertExpectation.fulfill()
 		}
 		
@@ -170,7 +195,14 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
-		XCTAssertEqual(container.database.selectPendingCount(), statuses.count)
+		container.database.selectPendingCount { result in
+			do {
+				let statusCount = try result.get()
+				XCTAssertEqual(statusCount, statuses.count)
+			} catch let e {
+				XCTFail("Error unwrapping database result: \(e)")
+			}
+		}
 	}
 	
 	func testSendStarredSuccess() {
@@ -178,7 +210,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		let statuses = articleIds.map { SyncStatus(articleID: $0, key: .starred, flag: true) }
 		
 		let insertExpectation = expectation(description: "Inserted Statuses")
-		container.database.insertStatuses(statuses) {
+		container.database.insertStatuses(statuses) { error in
+			XCTAssertNil(error)
 			insertExpectation.fulfill()
 		}
 		
@@ -202,7 +235,14 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
-		XCTAssertEqual(container.database.selectPendingCount(), 0)
+		container.database.selectPendingCount { result in
+			do {
+				let statusCount = try result.get()
+				XCTAssertEqual(statusCount, 0)
+			} catch let e {
+				XCTFail("Error unwrapping database result: \(e)")
+			}
+		}
 	}
 	
 	func testSendStarredFailure() {
@@ -210,7 +250,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		let statuses = articleIds.map { SyncStatus(articleID: $0, key: .starred, flag: true) }
 		
 		let insertExpectation = expectation(description: "Inserted Statuses")
-		container.database.insertStatuses(statuses) {
+		container.database.insertStatuses(statuses) { error in
+			XCTAssertNil(error)
 			insertExpectation.fulfill()
 		}
 		
@@ -234,7 +275,14 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
-		XCTAssertEqual(container.database.selectPendingCount(), statuses.count)
+		container.database.selectPendingCount { result in
+			do {
+				let statusCount = try result.get()
+				XCTAssertEqual(statusCount, statuses.count)
+			} catch let e {
+				XCTFail("Error unwrapping database result: \(e)")
+			}
+		}
 	}
 	
 	func testSendUnstarredSuccess() {
@@ -242,7 +290,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		let statuses = articleIds.map { SyncStatus(articleID: $0, key: .starred, flag: false) }
 		
 		let insertExpectation = expectation(description: "Inserted Statuses")
-		container.database.insertStatuses(statuses) {
+		container.database.insertStatuses(statuses) { error in
+			XCTAssertNil(error)
 			insertExpectation.fulfill()
 		}
 		
@@ -266,7 +315,14 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
-		XCTAssertEqual(container.database.selectPendingCount(), 0)
+		container.database.selectPendingCount { result in
+			do {
+				let statusCount = try result.get()
+				XCTAssertEqual(statusCount, 0)
+			} catch let e {
+				XCTFail("Error unwrapping database result: \(e)")
+			}
+		}
 	}
 	
 	func testSendUnstarredFailure() {
@@ -274,7 +330,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		let statuses = articleIds.map { SyncStatus(articleID: $0, key: .starred, flag: false) }
 		
 		let insertExpectation = expectation(description: "Inserted Statuses")
-		container.database.insertStatuses(statuses) {
+		container.database.insertStatuses(statuses) { error in
+			XCTAssertNil(error)
 			insertExpectation.fulfill()
 		}
 		
@@ -298,7 +355,14 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
-		XCTAssertEqual(container.database.selectPendingCount(), statuses.count)
+		container.database.selectPendingCount { result in
+			do {
+				let expectedCount = try result.get()
+				XCTAssertEqual(expectedCount, statuses.count)
+			} catch let e {
+				XCTFail("Error unwrapping database result: \(e)")
+			}
+		}
 	}
 	
 	func testSendAllSuccess() {
@@ -313,7 +377,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		}
 		
 		let insertExpectation = expectation(description: "Inserted Statuses")
-		container.database.insertStatuses(statuses) {
+		container.database.insertStatuses(statuses) { error in
+			XCTAssertNil(error)
 			insertExpectation.fulfill()
 		}
 		
@@ -346,7 +411,15 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		OperationQueue.main.addOperation(send)
 		
 		waitForExpectations(timeout: 2)
-		XCTAssertEqual(container.database.selectPendingCount(), 0)
+		
+		container.database.selectPendingCount { result in
+			do {
+				let statusCount = try result.get()
+				XCTAssertEqual(statusCount, 0)
+			} catch let e {
+				XCTFail("Error unwrapping database result: \(e)")
+			}
+		}
 	}
 	
 	func testSendAllFailure() {
@@ -361,7 +434,8 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		}
 		
 		let insertExpectation = expectation(description: "Inserted Statuses")
-		container.database.insertStatuses(statuses) {
+		container.database.insertStatuses(statuses) { error in
+			XCTAssertNil(error)
 			insertExpectation.fulfill()
 		}
 		
@@ -396,6 +470,13 @@ class FeedlySendArticleStatusesOperationTests: XCTestCase {
 		
 		waitForExpectations(timeout: 2)
 		
-		XCTAssertEqual(container.database.selectPendingCount(), statuses.count)
+		container.database.selectPendingCount { result in
+			do {
+				let statusCount = try result.get()
+				XCTAssertEqual(statusCount, statuses.count)
+			} catch let e {
+				XCTFail("Error unwrapping database result: \(e)")
+			}
+		}
 	}
 }

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySetStarredArticlesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySetStarredArticlesOperationTests.swift
@@ -55,8 +55,8 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 				XCTAssertTrue(accountArticlesIDs.isEmpty)
 				XCTAssertEqual(accountArticlesIDs, testIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking articles IDs: \(e)")
+			} catch {
+				XCTFail("Error checking articles IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -83,8 +83,8 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 				let accountArticlesIDs = try accountArticlesIDsResult.get()
 				XCTAssertEqual(accountArticlesIDs.count, testIds.count)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking articles IDs: \(e)")
+			} catch {
+				XCTFail("Error checking articles IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -111,8 +111,8 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 				let accountArticlesIDs = try accountArticlesIDsResult.get()
 				XCTAssertEqual(accountArticlesIDs.count, testIds.count)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking articles IDs: \(e)")
+			} catch {
+				XCTFail("Error checking articles IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -154,8 +154,8 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 				let remainingAccountArticlesIDs = try remainingAccountArticlesIDsResult.get()
 				XCTAssertEqual(remainingAccountArticlesIDs, remainingStarredIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking articles IDs: \(e)")
+			} catch {
+				XCTFail("Error checking articles IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -197,8 +197,8 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 				let remainingAccountArticlesIDs = try remainingAccountArticlesIDsResult.get()
 				XCTAssertEqual(remainingAccountArticlesIDs, remainingStarredIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking articles IDs: \(e)")
+			} catch {
+				XCTFail("Error checking articles IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -258,8 +258,8 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 				
 				XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking articles IDs: \(e)")
+			} catch {
+				XCTFail("Error checking articles IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -317,8 +317,8 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 				
 				XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking articles IDs: \(e)")
+			} catch {
+				XCTFail("Error checking articles IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -370,8 +370,8 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 				
 				XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking articles IDs: \(e)")
+			} catch {
+				XCTFail("Error checking articles IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -422,8 +422,8 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 				
 				XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking articles IDs: \(e)")
+			} catch {
+				XCTFail("Error checking articles IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -480,8 +480,8 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 				XCTAssertEqual(idsOfStarredArticles, someRemainingStarredIdsOfIngestedArticles)
 				
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking articles IDs: \(e)")
+			} catch {
+				XCTFail("Error checking articles IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySetStarredArticlesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySetStarredArticlesOperationTests.swift
@@ -257,6 +257,7 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 					.map { $0.articleID })
 				
 				XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
+				fetchIdsExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error checking articles IDs: \(e)")
 			}
@@ -315,6 +316,7 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 					.map { $0.articleID })
 				
 				XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
+				fetchIdsExpectation.fulfill()
 			} catch let e {
 				XCTFail("Error checking articles IDs: \(e)")
 			}

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySetStarredArticlesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySetStarredArticlesOperationTests.swift
@@ -49,10 +49,15 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { accountArticlesIDs in
-			XCTAssertTrue(accountArticlesIDs.isEmpty)
-			XCTAssertEqual(accountArticlesIDs, testIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertTrue(accountArticlesIDs.isEmpty)
+				XCTAssertEqual(accountArticlesIDs, testIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking articles IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -73,9 +78,14 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs.count, testIds.count)
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs.count, testIds.count)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking articles IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -96,9 +106,14 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs.count, testIds.count)
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs.count, testIds.count)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking articles IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -134,9 +149,14 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { remainingAccountArticlesIDs in
-			XCTAssertEqual(remainingAccountArticlesIDs, remainingStarredIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { remainingAccountArticlesIDsResult in
+			do {
+				let remainingAccountArticlesIDs = try remainingAccountArticlesIDsResult.get()
+				XCTAssertEqual(remainingAccountArticlesIDs, remainingStarredIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking articles IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -172,9 +192,14 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { remainingAccountArticlesIDs in
-			XCTAssertEqual(remainingAccountArticlesIDs, remainingStarredIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { remainingAccountArticlesIDsResult in
+			do {
+				let remainingAccountArticlesIDs = try remainingAccountArticlesIDsResult.get()
+				XCTAssertEqual(remainingAccountArticlesIDs, remainingStarredIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking articles IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -221,15 +246,20 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs, remainingStarredIds)
-			
-			let idsOfStarredArticles = Set(self.account
-				.fetchArticles(.articleIDs(remainingStarredIds))
-				.filter { $0.status.boolStatus(forKey: .starred) == true }
-				.map { $0.articleID })
-			
-			XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
+		account.fetchStarredArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs, remainingStarredIds)
+				
+				let idsOfStarredArticles = Set(try self.account
+					.fetchArticles(.articleIDs(remainingStarredIds))
+					.filter { $0.status.boolStatus(forKey: .starred) == true }
+					.map { $0.articleID })
+				
+				XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
+			} catch let e {
+				XCTFail("Error checking articles IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -274,15 +304,20 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs, remainingStarredIds)
-			
-			let idsOfStarredArticles = Set(self.account
-				.fetchArticles(.articleIDs(remainingStarredIds))
-				.filter { $0.status.boolStatus(forKey: .starred) == true }
-				.map { $0.articleID })
-			
-			XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
+		account.fetchStarredArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs, remainingStarredIds)
+				
+				let idsOfStarredArticles = Set(try self.account
+					.fetchArticles(.articleIDs(remainingStarredIds))
+					.filter { $0.status.boolStatus(forKey: .starred) == true }
+					.map { $0.articleID })
+				
+				XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
+			} catch let e {
+				XCTFail("Error checking articles IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -321,16 +356,21 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs, remainingStarredIds)
-			
-			let idsOfStarredArticles = Set(self.account
-				.fetchArticles(.articleIDs(remainingStarredIds))
-				.filter { $0.status.boolStatus(forKey: .starred) == true }
-				.map { $0.articleID })
-			
-			XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs, remainingStarredIds)
+				
+				let idsOfStarredArticles = Set(try self.account
+					.fetchArticles(.articleIDs(remainingStarredIds))
+					.filter { $0.status.boolStatus(forKey: .starred) == true }
+					.map { $0.articleID })
+				
+				XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking articles IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -368,16 +408,21 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs, remainingStarredIds)
-			
-			let idsOfStarredArticles = Set(self.account
-				.fetchArticles(.articleIDs(remainingStarredIds))
-				.filter { $0.status.boolStatus(forKey: .starred) == true }
-				.map { $0.articleID })
-			
-			XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs, remainingStarredIds)
+				
+				let idsOfStarredArticles = Set(try self.account
+					.fetchArticles(.articleIDs(remainingStarredIds))
+					.filter { $0.status.boolStatus(forKey: .starred) == true }
+					.map { $0.articleID })
+				
+				XCTAssertEqual(idsOfStarredArticles, remainingStarredIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking articles IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -418,19 +463,24 @@ class FeedlySetStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs, remainingStarredIds)
-			
-			let someTestItems = Set(someItemsAndFeeds.flatMap { $0.value })
-			let someRemainingStarredIdsOfIngestedArticles = Set(someTestItems.compactMap { $0.syncServiceID })
-			let idsOfStarredArticles = Set(self.account
-				.fetchArticles(.articleIDs(someRemainingStarredIdsOfIngestedArticles))
-				.filter { $0.status.boolStatus(forKey: .starred) == true }
-				.map { $0.articleID })
-			
-			XCTAssertEqual(idsOfStarredArticles, someRemainingStarredIdsOfIngestedArticles)
-			
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs, remainingStarredIds)
+				
+				let someTestItems = Set(someItemsAndFeeds.flatMap { $0.value })
+				let someRemainingStarredIdsOfIngestedArticles = Set(someTestItems.compactMap { $0.syncServiceID })
+				let idsOfStarredArticles = Set(try self.account
+					.fetchArticles(.articleIDs(someRemainingStarredIdsOfIngestedArticles))
+					.filter { $0.status.boolStatus(forKey: .starred) == true }
+					.map { $0.articleID })
+				
+				XCTAssertEqual(idsOfStarredArticles, someRemainingStarredIdsOfIngestedArticles)
+				
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking articles IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySetUnreadArticlesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySetUnreadArticlesOperationTests.swift
@@ -55,8 +55,8 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 				XCTAssertTrue(accountArticlesIDs.isEmpty)
 				XCTAssertEqual(accountArticlesIDs.count, testIds.count)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking account articles IDs result: \(e)")
+			} catch {
+				XCTFail("Error checking account articles IDs result: \(error)")
 			}
 		}
 		
@@ -84,8 +84,8 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 				let accountArticlesIDs = try accountArticlesIDsResult.get()
 				XCTAssertEqual(accountArticlesIDs.count, testIds.count)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking account articles IDs result: \(e)")
+			} catch {
+				XCTFail("Error checking account articles IDs result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -112,8 +112,8 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 				let accountArticlesIDs = try accountArticlesIDsResult.get()
 				XCTAssertEqual(accountArticlesIDs.count, testIds.count)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking account articles IDs result: \(e)")
+			} catch {
+				XCTFail("Error checking account articles IDs result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -155,8 +155,8 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 				let remainingAccountArticlesIDs = try remainingAccountArticlesIDsResult.get()
 				XCTAssertEqual(remainingAccountArticlesIDs, remainingUnreadIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking account articles IDs result: \(e)")
+			} catch {
+				XCTFail("Error checking account articles IDs result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -198,8 +198,8 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 				let remainingAccountArticlesIDs = try remainingAccountArticlesIDsResult.get()
 				XCTAssertEqual(remainingAccountArticlesIDs, remainingUnreadIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking account articles IDs result: \(e)")
+			} catch {
+				XCTFail("Error checking account articles IDs result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -258,8 +258,8 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 				
 				XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking account articles IDs result: \(e)")
+			} catch {
+				XCTFail("Error checking account articles IDs result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -317,8 +317,8 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 				
 				XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking account articles IDs result: \(e)")
+			} catch {
+				XCTFail("Error checking account articles IDs result: \(error)")
 			}
 		}
 	}
@@ -369,8 +369,8 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 				
 				XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking account articles IDs result: \(e)")
+			} catch {
+				XCTFail("Error checking account articles IDs result: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -421,8 +421,8 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 				
 				XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking account articles IDs result: \(e)")
+			} catch {
+				XCTFail("Error checking account articles IDs result: \(error)")
 			}
 		}
 	}
@@ -477,8 +477,8 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 				
 				XCTAssertEqual(idsOfUnreadArticles, someRemainingUnreadIdsOfIngestedArticles)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking account articles IDs result: \(e)")
+			} catch {
+				XCTFail("Error checking account articles IDs result: \(error)")
 			}
 		}
 	}

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySetUnreadArticlesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySetUnreadArticlesOperationTests.swift
@@ -49,10 +49,15 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetched Articles Ids")
-		account.fetchUnreadArticleIDs { accountArticlesIDs in
-			XCTAssertTrue(accountArticlesIDs.isEmpty)
-			XCTAssertEqual(accountArticlesIDs.count, testIds.count)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertTrue(accountArticlesIDs.isEmpty)
+				XCTAssertEqual(accountArticlesIDs.count, testIds.count)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking account articles IDs result: \(e)")
+			}
 		}
 		
 		waitForExpectations(timeout: 2)
@@ -74,9 +79,14 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetched Articles Ids")
-		account.fetchUnreadArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs.count, testIds.count)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs.count, testIds.count)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking account articles IDs result: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -97,9 +107,14 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetched Articles Ids")
-		account.fetchUnreadArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs.count, testIds.count)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs.count, testIds.count)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking account articles IDs result: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -135,9 +150,14 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetched Articles Ids")
-		account.fetchUnreadArticleIDs { remainingAccountArticlesIDs in
-			XCTAssertEqual(remainingAccountArticlesIDs, remainingUnreadIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { remainingAccountArticlesIDsResult in
+			do {
+				let remainingAccountArticlesIDs = try remainingAccountArticlesIDsResult.get()
+				XCTAssertEqual(remainingAccountArticlesIDs, remainingUnreadIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking account articles IDs result: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -173,9 +193,14 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetched Articles Ids")
-		account.fetchUnreadArticleIDs { remainingAccountArticlesIDs in
-			XCTAssertEqual(remainingAccountArticlesIDs, remainingUnreadIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { remainingAccountArticlesIDsResult in
+			do {
+				let remainingAccountArticlesIDs = try remainingAccountArticlesIDsResult.get()
+				XCTAssertEqual(remainingAccountArticlesIDs, remainingUnreadIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking account articles IDs result: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -222,15 +247,20 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetched Articles Ids")
-		account.fetchUnreadArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs, remainingUnreadIds)
-			let idsOfUnreadArticles = Set(self.account
-				.fetchArticles(.articleIDs(remainingUnreadIds))
-				.filter { $0.status.boolStatus(forKey: .read) == false }
-				.map { $0.articleID })
-			
-			XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs, remainingUnreadIds)
+				let idsOfUnreadArticles = Set(try self.account
+					.fetchArticles(.articleIDs(remainingUnreadIds))
+					.filter { $0.status.boolStatus(forKey: .read) == false }
+					.map { $0.articleID })
+				
+				XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking account articles IDs result: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -275,16 +305,21 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetched Articles Ids")
-		account.fetchUnreadArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs, remainingUnreadIds)
-			
-			let idsOfUnreadArticles = Set(self.account
-				.fetchArticles(.articleIDs(remainingUnreadIds))
-				.filter { $0.status.boolStatus(forKey: .read) == false }
-				.map { $0.articleID })
-			
-			XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs, remainingUnreadIds)
+				
+				let idsOfUnreadArticles = Set(try self.account
+					.fetchArticles(.articleIDs(remainingUnreadIds))
+					.filter { $0.status.boolStatus(forKey: .read) == false }
+					.map { $0.articleID })
+				
+				XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking account articles IDs result: \(e)")
+			}
 		}
 	}
 	
@@ -322,16 +357,21 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetched Articles Ids")
-		account.fetchUnreadArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs, remainingUnreadIds)
-			
-			let idsOfUnreadArticles = Set(self.account
-				.fetchArticles(.articleIDs(remainingUnreadIds))
-				.filter { $0.status.boolStatus(forKey: .read) == false }
-				.map { $0.articleID })
-			
-			XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs, remainingUnreadIds)
+				
+				let idsOfUnreadArticles = Set(try self.account
+					.fetchArticles(.articleIDs(remainingUnreadIds))
+					.filter { $0.status.boolStatus(forKey: .read) == false }
+					.map { $0.articleID })
+				
+				XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking account articles IDs result: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -369,16 +409,21 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetched Articles Ids")
-		account.fetchUnreadArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs, remainingUnreadIds)
-			
-			let idsOfUnreadArticles = Set(self.account
-				.fetchArticles(.articleIDs(remainingUnreadIds))
-				.filter { $0.status.boolStatus(forKey: .read) == false }
-				.map { $0.articleID })
-			
-			XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs, remainingUnreadIds)
+				
+				let idsOfUnreadArticles = Set(try self.account
+					.fetchArticles(.articleIDs(remainingUnreadIds))
+					.filter { $0.status.boolStatus(forKey: .read) == false }
+					.map { $0.articleID })
+				
+				XCTAssertEqual(idsOfUnreadArticles, remainingUnreadIds)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking account articles IDs result: \(e)")
+			}
 		}
 	}
 	
@@ -418,18 +463,23 @@ class FeedlySetUnreadArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetched Articles Ids")
-		account.fetchUnreadArticleIDs { accountArticlesIDs in
-			XCTAssertEqual(accountArticlesIDs, remainingUnreadIds)
-			
-			let someTestItems = Set(someItemsAndFeeds.flatMap { $0.value })
-			let someRemainingUnreadIdsOfIngestedArticles = Set(someTestItems.compactMap { $0.syncServiceID })
-			let idsOfUnreadArticles = Set(self.account
-				.fetchArticles(.articleIDs(someRemainingUnreadIdsOfIngestedArticles))
-				.filter { $0.status.boolStatus(forKey: .read) == false }
-				.map { $0.articleID })
-			
-			XCTAssertEqual(idsOfUnreadArticles, someRemainingUnreadIdsOfIngestedArticles)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { accountArticlesIDsResult in
+			do {
+				let accountArticlesIDs = try accountArticlesIDsResult.get()
+				XCTAssertEqual(accountArticlesIDs, remainingUnreadIds)
+				
+				let someTestItems = Set(someItemsAndFeeds.flatMap { $0.value })
+				let someRemainingUnreadIdsOfIngestedArticles = Set(someTestItems.compactMap { $0.syncServiceID })
+				let idsOfUnreadArticles = Set(try self.account
+					.fetchArticles(.articleIDs(someRemainingUnreadIdsOfIngestedArticles))
+					.filter { $0.status.boolStatus(forKey: .read) == false }
+					.map { $0.articleID })
+				
+				XCTAssertEqual(idsOfUnreadArticles, someRemainingUnreadIdsOfIngestedArticles)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking account articles IDs result: \(e)")
+			}
 		}
 	}
 }

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySyncAllOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySyncAllOperationTests.swift
@@ -114,18 +114,18 @@ class FeedlySyncAllOperationTests: XCTestCase {
 		return caller
 	}()
 	
-	func testSyncing() {
+	func testSyncing() throws {
 		performInitialSync()
-		verifyInitialSync()
+		try verifyInitialSync()
 		
 		performChangeStatuses()
-		verifyChangeStatuses()
+		try verifyChangeStatuses()
 		
 		performChangeStatusesAgain()
-		verifyChangeStatusesAgain()
+		try verifyChangeStatusesAgain()
 		
 		performAddFeedsAndFolders()
-		verifyAddFeedsAndFolders()
+		try verifyAddFeedsAndFolders()
 	}
 	
 	// MARK: 1 - Initial Sync
@@ -166,15 +166,15 @@ class FeedlySyncAllOperationTests: XCTestCase {
 		loadMockData(inSubdirectoryNamed: "feedly-1-initial")
 	}
 	
-	func verifyInitialSync() {
+	func verifyInitialSync() throws {
 		let subdirectory = "feedly-1-initial"
 		support.checkFoldersAndFeeds(in: account, againstCollectionsAndFeedsInJSONNamed: "collections", subdirectory: subdirectory)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all", subdirectory: subdirectory)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all@MTZkOTdkZWQ1NzM6NTE2OjUzYjgyNmEy", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all@MTZkOTdkZWQ1NzM6NTE2OjUzYjgyNmEy", subdirectory: subdirectory)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds", subdirectory: subdirectory, testCase: self)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds@MTZkOTRhOTNhZTQ6MzExOjUzYjgyNmEy", subdirectory: subdirectory, testCase: self)
 		support.checkStarredStatuses(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory, testCase: self)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory)
 	}
 	
 	// MARK: 2 - Change Statuses
@@ -183,14 +183,14 @@ class FeedlySyncAllOperationTests: XCTestCase {
 		loadMockData(inSubdirectoryNamed: "feedly-2-changestatuses")
 	}
 	
-	func verifyChangeStatuses() {
+	func verifyChangeStatuses() throws {
 		let subdirectory = "feedly-2-changestatuses"
 		support.checkFoldersAndFeeds(in: account, againstCollectionsAndFeedsInJSONNamed: "collections", subdirectory: subdirectory)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all", subdirectory: subdirectory)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds", subdirectory: subdirectory, testCase: self)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds@MTZkOTJkNjIwM2Q6MTEzYjpkNDUwNjA3MQ==", subdirectory: subdirectory, testCase: self)
 		support.checkStarredStatuses(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory, testCase: self)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory)
 	}
 	
 	// MARK: 3 - Change Statuses Again
@@ -199,14 +199,14 @@ class FeedlySyncAllOperationTests: XCTestCase {
 		loadMockData(inSubdirectoryNamed: "feedly-3-changestatusesagain")
 	}
 	
-	func verifyChangeStatusesAgain() {
+	func verifyChangeStatusesAgain() throws {
 		let subdirectory = "feedly-3-changestatusesagain"
 		support.checkFoldersAndFeeds(in: account, againstCollectionsAndFeedsInJSONNamed: "collections", subdirectory: subdirectory)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all", subdirectory: subdirectory)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds", subdirectory: subdirectory, testCase: self)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds@MTZkOGRlMjVmM2M6M2YyOmQ0NTA2MDcx", subdirectory: subdirectory, testCase: self)
 		support.checkStarredStatuses(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory, testCase: self)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory)
 	}
 	
 	// MARK: 4 - Add Feeds and Folders
@@ -215,14 +215,14 @@ class FeedlySyncAllOperationTests: XCTestCase {
 		loadMockData(inSubdirectoryNamed: "feedly-4-addfeedsandfolders")
 	}
 	
-	func verifyAddFeedsAndFolders() {
+	func verifyAddFeedsAndFolders() throws {
 		let subdirectory = "feedly-4-addfeedsandfolders"
 		support.checkFoldersAndFeeds(in: account, againstCollectionsAndFeedsInJSONNamed: "collections", subdirectory: subdirectory)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all", subdirectory: subdirectory)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds", subdirectory: subdirectory, testCase: self)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds@MTZkOTE3YTRlMzQ6YWZjOmQ0NTA2MDcx", subdirectory: subdirectory, testCase: self)
 		support.checkStarredStatuses(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory, testCase: self)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory)
 	}
 	
 	// MARK: 5 - Remove Feeds and Folders
@@ -231,14 +231,14 @@ class FeedlySyncAllOperationTests: XCTestCase {
 		loadMockData(inSubdirectoryNamed: "feedly-5-removefeedsandfolders")
 	}
 	
-	func verifyRemoveFeedsAndFolders() {
+	func verifyRemoveFeedsAndFolders() throws {
 		let subdirectory = "feedly-5-removefeedsandfolders"
 		support.checkFoldersAndFeeds(in: account, againstCollectionsAndFeedsInJSONNamed: "collections", subdirectory: subdirectory)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "global.all", subdirectory: subdirectory)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds", subdirectory: subdirectory, testCase: self)
 		support.checkUnreadStatuses(in: account, againstIdsInStreamInJSONNamed: "unreadIds@MTZkOGRlMjVmM2M6M2YxOmQ0NTA2MDcx", subdirectory: subdirectory, testCase: self)
 		support.checkStarredStatuses(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory, testCase: self)
-		support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory)
+		try support.checkArticles(in: account, againstItemsInStreamInJSONNamed: "starred", subdirectory: subdirectory)
 	}
 	
 	// MARK: Downloading Test Data

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySyncStarredArticlesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySyncStarredArticlesOperationTests.swift
@@ -56,21 +56,26 @@ class FeedlySyncStarredArticlesOperationTests: XCTestCase {
 		
 		let expectedArticleIds = Set(items.map { $0.id })
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { starredArticleIds in
-			let missingIds = expectedArticleIds.subtracting(starredArticleIds)
-			XCTAssertTrue(missingIds.isEmpty, "These article ids were not marked as starred.")
-			
-			// Fetch articles directly because account.fetchArticles(.starred) fetches starred articles for feeds subscribed to.
-			let expectedArticles = self.account.fetchArticles(.articleIDs(expectedArticleIds))
-			XCTAssertEqual(expectedArticles.count, expectedArticleIds.count, "Did not fetch all the articles.")
-			
-			let starredArticles = self.account.fetchArticles(.articleIDs(starredArticleIds))
-			XCTAssertEqual(expectedArticleIds.count, expectedArticles.count)
-			let missingArticles = expectedArticles.subtracting(starredArticles)
-			XCTAssertTrue(missingArticles.isEmpty, "These articles should be starred and fetched.")
-			XCTAssertEqual(expectedArticles, starredArticles)
-			
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { starredArticleIdsResult in
+			do {
+				let starredArticleIds = try starredArticleIdsResult.get()
+				let missingIds = expectedArticleIds.subtracting(starredArticleIds)
+				XCTAssertTrue(missingIds.isEmpty, "These article ids were not marked as starred.")
+				
+				// Fetch articles directly because account.fetchArticles(.starred) fetches starred articles for feeds subscribed to.
+				let expectedArticles = try self.account.fetchArticles(.articleIDs(expectedArticleIds))
+				XCTAssertEqual(expectedArticles.count, expectedArticleIds.count, "Did not fetch all the articles.")
+				
+				let starredArticles = try self.account.fetchArticles(.articleIDs(starredArticleIds))
+				XCTAssertEqual(expectedArticleIds.count, expectedArticles.count)
+				let missingArticles = expectedArticles.subtracting(starredArticles)
+				XCTAssertTrue(missingArticles.isEmpty, "These articles should be starred and fetched.")
+				XCTAssertEqual(expectedArticles, starredArticles)
+				
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking starred article IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -104,9 +109,14 @@ class FeedlySyncStarredArticlesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { starredArticleIds in
-			XCTAssertTrue(starredArticleIds.isEmpty)
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { starredArticleIdsResult in
+			do {
+				let starredArticleIds = try starredArticleIdsResult.get()
+				XCTAssertTrue(starredArticleIds.isEmpty)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking starred article IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -153,21 +163,26 @@ class FeedlySyncStarredArticlesOperationTests: XCTestCase {
 		// Find articles inserted.
 		let expectedArticleIds = Set(service.pages.values.map { $0.items }.flatMap { $0 }.map { $0.id })
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchStarredArticleIDs { starredArticleIds in
-			let missingIds = expectedArticleIds.subtracting(starredArticleIds)
-			XCTAssertTrue(missingIds.isEmpty, "These article ids were not marked as starred.")
-			
-			// Fetch articles directly because account.fetchArticles(.starred) fetches starred articles for feeds subscribed to.
-			let expectedArticles = self.account.fetchArticles(.articleIDs(expectedArticleIds))
-			XCTAssertEqual(expectedArticles.count, expectedArticleIds.count, "Did not fetch all the articles.")
-			
-			let starredArticles = self.account.fetchArticles(.articleIDs(starredArticleIds))
-			XCTAssertEqual(expectedArticleIds.count, expectedArticles.count)
-			let missingArticles = expectedArticles.subtracting(starredArticles)
-			XCTAssertTrue(missingArticles.isEmpty, "These articles should be starred and fetched.")
-			XCTAssertEqual(expectedArticles, starredArticles)
-			
-			fetchIdsExpectation.fulfill()
+		account.fetchStarredArticleIDs { starredArticleIdsResult in
+			do {
+				let starredArticleIds = try starredArticleIdsResult.get()
+				let missingIds = expectedArticleIds.subtracting(starredArticleIds)
+				XCTAssertTrue(missingIds.isEmpty, "These article ids were not marked as starred.")
+				
+				// Fetch articles directly because account.fetchArticles(.starred) fetches starred articles for feeds subscribed to.
+				let expectedArticles = try self.account.fetchArticles(.articleIDs(expectedArticleIds))
+				XCTAssertEqual(expectedArticles.count, expectedArticleIds.count, "Did not fetch all the articles.")
+				
+				let starredArticles = try self.account.fetchArticles(.articleIDs(starredArticleIds))
+				XCTAssertEqual(expectedArticleIds.count, expectedArticles.count)
+				let missingArticles = expectedArticles.subtracting(starredArticles)
+				XCTAssertTrue(missingArticles.isEmpty, "These articles should be starred and fetched.")
+				XCTAssertEqual(expectedArticles, starredArticles)
+				
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking starred article IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySyncStarredArticlesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySyncStarredArticlesOperationTests.swift
@@ -73,8 +73,8 @@ class FeedlySyncStarredArticlesOperationTests: XCTestCase {
 				XCTAssertEqual(expectedArticles, starredArticles)
 				
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking starred article IDs: \(e)")
+			} catch {
+				XCTFail("Error checking starred article IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -114,8 +114,8 @@ class FeedlySyncStarredArticlesOperationTests: XCTestCase {
 				let starredArticleIds = try starredArticleIdsResult.get()
 				XCTAssertTrue(starredArticleIds.isEmpty)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking starred article IDs: \(e)")
+			} catch {
+				XCTFail("Error checking starred article IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -180,8 +180,8 @@ class FeedlySyncStarredArticlesOperationTests: XCTestCase {
 				XCTAssertEqual(expectedArticles, starredArticles)
 				
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking starred article IDs: \(e)")
+			} catch {
+				XCTFail("Error checking starred article IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySyncStreamContentsOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySyncStreamContentsOperationTests.swift
@@ -26,7 +26,7 @@ class FeedlySyncStreamContentsOperationTests: XCTestCase {
 		super.tearDown()
 	}
 	
-	func testIngestsOnePageSuccess() {
+	func testIngestsOnePageSuccess() throws {
 		let service = TestGetStreamContentsService()
 		let resource = FeedlyCategoryResourceId(id: "user/1234/category/5678")
 		let newerThan: Date? = Date(timeIntervalSinceReferenceDate: 0)
@@ -56,7 +56,7 @@ class FeedlySyncStreamContentsOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let expectedArticleIds = Set(items.map { $0.id })
-		let expectedArticles = account.fetchArticles(.articleIDs(expectedArticleIds))
+		let expectedArticles = try account.fetchArticles(.articleIDs(expectedArticleIds))
 		XCTAssertEqual(expectedArticles.count, expectedArticleIds.count, "Did not fetch all the articles.")
 	}
 	
@@ -90,7 +90,7 @@ class FeedlySyncStreamContentsOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 	}
 	
-	func testIngestsManyPagesSuccess() {
+	func testIngestsManyPagesSuccess() throws {
 		let service = TestGetPagedStreamContentsService()
 		let resource = FeedlyCategoryResourceId(id: "user/1234/category/5678")
 		let newerThan: Date? = Date(timeIntervalSinceReferenceDate: 0)
@@ -132,7 +132,7 @@ class FeedlySyncStreamContentsOperationTests: XCTestCase {
 		
 		// Find articles inserted.
 		let articleIds = Set(service.pages.values.map { $0.items }.flatMap { $0 }.map { $0.id })
-		let articles = account.fetchArticles(.articleIDs(articleIds))
+		let articles = try account.fetchArticles(.articleIDs(articleIds))
 		XCTAssertEqual(articleIds.count, articles.count)
 	}
 }

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySyncUnreadStatusesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySyncUnreadStatusesOperationTests.swift
@@ -62,8 +62,8 @@ class FeedlySyncUnreadStatusesOperationTests: XCTestCase {
 				let missingIds = expectedArticleIds.subtracting(unreadArticleIds)
 				XCTAssertTrue(missingIds.isEmpty, "These article ids were not marked as unread.")
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking unread article IDs: \(e)")
+			} catch {
+				XCTFail("Error checking unread article IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -103,8 +103,8 @@ class FeedlySyncUnreadStatusesOperationTests: XCTestCase {
 				let unreadArticleIds = try unreadArticleIdsResult.get()
 				XCTAssertTrue(unreadArticleIds.isEmpty)
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking unread article IDs: \(e)")
+			} catch {
+				XCTFail("Error checking unread article IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)
@@ -158,8 +158,8 @@ class FeedlySyncUnreadStatusesOperationTests: XCTestCase {
 				let missingIds = expectedArticleIds.subtracting(unreadArticleIds)
 				XCTAssertTrue(missingIds.isEmpty, "These article ids were not marked as unread.")
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error checking unread article IDs: \(e)")
+			} catch {
+				XCTFail("Error checking unread article IDs: \(error)")
 			}
 		}
 		waitForExpectations(timeout: 2)

--- a/Frameworks/Account/AccountTests/Feedly/FeedlySyncUnreadStatusesOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySyncUnreadStatusesOperationTests.swift
@@ -56,10 +56,15 @@ class FeedlySyncUnreadStatusesOperationTests: XCTestCase {
 		
 		let expectedArticleIds = Set(ids)
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchUnreadArticleIDs { unreadArticleIds in
-			let missingIds = expectedArticleIds.subtracting(unreadArticleIds)
-			XCTAssertTrue(missingIds.isEmpty, "These article ids were not marked as unread.")
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { unreadArticleIdsResult in
+			do {
+				let unreadArticleIds = try unreadArticleIdsResult.get()
+				let missingIds = expectedArticleIds.subtracting(unreadArticleIds)
+				XCTAssertTrue(missingIds.isEmpty, "These article ids were not marked as unread.")
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking unread article IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -93,9 +98,14 @@ class FeedlySyncUnreadStatusesOperationTests: XCTestCase {
 		waitForExpectations(timeout: 2)
 		
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchUnreadArticleIDs { unreadArticleIds in
-			XCTAssertTrue(unreadArticleIds.isEmpty)
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { unreadArticleIdsResult in
+			do {
+				let unreadArticleIds = try unreadArticleIdsResult.get()
+				XCTAssertTrue(unreadArticleIds.isEmpty)
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking unread article IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}
@@ -142,10 +152,15 @@ class FeedlySyncUnreadStatusesOperationTests: XCTestCase {
 		// Find statuses inserted.
 		let expectedArticleIds = Set(service.pages.values.map { $0.ids }.flatMap { $0 })
 		let fetchIdsExpectation = expectation(description: "Fetch Article Ids")
-		account.fetchUnreadArticleIDs { unreadArticleIds in
-			let missingIds = expectedArticleIds.subtracting(unreadArticleIds)
-			XCTAssertTrue(missingIds.isEmpty, "These article ids were not marked as unread.")
-			fetchIdsExpectation.fulfill()
+		account.fetchUnreadArticleIDs { unreadArticleIdsResult in
+			do {
+				let unreadArticleIds = try unreadArticleIdsResult.get()
+				let missingIds = expectedArticleIds.subtracting(unreadArticleIds)
+				XCTAssertTrue(missingIds.isEmpty, "These article ids were not marked as unread.")
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error checking unread article IDs: \(e)")
+			}
 		}
 		waitForExpectations(timeout: 2)
 	}

--- a/Frameworks/Account/AccountTests/Feedly/FeedlyTestSupport.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyTestSupport.swift
@@ -141,13 +141,13 @@ class FeedlyTestSupport {
 		XCTAssertTrue(missingFeedIds.isEmpty, "Feeds with these ids were not found in the \"\(label)\" folder.")
 	}
 	
-	func checkArticles(in account: Account, againstItemsInStreamInJSONNamed name: String, subdirectory: String? = nil) {
+	func checkArticles(in account: Account, againstItemsInStreamInJSONNamed name: String, subdirectory: String? = nil) throws {
 		let stream = testJSON(named: name, subdirectory: subdirectory) as! [String:Any]
-		checkArticles(in: account, againstItemsInStreamInJSONPayload: stream)
+		try checkArticles(in: account, againstItemsInStreamInJSONPayload: stream)
 	}
 	
-	func checkArticles(in account: Account, againstItemsInStreamInJSONPayload stream: [String: Any]) {
-		checkArticles(in: account, correspondToStreamItemsIn: stream)
+	func checkArticles(in account: Account, againstItemsInStreamInJSONPayload stream: [String: Any]) throws {
+		try checkArticles(in: account, correspondToStreamItemsIn: stream)
 	}
 	
 	private struct ArticleItem {
@@ -188,13 +188,13 @@ class FeedlyTestSupport {
 	}
 	
 	/// Awkwardly titled to make it clear the JSON given is from a stream response.
-	func checkArticles(in testAccount: Account, correspondToStreamItemsIn stream: [String: Any]) {
+	func checkArticles(in testAccount: Account, correspondToStreamItemsIn stream: [String: Any]) throws {
 
 		let items = stream["items"] as! [[String: Any]]
 		let articleItems = items.map { ArticleItem(item: $0) }
 		let itemIds = Set(articleItems.map { $0.id })
 		
-		let articles = testAccount.fetchArticles(.articleIDs(itemIds))
+		let articles = try testAccount.fetchArticles(.articleIDs(itemIds))
 		let articleIds = Set(articles.map { $0.articleID })
 		
 		let missing = itemIds.subtracting(articleIds)

--- a/Frameworks/Account/AccountTests/Feedly/FeedlyTestSupport.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyTestSupport.swift
@@ -220,12 +220,17 @@ class FeedlyTestSupport {
 	func checkUnreadStatuses(in testAccount: Account, correspondToIdsInJSONPayload streamIds: [String: Any], testCase: XCTestCase) {
 		let ids = Set(streamIds["ids"] as! [String])
 		let fetchIdsExpectation = testCase.expectation(description: "Fetch Article Ids")
-		testAccount.fetchUnreadArticleIDs { articleIds in
-			// Unread statuses can be paged from Feedly.
-			// Instead of joining test data, the best we can do is
-			// make sure that these ids are marked as unread (a subset of the total).
-			XCTAssertTrue(ids.isSubset(of: articleIds), "Some articles in `ids` are not marked as unread.")
-			fetchIdsExpectation.fulfill()
+		testAccount.fetchUnreadArticleIDs { articleIdsResult in
+			do {
+				let articleIds = try articleIdsResult.get()
+				// Unread statuses can be paged from Feedly.
+				// Instead of joining test data, the best we can do is
+				// make sure that these ids are marked as unread (a subset of the total).
+				XCTAssertTrue(ids.isSubset(of: articleIds), "Some articles in `ids` are not marked as unread.")
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error unwrapping article IDs: \(e)")
+			}
 		}
 		testCase.wait(for: [fetchIdsExpectation], timeout: 2)
 	}
@@ -239,12 +244,17 @@ class FeedlyTestSupport {
 		let items = stream["items"] as! [[String: Any]]
 		let ids = Set(items.map { $0["id"] as! String })
 		let fetchIdsExpectation = testCase.expectation(description: "Fetch Article Ids")
-		testAccount.fetchStarredArticleIDs { articleIds in
-			// Starred articles can be paged from Feedly.
-			// Instead of joining test data, the best we can do is
-			// make sure that these articles are marked as starred (a subset of the total).
-			XCTAssertTrue(ids.isSubset(of: articleIds), "Some articles in `ids` are not marked as starred.")
-			fetchIdsExpectation.fulfill()
+		testAccount.fetchStarredArticleIDs { articleIdsResult in
+			do {
+				let articleIds = try articleIdsResult.get()
+				// Starred articles can be paged from Feedly.
+				// Instead of joining test data, the best we can do is
+				// make sure that these articles are marked as starred (a subset of the total).
+				XCTAssertTrue(ids.isSubset(of: articleIds), "Some articles in `ids` are not marked as starred.")
+				fetchIdsExpectation.fulfill()
+			} catch let e {
+				XCTFail("Error unwrapping article IDs: \(e)")
+			}
 		}
 		testCase.wait(for: [fetchIdsExpectation], timeout: 2)
 	}

--- a/Frameworks/Account/AccountTests/Feedly/FeedlyTestSupport.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyTestSupport.swift
@@ -228,8 +228,8 @@ class FeedlyTestSupport {
 				// make sure that these ids are marked as unread (a subset of the total).
 				XCTAssertTrue(ids.isSubset(of: articleIds), "Some articles in `ids` are not marked as unread.")
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping article IDs: \(e)")
+			} catch {
+				XCTFail("Error unwrapping article IDs: \(error)")
 			}
 		}
 		testCase.wait(for: [fetchIdsExpectation], timeout: 2)
@@ -252,8 +252,8 @@ class FeedlyTestSupport {
 				// make sure that these articles are marked as starred (a subset of the total).
 				XCTAssertTrue(ids.isSubset(of: articleIds), "Some articles in `ids` are not marked as starred.")
 				fetchIdsExpectation.fulfill()
-			} catch let e {
-				XCTFail("Error unwrapping article IDs: \(e)")
+			} catch {
+				XCTFail("Error unwrapping article IDs: \(error)")
 			}
 		}
 		testCase.wait(for: [fetchIdsExpectation], timeout: 2)

--- a/Frameworks/Account/AccountTests/Feedly/FeedlyUpdateAccountFeedsWithItemsOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyUpdateAccountFeedsWithItemsOperationTests.swift
@@ -32,7 +32,7 @@ class FeedlyUpdateAccountFeedsWithItemsOperationTests: XCTestCase {
 		var parsedItemsKeyedByFeedId: [String: Set<ParsedItem>]
 	}
 	
-	func testUpdateAccountWithEmptyItems() {
+	func testUpdateAccountWithEmptyItems() throws {
 		let testItems = support.makeParsedItemTestDataFor(numberOfFeeds: 0, numberOfItemsInFeeds: 0)
 		let resource = FeedlyCategoryResourceId(id: "user/12345/category/6789")
 		let provider = TestItemsByFeedProvider(providerName: resource.id, parsedItemsKeyedByFeedId: testItems)
@@ -52,11 +52,11 @@ class FeedlyUpdateAccountFeedsWithItemsOperationTests: XCTestCase {
 		let articleIds = Set(entries.compactMap { $0.syncServiceID })
 		XCTAssertEqual(articleIds.count, entries.count, "Not every item has a value for \(\ParsedItem.syncServiceID).")
 		
-		let accountArticles = account.fetchArticles(.articleIDs(articleIds))
+		let accountArticles = try account.fetchArticles(.articleIDs(articleIds))
 		XCTAssertTrue(accountArticles.isEmpty)
 	}
 	
-	func testUpdateAccountWithOneItem() {
+	func testUpdateAccountWithOneItem() throws {
 		let testItems = support.makeParsedItemTestDataFor(numberOfFeeds: 1, numberOfItemsInFeeds: 1)
 		let resource = FeedlyCategoryResourceId(id: "user/12345/category/6789")
 		let provider = TestItemsByFeedProvider(providerName: resource.id, parsedItemsKeyedByFeedId: testItems)
@@ -76,7 +76,7 @@ class FeedlyUpdateAccountFeedsWithItemsOperationTests: XCTestCase {
 		let articleIds = Set(entries.compactMap { $0.syncServiceID })
 		XCTAssertEqual(articleIds.count, entries.count, "Not every item has a value for \(\ParsedItem.syncServiceID).")
 		
-		let accountArticles = account.fetchArticles(.articleIDs(articleIds))
+		let accountArticles = try account.fetchArticles(.articleIDs(articleIds))
 		XCTAssertTrue(accountArticles.count == entries.count)
 		
 		let accountArticleIds = Set(accountArticles.map { $0.articleID })
@@ -84,7 +84,7 @@ class FeedlyUpdateAccountFeedsWithItemsOperationTests: XCTestCase {
 		XCTAssertTrue(missingIds.isEmpty)
 	}
 	
-	func testUpdateAccountWithManyItems() {
+	func testUpdateAccountWithManyItems() throws {
 		let testItems = support.makeParsedItemTestDataFor(numberOfFeeds: 100, numberOfItemsInFeeds: 100)
 		let resource = FeedlyCategoryResourceId(id: "user/12345/category/6789")
 		let provider = TestItemsByFeedProvider(providerName: resource.id, parsedItemsKeyedByFeedId: testItems)
@@ -104,7 +104,7 @@ class FeedlyUpdateAccountFeedsWithItemsOperationTests: XCTestCase {
 		let articleIds = Set(entries.compactMap { $0.syncServiceID })
 		XCTAssertEqual(articleIds.count, entries.count, "Not every item has a value for \(\ParsedItem.syncServiceID).")
 		
-		let accountArticles = account.fetchArticles(.articleIDs(articleIds))
+		let accountArticles = try account.fetchArticles(.articleIDs(articleIds))
 		XCTAssertTrue(accountArticles.count == entries.count)
 		
 		let accountArticleIds = Set(accountArticles.map { $0.articleID })
@@ -112,7 +112,7 @@ class FeedlyUpdateAccountFeedsWithItemsOperationTests: XCTestCase {
 		XCTAssertTrue(missingIds.isEmpty)
 	}
 	
-	func testCancelUpdateAccount() {
+	func testCancelUpdateAccount() throws {
 		let testItems = support.makeParsedItemTestDataFor(numberOfFeeds: 1, numberOfItemsInFeeds: 1)
 		let resource = FeedlyCategoryResourceId(id: "user/12345/category/6789")
 		let provider = TestItemsByFeedProvider(providerName: resource.id, parsedItemsKeyedByFeedId: testItems)
@@ -134,7 +134,7 @@ class FeedlyUpdateAccountFeedsWithItemsOperationTests: XCTestCase {
 		let articleIds = Set(entries.compactMap { $0.syncServiceID })
 		XCTAssertEqual(articleIds.count, entries.count, "Not every item has a value for \(\ParsedItem.syncServiceID).")
 		
-		let accountArticles = account.fetchArticles(.articleIDs(articleIds))
+		let accountArticles = try account.fetchArticles(.articleIDs(articleIds))
 		XCTAssertTrue(accountArticles.isEmpty)
 	}
 }


### PR DESCRIPTION
This PR updates unit tests in AccountTests, primarily against the Feedly service, to accommodate new async syntax in Account.framework. A more detailed description of the issue is in #1501. After these changes, the tests build for me; I have not run them, due to not yet having a Catalina system at hand.