### PR TITLE
Models the feed website url of feedly articles as an optional…

### DIFF
--- a/Frameworks/Account/Feedly/Models/FeedlyOrigin.swift
+++ b/Frameworks/Account/Feedly/Models/FeedlyOrigin.swift
@@ -11,5 +11,5 @@ import Foundation
 struct FeedlyOrigin: Decodable {
 	var title: String?
 	var streamId: String?
-	var htmlUrl: String
+	var htmlUrl: String?
 }


### PR DESCRIPTION
…since it seems the Feedly API will not always provide one. Issue #1449.