### PR TITLE
Indicate FeedlyOperation is asychronous.

### DIFF
--- a/Frameworks/Account/Feedly/Models/FeedlyOrigin.swift
+++ b/Frameworks/Account/Feedly/Models/FeedlyOrigin.swift
@@ -11,5 +11,5 @@ import Foundation
 struct FeedlyOrigin: Decodable {
 	var title: String?
 	var streamId: String?
-	var htmlUrl: String
+	var htmlUrl: String?
 }

--- a/Frameworks/Account/Feedly/Operations/FeedlyOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyOperation.swift
@@ -29,6 +29,10 @@ class FeedlyOperation: Operation {
 		}
 	}
 	
+	override var isAsynchronous: Bool {
+		return true
+	}
+	
 	func didFinish() {
 		assert(Thread.isMainThread)
 		assert(!isFinished, "Finished operation is attempting to finish again.")


### PR DESCRIPTION
As observed on issue #1481.

I initially dismissed overriding this property because Apple's documentation doesn't make much sense:
> The value of this property is YES for operations that run asynchronously with respect to the current thread or NO for operations that run synchronously on the current thread. The default value of this property is NO.

What scope is one in to know which thread is the current thread? Is it when I'm adding the operation to a queue? Or is it when its start or main method is called?

What changed my mind now was the next line:
> When implementing an asynchronous operation object, you must implement this property and return YES.

Generally, `FeedlyOperation` is intendeded to be asynchronous given the overrides for `start`, `executing` and `finished` etc. So if there exists overrides for those, then by the documentation's definition, it is an asynchronous operation, so `isAsynchronous` should probably return `true`.

I doubt this will fix any crashes but who knows? The documentation doesn't say how the fact an operation is asynchronous actually affects anything.