### PR TITLE
Switch order of context menu items to show delete at the bottom #1503

### DIFF
--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -876,14 +876,14 @@ private extension MasterFeedViewController {
 			if let copyHomePageAction = self.copyHomePageAction(indexPath: indexPath) {
 				actions.append(copyHomePageAction)
 			}
-			
-			if includeDeleteRename {
-				actions.append(self.deleteAction(indexPath: indexPath))
-				actions.append(self.renameAction(indexPath: indexPath))
-			}
 
 			if let markAllAction = self.markAllAsReadAction(indexPath: indexPath) {
 				actions.append(markAllAction)
+			}
+			
+			if includeDeleteRename {
+				actions.append(self.renameAction(indexPath: indexPath))
+				actions.append(self.deleteAction(indexPath: indexPath))
 			}
 			
 			return UIMenu(title: "", children: actions)


### PR DESCRIPTION
I switched the order of the `rename` and `delete` action and moved the `Mark All as Read` action above them. Fixes #1503 

I was considering moving the `Mark All as Read` action to the top to be aligned with NNW for Mac but I feel this would impact usability as the action gets harder to reach for most cases.

Very happy to adjust if needed!