### PR TITLE
Change cache location to a subdirectory whose name matches the app bundle identifier

### DIFF
--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -128,17 +128,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
 
 		CacheCleaner.purgeIfNecessary()
 
-		// Try to establish a cache in the Caches folder, but if it fails for some reason fall back to a temporary dir
-		let cacheFolder: String
-		if let userCacheFolder = try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false).path {
-			cacheFolder = userCacheFolder
-		} else {
-			let bundleIdentifier = (Bundle.main.infoDictionary!["CFBundleIdentifier"]! as! String)
-			cacheFolder = (NSTemporaryDirectory() as NSString).appendingPathComponent(bundleIdentifier)
-		}
-
-		let imagesFolder = (cacheFolder as NSString).appendingPathComponent("Images")
-		let imagesFolderURL = URL(fileURLWithPath: imagesFolder)
+		let imagesFolderURL = AppConfig.cacheSubfolder(named: "Images")
 		try! FileManager.default.createDirectory(at: imagesFolderURL, withIntermediateDirectories: true, attributes: nil)
 	}
 

--- a/Modules/RSCore/Sources/RSCore/AppConfig.swift
+++ b/Modules/RSCore/Sources/RSCore/AppConfig.swift
@@ -15,11 +15,12 @@ public final class AppConfig {
 	public static let cacheFolder: URL = {
 
 		let folderURL: URL
+		let bundleIdentifier = (Bundle.main.infoDictionary!["CFBundleIdentifier"]! as! String)
 
+		// Try to establish a cache in the Caches folder, but if it fails for some reason fall back to a temporary dir
 		if let userCacheFolder = try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true) {
-			folderURL = userCacheFolder
+			folderURL = userCacheFolder.appendingPathComponent(bundleIdentifier, isDirectory: true)
 		} else {
-			let bundleIdentifier = (Bundle.main.infoDictionary!["CFBundleIdentifier"]! as! String)
 			let tempFolder = (NSTemporaryDirectory() as NSString).appendingPathComponent(bundleIdentifier)
 			folderURL = URL(fileURLWithPath: tempFolder, isDirectory: true)
 			createFolderIfNecessary(folderURL)

--- a/Shared/Extensions/CacheCleaner.swift
+++ b/Shared/Extensions/CacheCleaner.swift
@@ -27,16 +27,14 @@ struct CacheCleaner {
 				if reachability.connection != .unavailable {
 
 					let tempDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-					let faviconsFolderURL = tempDir.appendingPathComponent("Favicons")
-					let imagesFolderURL = tempDir.appendingPathComponent("Images")
-					let feedURLToIconURL = tempDir.appendingPathComponent("FeedURLToIconURLCache.plist")
-					let homePageToIconURL = tempDir.appendingPathComponent("HomePageToIconURLCache.plist")
-					let homePagesWithNoIconURL = tempDir.appendingPathComponent("HomePagesWithNoIconURLCache.plist")
+						.appendingPathComponent((Bundle.main.infoDictionary!["CFBundleIdentifier"]! as! String), isDirectory: true)
 
-					for tempItem in [faviconsFolderURL, imagesFolderURL, feedURLToIconURL, homePageToIconURL, homePagesWithNoIconURL] {
+					for tempItem in ["Favicons", "Images", "FeedIcons"] {
+						let tempPath = tempDir.appendingPathComponent(tempItem)
+
 						do {
-							os_log(.info, log: self.log, "Removing cache file: %@", tempItem.absoluteString)
-							try FileManager.default.removeItem(at: tempItem)
+							os_log(.info, log: self.log, "Removing cache file: %@", tempPath.absoluteString)
+							try FileManager.default.removeItem(at: tempPath)
 						} catch {
 							os_log(.error, log: self.log, "Could not delete cache file: %@", error.localizedDescription)
 						}


### PR DESCRIPTION
Closes #4543. The following fixes are also included:
- Correctly clean `FeedURLToIconURLCache.plist`. Since this is in the `FeedIcons` directory, it seems the cleanup had not been working.
- Quit cleaning `HomePageToIconURLCache.plist` and `HomePagesWithNoIconURLCache.plist`. These files no longer appear to be in use.