### PR TITLE
Declare utf-8 charset for HTML text written to the pasteboard.

### DIFF
--- a/Mac/MainWindow/Timeline/ArticlePasteboardWriter.swift
+++ b/Mac/MainWindow/Timeline/ArticlePasteboardWriter.swift
@@ -26,7 +26,7 @@ extension Article: @retroactive PasteboardWriterOwner {
 
 	private lazy var renderedHTML: String = {
 		let rendering = ArticleRenderer.articleHTML(article: article, theme: ArticleThemesManager.shared.currentTheme)
-		return rendering.html
+		return "<meta charset=\"utf-8\">\n" + rendering.html
 	}()
 
 	init(article: Article) {


### PR DESCRIPTION
This PR fixes #3978 by prefixing [`<meta charset="utf-8">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#charset) when writing [`NSPasteboard.PasteboardType.html`](https://developer.apple.com/documentation/appkit/nspasteboard/pasteboardtype/1529057-html) type to the pasteboard.

Replaces PR #3979.