### PR TITLE
🩹 Stop keyboard reappearing after dismissal

### DIFF
--- a/iOS/Article/ArticleSearchBar.swift
+++ b/iOS/Article/ArticleSearchBar.swift
@@ -21,6 +21,7 @@ import UIKit
 	var nextButton: UIButton!
 	var prevButton: UIButton!
 	var background: UIView!
+	var shouldBeginEditing: Bool = true
 	
 	weak private var resultsLabel: UILabel!
 	
@@ -172,5 +173,9 @@ extension ArticleSearchBar: UITextFieldDelegate {
 	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
 		delegate?.nextWasPressed?(self)
 		return false
+	}
+	
+	func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+		return shouldBeginEditing
 	}
 }

--- a/iOS/Article/ArticleViewController.swift
+++ b/iOS/Article/ArticleViewController.swift
@@ -175,12 +175,14 @@ final class ArticleViewController: UIViewController {
 	override func viewDidAppear(_ animated: Bool) {
 		super.viewDidAppear(true)
 		coordinator.isArticleViewControllerPending = false
+		searchBar.shouldBeginEditing = true
 	}
 	
 	override func viewWillDisappear(_ animated: Bool) {
 		super.viewWillDisappear(animated)
 		if searchBar != nil && !searchBar.isHidden {
 			endFind()
+			searchBar.shouldBeginEditing = false
 		}
 	}
 	
@@ -507,4 +509,21 @@ private extension ArticleViewController {
 		return controller
 	}
 	
+}
+
+
+extension UIResponder {
+	private struct Static {
+		static weak var firstResponder: UIResponder?
+	}
+	
+	static func currentFirstResponder() -> UIResponder? {
+		Static.firstResponder = nil
+		UIApplication.shared.sendAction(#selector(UIResponder._trapFirstResponder(_:)), to: nil, from: nil, for: nil)
+		return Static.firstResponder
+	}
+	
+	@objc private func _trapFirstResponder(_ sender: Any) {
+		UIResponder.Static.firstResponder = self
+	}
 }

--- a/iOS/Article/ArticleViewController.swift
+++ b/iOS/Article/ArticleViewController.swift
@@ -510,20 +510,3 @@ private extension ArticleViewController {
 	}
 	
 }
-
-
-extension UIResponder {
-	private struct Static {
-		static weak var firstResponder: UIResponder?
-	}
-	
-	static func currentFirstResponder() -> UIResponder? {
-		Static.firstResponder = nil
-		UIApplication.shared.sendAction(#selector(UIResponder._trapFirstResponder(_:)), to: nil, from: nil, for: nil)
-		return Static.firstResponder
-	}
-	
-	@objc private func _trapFirstResponder(_ sender: Any) {
-		UIResponder.Static.firstResponder = self
-	}
-}


### PR DESCRIPTION
Only allow the article search bar to start editing in `viewDidAppear`. This stops the keyboard appearing at the wrong time as described in #4796.

Fixes #4796 