### PR TITLE
Tweak Sepia theme’s stylesheet.css

### DIFF
--- a/Shared/Resources/Sepia.nnwtheme/stylesheet.css
+++ b/Shared/Resources/Sepia.nnwtheme/stylesheet.css
@@ -10,7 +10,9 @@ body {
 }
 
 a {
-	text-decoration: none;
+	text-decoration: underline;
+	text-decoration-style: dotted;
+	text-decoration-offset: 0.15em;
 }
 a:hover {
 	text-shadow: 0 1px rgba(255, 255, 255, 2);


### PR DESCRIPTION
Gives hyperlinks a dotted underline so they’re more visible, given that the theme sets their color to be very, very close to the main text color.