### PR TITLE
Fix refresh progress task counting in ReaderAPI

### DIFF
--- a/Modules/Account/Sources/Account/ReaderAPI/ReaderAPIAccountDelegate.swift
+++ b/Modules/Account/Sources/Account/ReaderAPI/ReaderAPIAccountDelegate.swift
@@ -760,7 +760,7 @@ private extension ReaderAPIAccountDelegate {
 			let articleIDs = Array(fetchedArticleIDs)
 			let chunkedArticleIDs = articleIDs.chunked(into: 150)
 
-			refreshProgress.addTasks(chunkedArticleIDs.count - 1)
+			refreshProgress.addTasks(chunkedArticleIDs.count + 1)
 
 			for chunk in chunkedArticleIDs {
 


### PR DESCRIPTION
It triggered the state.numberCompleted <= state.numberOfTasks assert in completeTask.