### PR TITLE
🚑️ Fixes unread counts not displaying correctly

### DIFF
--- a/iOS/MainFeed/MainFeedCollectionViewController.swift
+++ b/iOS/MainFeed/MainFeedCollectionViewController.swift
@@ -636,12 +636,7 @@ final class MainFeedCollectionViewController: UICollectionViewController, Undoab
 			return
 		}
 
-		var node: Node? = nil
-		if let feed = coordinator.timelineFeed {
-			node = coordinator.rootNode.descendantNodeRepresentingObject(feed as AnyObject)
-		} else {
-			node = coordinator.rootNode.descendantNodeRepresentingObject(unreadCountProvider as AnyObject)
-		}
+		let node: Node? = coordinator.rootNode.descendantNodeRepresentingObject(unreadCountProvider as AnyObject)
 
 		guard let unreadCountNode = node, let indexPath = coordinator.indexPathFor(unreadCountNode) else { return }
 


### PR DESCRIPTION
In previous versions of NetNewsWire, there was a redunant `if let` cast that pushed the code to follow the `else` statement only. This commit ensure that the `else` statement code is now executed.