### PR TITLE
feat(settings): add "mark as read on open" setting for iOS and macOS

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -42,6 +42,7 @@ final class AppDefaults: Sendable {
 		static let exportOPMLAccountID = "exportOPMLAccountID"
 		static let defaultBrowserID = "defaultBrowserID"
 		static let currentThemeName = "currentThemeName"
+		static let markAsReadOnOpenEnabled = "markAsReadOnOpenEnabled"
 		static let articleContentJavascriptEnabled = "articleContentJavascriptEnabled"
 
 		// Hidden prefs
@@ -307,6 +308,15 @@ final class AppDefaults: Sendable {
 		}
 	}
 
+	var isMarkAsReadOnOpenEnabled: Bool {
+		get {
+			UserDefaults.standard.bool(forKey: Key.markAsReadOnOpenEnabled)
+		}
+		set {
+			UserDefaults.standard.set(newValue, forKey: Key.markAsReadOnOpenEnabled)
+		}
+	}
+	
 	var isArticleContentJavascriptEnabled: Bool {
 		get {
 			UserDefaults.standard.bool(forKey: Key.articleContentJavascriptEnabled)
@@ -333,6 +343,7 @@ final class AppDefaults: Sendable {
 			Key.refreshInterval: RefreshInterval.everyHour.rawValue,
 			Key.showDebugMenu: showDebugMenu,
 			Key.currentThemeName: Self.defaultThemeName,
+			Key.markAsReadOnOpenEnabled: true,
 			Key.articleContentJavascriptEnabled: true
 		]
 

--- a/Mac/Base.lproj/Preferences.storyboard
+++ b/Mac/Base.lproj/Preferences.storyboard
@@ -46,7 +46,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <popUpButton horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Z6O-Zt-V1g">
-                                        <rect key="frame" x="117" y="400" width="282" height="24"/>
+                                        <rect key="frame" x="114" y="380" width="289" height="25"/>
                                         <popUpButtonCell key="cell" type="push" title="Medium" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="2" imageScaling="proportionallyDown" inset="2" selectedItem="jMV-2o-5Oh" id="6pw-Vq-tjM">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message"/>
@@ -118,6 +118,26 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FZh-t4-coy">
+                                        <rect key="frame" x="117" y="328" width="283" height="16"/>
+                                        <buttonCell key="cell" type="check" title="Mark as Read on Open" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="mF5-NC-6s2">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <binding destination="mAF-gO-1PI" name="value" keyPath="values.markAsReadOnOpenEnabled" id="MarkAsRead-Binding">
+                                                <dictionary key="options">
+                                                    <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                    <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                    <integer key="NSMultipleValuesPlaceholder" value="1"/>
+                                                    <integer key="NSNoSelectionPlaceholder" value="1"/>
+                                                    <integer key="NSNotApplicablePlaceholder" value="1"/>
+                                                    <integer key="NSNullPlaceholder" value="1"/>
+                                                    <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                                </dictionary>
+                                            </binding>
+                                        </connections>
+                                    </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UI6-sq-M15">
                                         <rect key="frame" x="117" y="300" width="283" height="16"/>
                                         <buttonCell key="cell" type="check" title="Enable JavaScript" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="GUo-0M-xMc">
@@ -244,7 +264,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SFF-mL-yc8">
-                                        <rect key="frame" x="117" y="4" width="282" height="24"/>
+                                        <rect key="frame" x="114" y="0.0" width="289" height="25"/>
                                         <popUpButtonCell key="cell" type="push" title="Every 30 minutes" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="3" imageScaling="proportionallyDown" inset="2" selectedItem="rZU-Tg-xwo" id="Jwn-HD-eP6">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message"/>
@@ -282,6 +302,7 @@
                                 <constraints>
                                     <constraint firstItem="Ci4-fW-KjU" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" id="0Do-jh-Hqq"/>
                                     <constraint firstItem="92N-8I-bOs" firstAttribute="trailing" secondItem="S2Z-bG-jYk" secondAttribute="trailing" id="2ZD-KR-H5A"/>
+                                    <constraint firstItem="FZh-t4-coy" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" id="43S-zb-paT"/>
                                     <constraint firstItem="S2Z-bG-jYk" firstAttribute="trailing" secondItem="pR2-Bf-7Fd" secondAttribute="trailing" id="4wu-2O-1fb"/>
                                     <constraint firstItem="Tdg-6Y-gvW" firstAttribute="top" secondItem="0W5-tO-S63" secondAttribute="bottom" constant="20" id="5a3-LF-TvY"/>
                                     <constraint firstItem="0W5-tO-S63" firstAttribute="top" secondItem="UI6-sq-M15" secondAttribute="bottom" constant="8" id="5mw-aE-uy4"/>
@@ -290,7 +311,7 @@
                                     <constraint firstItem="hQy-ng-ijd" firstAttribute="top" secondItem="Yrc-6Q-kx8" secondAttribute="bottom" constant="20" id="7iQ-QN-Ubh"/>
                                     <constraint firstItem="Yrc-6Q-kx8" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" id="AQY-vT-qR7"/>
                                     <constraint firstItem="yrg-M3-Dbz" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" id="Bmt-Mn-CCl"/>
-                                    <constraint firstItem="UI6-sq-M15" firstAttribute="top" secondItem="1w0-nA-DEO" secondAttribute="bottom" constant="12" id="DMk-OP-dpa"/>
+                                    <constraint firstItem="FZh-t4-coy" firstAttribute="top" secondItem="1w0-nA-DEO" secondAttribute="bottom" constant="12" id="DMk-OP-dpa"/>
                                     <constraint firstItem="Ubm-Pk-l7x" firstAttribute="top" secondItem="Ci4-fW-KjU" secondAttribute="bottom" constant="12" id="E3r-xf-7aZ"/>
                                     <constraint firstAttribute="bottom" secondItem="SFF-mL-yc8" secondAttribute="bottom" constant="4" id="FAd-wh-IFu"/>
                                     <constraint firstItem="pR2-Bf-7Fd" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" constant="8" id="G0C-1M-LW1"/>
@@ -300,7 +321,7 @@
                                     <constraint firstItem="ISO-Wu-R60" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" id="M2S-SQ-vXb"/>
                                     <constraint firstItem="ucw-vG-yLt" firstAttribute="trailing" secondItem="pR2-Bf-7Fd" secondAttribute="trailing" id="Nnp-Vh-NEA"/>
                                     <constraint firstItem="ISO-Wu-R60" firstAttribute="top" secondItem="Z6O-Zt-V1g" secondAttribute="bottom" constant="12" id="Obh-mq-3Tg"/>
-                                    <constraint firstItem="92N-8I-bOs" firstAttribute="firstBaseline" secondItem="UI6-sq-M15" secondAttribute="firstBaseline" id="P1b-YG-fd6"/>
+                                    <constraint firstItem="92N-8I-bOs" firstAttribute="firstBaseline" secondItem="FZh-t4-coy" secondAttribute="firstBaseline" id="P1b-YG-fd6"/>
                                     <constraint firstItem="Ubm-Pk-l7x" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" id="PXc-G4-8pH"/>
                                     <constraint firstItem="S2Z-bG-jYk" firstAttribute="firstBaseline" secondItem="ISO-Wu-R60" secondAttribute="firstBaseline" id="QBC-MT-MY5"/>
                                     <constraint firstAttribute="trailing" secondItem="Z6O-Zt-V1g" secondAttribute="trailing" constant="1" id="Qa5-bc-lvY"/>
@@ -313,6 +334,7 @@
                                     <constraint firstItem="ucw-vG-yLt" firstAttribute="firstBaseline" secondItem="SFF-mL-yc8" secondAttribute="firstBaseline" id="XHk-Fk-1pC"/>
                                     <constraint firstAttribute="trailing" secondItem="wtY-Zd-Ps9" secondAttribute="trailing" id="YAf-to-Ruz"/>
                                     <constraint firstItem="1w0-nA-DEO" firstAttribute="top" secondItem="ISO-Wu-R60" secondAttribute="bottom" constant="12" id="Yal-X7-BjE"/>
+                                    <constraint firstItem="UI6-sq-M15" firstAttribute="top" secondItem="FZh-t4-coy" secondAttribute="bottom" constant="12" id="a9E-Wa-PdK"/>
                                     <constraint firstAttribute="trailing" secondItem="hQy-ng-ijd" secondAttribute="trailing" constant="1" id="aaL-6A-h6v"/>
                                     <constraint firstItem="92N-8I-bOs" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" id="bfi-Tx-kxY"/>
                                     <constraint firstItem="S2Z-bG-jYk" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" id="cAs-rZ-scx"/>
@@ -323,7 +345,8 @@
                                     <constraint firstAttribute="trailing" secondItem="Ci4-fW-KjU" secondAttribute="trailing" constant="1" id="h0b-Nh-tJJ"/>
                                     <constraint firstAttribute="trailing" secondItem="SFF-mL-yc8" secondAttribute="trailing" constant="1" id="hYk-Ff-wTy"/>
                                     <constraint firstItem="SFF-mL-yc8" firstAttribute="leading" secondItem="hQy-ng-ijd" secondAttribute="trailing" constant="-282" id="hhb-8Q-KWc"/>
-                                    <constraint firstItem="0W5-tO-S63" firstAttribute="leading" secondItem="UI6-sq-M15" secondAttribute="leading" constant="22" id="jmc-lb-wp2"/>
+                                    <constraint firstItem="0W5-tO-S63" firstAttribute="leading" secondItem="UI6-sq-M15" secondAttribute="leading" constant="20" id="jmc-lb-wp2"/>
+                                    <constraint firstAttribute="trailing" secondItem="FZh-t4-coy" secondAttribute="trailing" id="kAo-hE-vfB"/>
                                     <constraint firstAttribute="trailing" secondItem="Yrc-6Q-kx8" secondAttribute="trailing" id="o3L-x4-mEr"/>
                                     <constraint firstItem="Wsb-Lr-8Q7" firstAttribute="trailing" secondItem="pR2-Bf-7Fd" secondAttribute="trailing" id="obL-84-81H"/>
                                     <constraint firstItem="Wsb-Lr-8Q7" firstAttribute="firstBaseline" secondItem="Ci4-fW-KjU" secondAttribute="firstBaseline" id="pCJ-eR-07V"/>

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -934,7 +934,7 @@ extension TimelineViewController: NSTableViewDelegate {
 			return
 		}
 
-		if selectedArticles.count == 1 {
+		if selectedArticles.count == 1 && AppDefaults.shared.isMarkAsReadOnOpenEnabled {
 			let article = selectedArticles.first!
 			if !article.status.read {
 				markArticles(Set([article]), statusKey: .read, flag: true)

--- a/Modules/Account/Sources/Account/SecretKey.swift
+++ b/Modules/Account/Sources/Account/SecretKey.swift
@@ -1,0 +1,6 @@
+enum SecretKey {
+	static var feedlyClientID: String { fatalError("update with live secret") }
+	static var feedlyClientSecret: String { fatalError("update with live secret") }
+	static var inoreaderAppID: String { fatalError("update with live secret") }
+	static var inoreaderAppKey: String { fatalError("update with live secret") }
+}

--- a/Shared/SecretKey.swift
+++ b/Shared/SecretKey.swift
@@ -1,0 +1,4 @@
+enum SecretKey {
+	static var mercuryClientID: String { fatalError("update with live secret") }
+	static var mercuryClientSecret: String { fatalError("update with live secret") }
+}

--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -58,6 +58,7 @@ final class AppDefaults: Sendable {
 		static let timelineSortDirection = "timelineSortDirection"
 		static let articleFullscreenAvailable = "articleFullscreenAvailable"
 		static let articleFullscreenEnabled = "articleFullscreenEnabled"
+		static let markAsReadOnOpen = "markAsReadOnOpen"
 		static let confirmMarkAllAsRead = "confirmMarkAllAsRead"
 		static let lastRefresh = "lastRefresh"
 		static let addFeedAccountID = "addFeedAccountID"
@@ -201,6 +202,15 @@ final class AppDefaults: Sendable {
 		articleFullscreenAvailable && articleFullscreenEnabled
 	}
 
+	var markAsReadOnOpen: Bool {
+		get {
+			return AppDefaults.bool(for: Key.markAsReadOnOpen)
+		}
+		set {
+			AppDefaults.setBool(for: Key.markAsReadOnOpen, newValue)
+		}
+	}
+	
 	var confirmMarkAllAsRead: Bool {
 		get {
 			return AppDefaults.bool(for: Key.confirmMarkAllAsRead)
@@ -396,6 +406,7 @@ final class AppDefaults: Sendable {
 										Key.timelineSortDirection: ComparisonResult.orderedDescending.rawValue,
 										Key.articleFullscreenAvailable: false,
 										Key.articleFullscreenEnabled: false,
+									    Key.markAsReadOnOpen: true,
 										Key.confirmMarkAllAsRead: true,
 										Key.articleContentJavascriptEnabled: true,
 										Key.currentThemeName: Self.defaultThemeName,

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -1026,7 +1026,9 @@ struct SidebarItemNode: Hashable, Sendable {
 		mainTimelineViewController?.didPushArticleViewController = true
 
 		// Mark article as read before navigating to it, so the read status does not flash unread/read on display
-		markArticles(Set([article!]), statusKey: .read, flag: true)
+		if AppDefaults.shared.markAsReadOnOpen {
+			markArticles(Set([article!]), statusKey: .read, flag: true)
+		}
 
 		mainTimelineViewController?.updateArticleSelection(animations: animations)
 		articleViewController?.article = article

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -308,7 +308,40 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="EYf-v1-lNi" customClass="VibrantBasicTableViewCell" customModule="NetNewsWire" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="y5p-Tk-nrg" customClass="VibrantTableViewCell" customModule="NetNewsWire" customModuleProvider="target">
+                                        <rect key="frame" x="20" y="842.5" width="374" height="51.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="y5p-Tk-nrg" id="M7x-Lg-GAt">
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="51.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Mark as Read on Open" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nam-yV-0Mh">
+                                                    <rect key="frame" x="20" y="15" width="172.5" height="21.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="m11-vJ-pOQ">
+                                                    <rect key="frame" x="295" y="12" width="63" height="28"/>
+                                                    <color key="onTintColor" name="primaryAccentColor"/>
+                                                    <connections>
+                                                        <action selector="switchMarkAsReadOnOpen:" destination="a0p-rk-skQ" eventType="valueChanged" id="gcF-7t-DGR"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="m11-vJ-pOQ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Nam-yV-0Mh" secondAttribute="trailing" constant="8" id="IAp-8U-N66"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Nam-yV-0Mh" secondAttribute="bottom" id="SwR-nl-stK"/>
+                                                <constraint firstItem="Nam-yV-0Mh" firstAttribute="top" secondItem="M7x-Lg-GAt" secondAttribute="topMargin" id="UVR-0q-clJ"/>
+                                                <constraint firstAttribute="trailing" secondItem="m11-vJ-pOQ" secondAttribute="trailing" constant="18" id="cdQ-td-1xx"/>
+                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="m11-vJ-pOQ" secondAttribute="bottom" constant="6" id="ket-Oj-wua"/>
+                                                <constraint firstItem="Nam-yV-0Mh" firstAttribute="leading" secondItem="M7x-Lg-GAt" secondAttribute="leadingMargin" id="q5e-sq-l0O"/>
+                                                <constraint firstItem="m11-vJ-pOQ" firstAttribute="centerY" secondItem="M7x-Lg-GAt" secondAttribute="centerY" id="seI-nP-Qk7"/>
+                                                <constraint firstItem="m11-vJ-pOQ" firstAttribute="top" relation="greaterThanOrEqual" secondItem="M7x-Lg-GAt" secondAttribute="top" constant="6" id="wfw-GZ-8B9"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="EYf-v1-lNi" customClass="VibrantBasicTableViewCell" customModule="NetNewsWire" customModuleProvider="target">
                                         <rect key="frame" x="20" y="843" width="374" height="52"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EYf-v1-lNi" id="7nz-0Y-HaW">
@@ -574,6 +607,7 @@
                         <outlet property="confirmMarkAllAsReadSwitch" destination="UOo-9z-IuL" id="yLZ-Kf-wDt"/>
                         <outlet property="enableJavaScriptSwitch" destination="Djo-HE-LWS" id="muL-I5-eDE"/>
                         <outlet property="groupByFeedSwitch" destination="JNi-Wz-RbU" id="TwH-Kd-o6N"/>
+                        <outlet property="markAsReadOnOpenSwitch" destination="m11-vJ-pOQ" id="qnh-Mz-6EF"/>
                         <outlet property="openLinksInNetNewsWire" destination="dhR-L2-PX3" id="z1b-pX-bwG"/>
                         <outlet property="refreshClearsReadArticlesSwitch" destination="duV-CN-JmH" id="xTd-jF-Ei1"/>
                         <outlet property="showFullscreenArticlesSwitch" destination="2Md-2E-7Z4" id="lEN-VP-wEO"/>

--- a/iOS/Settings/SettingsViewController.swift
+++ b/iOS/Settings/SettingsViewController.swift
@@ -22,6 +22,7 @@ final class SettingsViewController: UITableViewController {
 	@IBOutlet var groupByFeedSwitch: UISwitch!
 	@IBOutlet var refreshClearsReadArticlesSwitch: UISwitch!
 	@IBOutlet var articleThemeDetailLabel: UILabel!
+	@IBOutlet var markAsReadOnOpenSwitch: UISwitch!
 	@IBOutlet var confirmMarkAllAsReadSwitch: UISwitch!
 	@IBOutlet var showFullscreenArticlesSwitch: UISwitch!
 	@IBOutlet var colorPaletteDetailLabel: UILabel!
@@ -70,6 +71,12 @@ final class SettingsViewController: UITableViewController {
 
 		articleThemeDetailLabel.text = ArticleThemesManager.shared.currentTheme.name
 
+		if AppDefaults.shared.markAsReadOnOpen {
+			markAsReadOnOpenSwitch.isOn = true
+		} else {
+			markAsReadOnOpenSwitch.isOn = false
+		}
+		
 		if AppDefaults.shared.confirmMarkAllAsRead {
 			confirmMarkAllAsReadSwitch.isOn = true
 		} else {
@@ -293,6 +300,14 @@ final class SettingsViewController: UITableViewController {
 		}
 	}
 
+	@IBAction func switchMarkAsReadOnOpen(_ sender: Any) {
+		if markAsReadOnOpenSwitch.isOn {
+			AppDefaults.shared.markAsReadOnOpen = true
+		} else {
+			AppDefaults.shared.markAsReadOnOpen = false
+		}
+	}
+	
 	@IBAction func switchConfirmMarkAllAsRead(_ sender: Any) {
 		if confirmMarkAllAsReadSwitch.isOn {
 			AppDefaults.shared.confirmMarkAllAsRead = true


### PR DESCRIPTION
"Mark as Read on Open" setting is added to iOS and macOS apps. It is set to `true` by default. When disabled, articles are not set as read, when opened. Fixes [#4549](https://github.com/Ranchero-Software/NetNewsWire/issues/4549)

<img width="50%" src="https://github.com/user-attachments/assets/3a2afd3d-ab95-440a-95d4-229f2427fbec" /><img width="50%" align="top" src="https://github.com/user-attachments/assets/6bb9525f-fac2-4631-804c-80b46e2aef30" />
