### PR TITLE
🚑️ Use NSSharingServicePicker to resolve crash

### DIFF
--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -27,6 +27,8 @@ enum TimelineShowFeedName: Sendable {
 final class TimelineViewController: NSViewController, UndoableCommandRunner, UnreadCountProvider {
 
 	@IBOutlet var tableView: TimelineTableView!
+	
+	internal var sharingServicePickerDelegate: NSSharingServicePickerDelegate?
 
 	private var feedsHidingReadArticles = Set<SidebarItemIdentifier>()
 	private var readFilterEnabledTable: [SidebarItemIdentifier: Bool] {
@@ -255,6 +257,8 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 			}
 			didRegisterForNotifications = true
 		}
+		
+		sharingServicePickerDelegate = SharingServicePickerDelegate(self.view.window)
 	}
 
 	override func viewDidAppear() {


### PR DESCRIPTION
Fixes #4929

- Always show a "Share..." menu, but disable it when necessary.
- `Share...` presents `NSSharingServicePicker` (similar to Toolbar)
- The `NSSharingServicePicker` is anchored to the trailing x coordinate of the selected row