### PR TITLE
🚑️ Fix #4938 - Theme persistence

### DIFF
--- a/Shared/ArticleStyles/ArticleThemesManager.swift
+++ b/Shared/ArticleStyles/ArticleThemesManager.swift
@@ -160,10 +160,8 @@ private extension ArticleThemesManager {
 		let allThemeNames = appThemeNames.union(installedThemeNames)
 
 		let sortedThemeNames = allThemeNames.sorted(by: { $0.compare($1, options: .caseInsensitive) == .orderedAscending })
-		Task { @MainActor in
-			if sortedThemeNames != themeNames {
-				themeNames = sortedThemeNames
-			}
+		if sortedThemeNames != themeNames {
+			themeNames = sortedThemeNames
 		}
 	}
 


### PR DESCRIPTION
When setting a new theme, these three functions need to run in sequence.

```swift
AppDefaults.shared.currentThemeName = newValue
updateThemeNames()
updateCurrentTheme()
```

Within `updateThemeNames()` there is a `Task { @MainActor in }` that allows  `updateCurrentTheme()` to complete before `updateThemeNames()` returns. In this scenario, when `updateCurrentTheme() is run the app hasn't got an itinerary of installed themes, so it sets the current them back to Default.

Removing the `Task` fixes the persistence issue.