### PR TITLE
MainFeedCollectionViewController Audit

### DIFF
--- a/iOS/MainFeed/MainFeedCollectionViewController.swift
+++ b/iOS/MainFeed/MainFeedCollectionViewController.swift
@@ -71,12 +71,14 @@ final class MainFeedCollectionViewController: UICollectionViewController, Undoab
 		updateUI()
 		super.viewWillAppear(animated)
 
-		collectionView.refreshControl = UIRefreshControl()
-		collectionView.refreshControl!.addTarget(self, action: #selector(refreshAccounts(_:)), for: .valueChanged)
-
 		if traitCollection.userInterfaceIdiom == .phone {
-			self.navigationController?.navigationBar.prefersLargeTitles = false
-
+			self.navigationController?.navigationBar.prefersLargeTitles = true
+			self.navigationItem.largeTitleDisplayMode = .always
+			DispatchQueue.main.async {
+				/// This sizes the navigation bar to large.
+				self.navigationController?.navigationBar.sizeToFit()
+			}
+			
 			/// On iPhone, we want to deselect the feed when the user navigates
 			/// back to the feeds view. To prevent the user from selecting a new feed while
 			/// the current feed is being deselected, set `isAnimating` to true.


### PR DESCRIPTION
Removes unused #warning comments [bc41f74]
Removes a duplicate assignment of the refresh control [2336638]
Large titles added for iPhone (just like Mail) which fixes #4963 [2336638]


<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-01-17 at 00 10 57" src="https://github.com/user-attachments/assets/f244c305-78d4-485c-a6f4-95d7f5cfb982" />
