### PR TITLE
Add Copy Link with Highlight feature for iOS

### DIFF
--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -136,6 +136,12 @@ function error() {
 	document.body.innerHTML = "error";
 }
 
+// Returns the currently selected text in the WebView, or empty string if no selection
+function getSelectedText() {
+	const selection = window.getSelection();
+	return selection ? selection.toString().trim() : "";
+}
+
 // Takes into account absoluting of URLs.
 function isLocalFootnote(target) {
 	return target.hash.startsWith("#fn") && target.href.indexOf(document.baseURI) === 0;

--- a/Shared/TextFragmentURL.swift
+++ b/Shared/TextFragmentURL.swift
@@ -1,0 +1,53 @@
+//
+//  TextFragmentURL.swift
+//  NetNewsWire
+//
+//  Created by Jérôme Meyer on 1/24/26.
+//  Copyright © 2026 Ranchero Software. All rights reserved.
+//
+
+import Foundation
+
+/// Utility for creating text fragment URLs.
+/// Text fragments allow linking directly to a highlighted portion of a web page.
+/// Format: https://example.com/article#:~:text=selected%20text
+enum TextFragmentURL {
+
+	/// Creates a text fragment URL from a base URL and selected text.
+	/// Returns nil if the URL cannot be created.
+	static func url(from baseURL: URL, selectedText: String) -> URL? {
+		guard !selectedText.isEmpty else {
+			return nil
+		}
+
+		// Remove any existing fragment from the URL
+		var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+		components?.fragment = nil
+
+		guard var urlString = components?.string else {
+			return nil
+		}
+
+		// Encode the text for use in a text fragment
+		guard let encodedText = encodeTextFragment(selectedText) else {
+			return nil
+		}
+
+		// Append the text fragment directive
+		urlString += "#:~:text=\(encodedText)"
+
+		return URL(string: urlString)
+	}
+
+	private static func encodeTextFragment(_ text: String) -> String? {
+		// Text fragments require encoding per the spec
+		// Special characters that need encoding: & - , =
+		// Plus standard percent encoding for non-ASCII and reserved characters
+
+		var allowed = CharacterSet.urlQueryAllowed
+		// Remove characters that have special meaning in text fragments
+		allowed.remove(charactersIn: "&-,=")
+
+		return text.addingPercentEncoding(withAllowedCharacters: allowed)
+	}
+}

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -282,6 +282,16 @@ final class WebViewController: UIViewController {
 		present(activityViewController, animated: true)
 	}
 
+	func getSelectedText(completion: @escaping (String?) -> Void) {
+		webView?.evaluateJavaScript("getSelectedText()") { result, error in
+			guard error == nil, let text = result as? String, !text.isEmpty else {
+				completion(nil)
+				return
+			}
+			completion(text)
+		}
+	}
+
 	func openInAppBrowser() {
 		guard let url = article?.preferredURL else { return }
 		if AppDefaults.shared.useSystemBrowser {
@@ -558,6 +568,7 @@ private extension WebViewController {
 				webView.navigationDelegate = self
 				webView.uiDelegate = self
 				webView.scrollView.delegate = self
+				webView.editMenuDelegate = self
 				self.configureContextMenuInteraction()
 
 				// Remove possible existing message handlers
@@ -894,4 +905,13 @@ extension WebViewController {
 		webView?.evaluateJavaScript("selectPreviousResult()")
 	}
 
+}
+
+// MARK: PreloadedWebViewDelegate
+
+extension WebViewController: PreloadedWebViewDelegate {
+
+	var articleURL: URL? {
+		return article?.preferredURL
+	}
 }


### PR DESCRIPTION
Addresses #4793

## Summary
Adds a "Copy Link with Highlight" option to the context menu on iOS. When text is selected in an article, this option copies a [text fragment URL](https://developer.mozilla.org/en-US/docs/Web/URI/Fragment/Text_fragments) that will highlight the selected text when opened in a browser, similar to existing macOS version behaviour.

<img width="362" height="485" alt="Capture d’écran 2026-02-01 à 15 06 51" src="https://github.com/user-attachments/assets/f12c438a-fbdc-42e7-9fb1-eb507a260fcb" />

## Changes
- New `TextFragmentURL` utility for creating text fragment URLs
- Added `getSelectedText()` JavaScript function to retrieve selected text from the WebView
- Added "Copy Link with Highlight" to the WebView context menu
- The standard share sheet is unchanged and always uses the plain article URL, to keep the scope narrow.