### PR TITLE
Increase the height of the panel and height of the copyright label

### DIFF
--- a/Mac/About/AboutWindowController.xib
+++ b/Mac/About/AboutWindowController.xib
@@ -20,14 +20,14 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="Window" separatorStyle="none" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
-            <rect key="contentRect" x="196" y="120" width="490" height="274"/>
+            <rect key="contentRect" x="196" y="120" width="490" height="278"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1410"/>
             <view key="contentView" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="490" height="274"/>
+                <rect key="frame" x="0.0" y="0.0" width="490" height="278"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="kFw-rc-wEJ">
-                        <rect key="frame" x="66" y="141" width="85" height="85"/>
+                        <rect key="frame" x="66" y="145" width="85" height="85"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="85" id="36U-FK-YAn"/>
                             <constraint firstAttribute="width" constant="85" id="GX8-xO-f4C"/>
@@ -35,7 +35,7 @@
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon" id="G5J-V9-bZN"/>
                     </imageView>
                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zSW-nT-ANt">
-                        <rect key="frame" x="56" y="114" width="105" height="19"/>
+                        <rect key="frame" x="56" y="118" width="105" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="NetNewsWire" id="gJ9-0j-Zg6">
                             <font key="font" size="16" name="SFProDisplay-Semibold"/>
@@ -44,12 +44,12 @@
                         </textFieldCell>
                     </textField>
                     <textView wantsLayer="YES" editable="NO" drawsBackground="NO" importsGraphics="NO" richText="NO" verticallyResizable="NO" allowsCharacterPickerTouchBarItem="NO" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aNw-sB-24m" customClass="LinksTextView" customModule="NetNewsWire" customModuleProvider="target">
-                        <rect key="frame" x="18" y="56" width="181" height="28"/>
+                        <rect key="frame" x="18" y="60" width="181" height="28"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <size key="minSize" width="181" height="28"/>
-                        <size key="maxSize" width="181" height="28"/>
+                        <size key="minSize" width="181" height="32"/>
+                        <size key="maxSize" width="181" height="32"/>
                     </textView>
                     <scrollView fixedFrame="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HQS-xi-g6z">
                         <rect key="frame" x="215" y="28" width="255" height="198"/>
@@ -79,7 +79,7 @@
                         </scroller>
                     </scrollView>
                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" contentType="url" translatesAutoresizingMaskIntoConstraints="NO" id="quK-3X-Mnw" customClass="LinkLabel" customModule="NetNewsWire" customModuleProvider="target">
-                        <rect key="frame" x="59" y="34" width="100" height="14"/>
+                        <rect key="frame" x="59" y="34" width="100" height="16"/>
                         <textFieldCell key="cell" alignment="center" title="netnewswire.com" id="TYf-Hx-QuA">
                             <font key="font" textStyle="subheadline" name=".SFNS-Regular"/>
                             <color key="textColor" name="linkColor" catalog="System" colorSpace="catalog"/>
@@ -87,7 +87,7 @@
                         </textFieldCell>
                     </textField>
                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xLI-yT-116">
-                        <rect key="frame" x="18" y="92" width="181" height="14"/>
+                        <rect key="frame" x="18" y="96" width="181" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Version Text" id="G9F-XS-Hb5">
                             <font key="font" textStyle="subheadline" name=".SFNS-Regular"/>


### PR DESCRIPTION
Increase the height of the panel and height of the copyright label by 4 points to avoid clipping the copyright text. Fixes #5074.