### PR TITLE
✨Add Account-level Notification Management on iOS

### DIFF
--- a/Shared/Extensions/IconImageView.swift
+++ b/Shared/Extensions/IconImageView.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2026 Ranchero Software. All rights reserved.
 //
 
-
 // SwiftUI wrapper for `IconImage`
 
 import SwiftUI

--- a/Shared/Extensions/IconImageView.swift
+++ b/Shared/Extensions/IconImageView.swift
@@ -1,0 +1,87 @@
+//
+//  IconImageView.swift
+//  NetNewsWire
+//
+//  Created by Stuart Breckenridge on 07/02/2026.
+//  Copyright © 2026 Ranchero Software. All rights reserved.
+//
+
+
+// SwiftUI wrapper for `IconImage`
+
+import SwiftUI
+#if os(macOS)
+import AppKit
+typealias PlatformColor = NSColor
+#else
+import UIKit
+typealias PlatformColor = UIColor
+#endif
+
+struct IconImageView: View {
+	let icon: IconImage
+	var size: IconSize = .small
+	var cornerRadius: CGFloat = 4
+
+	@Environment(\.colorScheme) private var colorScheme
+
+	private var isDarkMode: Bool { colorScheme == .dark }
+
+	private var shouldShowBackground: Bool {
+		guard !icon.isBackgroundSuppressed else { return false }
+		if isDarkMode {
+			return icon.isDark
+		} else {
+			return icon.isBright
+		}
+	}
+
+	private var tintColor: Color? {
+		guard let cg = icon.preferredColor else { return nil }
+		return Color(cgColor: cg)
+	}
+
+	var body: some View {
+		ZStack {
+			if shouldShowBackground {
+				RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+					.fill(backgroundColor)
+			}
+
+			platformImage(for: icon)
+				.resizable()
+				.scaledToFit()
+				.symbolRenderingMode(icon.isSymbol ? SymbolRenderingMode.palette : SymbolRenderingMode.hierarchical)
+				.foregroundStyle(tintColor ?? defaultTint)
+		}
+		.frame(width: size.size.width, height: size.size.height)
+		.clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+		.accessibilityHidden(false)
+	}
+
+	private var backgroundColor: Color {
+		#if os(macOS)
+		let nsColor = isDarkMode ? Assets.Colors.iconDarkBackground : Assets.Colors.iconLightBackground
+		return Color(nsColor: nsColor)
+		#else
+		return Color(Assets.Colors.iconBackground)
+		#endif
+	}
+
+	// Fallback tint to something sensible if preferredColor is not set (for symbols)
+	private var defaultTint: Color {
+		#if os(macOS)
+		return Color(nsColor: Assets.Colors.primaryAccent)
+		#else
+		return Color(Assets.Colors.secondaryAccent)
+		#endif
+	}
+
+	private func platformImage(for icon: IconImage) -> Image {
+		#if os(macOS)
+		return Image(nsImage: icon.image)
+		#else
+		return Image(uiImage: icon.image)
+		#endif
+	}
+}

--- a/iOS/Account/AccountNotificationInspectorView.swift
+++ b/iOS/Account/AccountNotificationInspectorView.swift
@@ -13,6 +13,7 @@ import Account
 struct AccountNotificationInspectorView: View {
 	
 	@Environment(\.dismiss) private var dismiss
+	@State private var uuid = UUID()
     
 	var account: Account!
 	
@@ -23,11 +24,12 @@ struct AccountNotificationInspectorView: View {
 			}), id: \.feedID) { feed in
 				Toggle(isOn: Binding(get: { feed.isNotifyAboutNewArticles ?? false }, set: { feed.isNotifyAboutNewArticles = $0 })) {
 					HStack {
-						if feed.smallIcon != nil {
-							Image(uiImage: feed.smallIcon!.image)
-								.resizable()
-								.frame(width: 24, height: 24)
-								.clipShape(RoundedRectangle(cornerRadius: 4.0, style: .continuous))
+						if let img = IconImageCache.shared.imageFor(feed.sidebarItemID!) {
+							IconImageView(icon: img)
+								.id(uuid)
+						} else if let img = feed.smallIcon {
+							IconImageView(icon: img)
+								.id(uuid)
 						}
 						Text(verbatim: feed.nameForDisplay)
 						Spacer()
@@ -43,6 +45,9 @@ struct AccountNotificationInspectorView: View {
 						dismiss()
 					}
 				}
+			}
+			.onReceive(NotificationCenter.default.publisher(for: Notification.Name.feedIconDidBecomeAvailable)) { _ in
+				uuid = UUID()
 			}
 		}
     }

--- a/iOS/Account/AccountNotificationInspectorView.swift
+++ b/iOS/Account/AccountNotificationInspectorView.swift
@@ -35,6 +35,7 @@ struct AccountNotificationInspectorView: View {
 					.tint(.accentColor)
 				}
 				.navigationTitle(Text("New Article Notifications", comment: "New Article Notifications"))
+				.navigationSubtitle(Text(verbatim: account.nameForDisplay))
 				.navigationBarTitleDisplayMode(.inline)
 				.toolbar {
 					ToolbarItem(placement: .topBarTrailing) {
@@ -64,6 +65,7 @@ struct AccountNotificationInspectorView: View {
 				}
 				.navigationTitle(Text("New Article Notifications", comment: "New Article Notifications"))
 				.navigationBarTitleDisplayMode(.inline)
+				.navigationSubtitle(Text(verbatim: account.nameForDisplay))
 				.toolbar {
 					ToolbarItem(placement: .topBarTrailing) {
 						Button(role: .close) {

--- a/iOS/Account/AccountNotificationInspectorView.swift
+++ b/iOS/Account/AccountNotificationInspectorView.swift
@@ -14,42 +14,80 @@ struct AccountNotificationInspectorView: View {
 	
 	@Environment(\.dismiss) private var dismiss
 	@State private var uuid = UUID()
+	@State private var authorisationStatus: UNAuthorizationStatus = .notDetermined
     
 	var account: Account!
 	
 	var body: some View {
 		NavigationStack {
-			List(account.flattenedFeeds().sorted(by: { a, b in
-				a.nameForDisplay < b.nameForDisplay
-			}), id: \.feedID) { feed in
-				Toggle(isOn: Binding(get: { feed.isNotifyAboutNewArticles ?? false }, set: { feed.isNotifyAboutNewArticles = $0 })) {
-					HStack {
-						if let img = IconImageCache.shared.imageFor(feed.sidebarItemID!) {
-							IconImageView(icon: img)
-								.id(uuid)
-						} else if let img = feed.smallIcon {
-							IconImageView(icon: img)
-								.id(uuid)
+			if authorisationStatus == .notDetermined || authorisationStatus == .denied {
+				VStack {
+					ContentUnavailableView("Notifications Disabled",
+										   systemImage: "bell.slash",
+										   description: Text("Enable Notifications in Settings", comment: "Enable Notifications in Settings"))
+					
+					Button {
+						UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+					} label: {
+						Text("Open Settings", comment: "Open Settings")
+					}
+					.buttonStyle(.borderedProminent)
+					.tint(.accentColor)
+				}
+				.navigationTitle(Text("New Article Notifications", comment: "New Article Notifications"))
+				.navigationBarTitleDisplayMode(.inline)
+				.toolbar {
+					ToolbarItem(placement: .topBarTrailing) {
+						Button(role: .close) {
+							dismiss()
 						}
-						Text(verbatim: feed.nameForDisplay)
-						Spacer()
 					}
 				}
-				.tint(.accentColor)
-			}
-			.navigationTitle(Text("New Article Notifications", comment: "New Article Notifications"))
-			.navigationBarTitleDisplayMode(.inline)
-			.toolbar {
-				ToolbarItem(placement: .topBarTrailing) {
-					Button(role: .close) {
-						dismiss()
+			} else {
+				List(account.flattenedFeeds().sorted(by: { a, b in
+					a.nameForDisplay < b.nameForDisplay
+				}), id: \.feedID) { feed in
+					Toggle(isOn: Binding(get: { feed.isNotifyAboutNewArticles ?? false }, set: { feed.isNotifyAboutNewArticles = $0 })) {
+						HStack {
+							if let img = IconImageCache.shared.imageFor(feed.sidebarItemID!) {
+								IconImageView(icon: img)
+									.id(uuid)
+							} else if let img = feed.smallIcon {
+								IconImageView(icon: img)
+									.id(uuid)
+							}
+							Text(verbatim: feed.nameForDisplay)
+							Spacer()
+						}
+					}
+					.tint(.accentColor)
+				}
+				.navigationTitle(Text("New Article Notifications", comment: "New Article Notifications"))
+				.navigationBarTitleDisplayMode(.inline)
+				.toolbar {
+					ToolbarItem(placement: .topBarTrailing) {
+						Button(role: .close) {
+							dismiss()
+						}
 					}
 				}
+				.onReceive(NotificationCenter.default.publisher(for: Notification.Name.feedIconDidBecomeAvailable)) { _ in
+					uuid = UUID()
+				}
 			}
-			.onReceive(NotificationCenter.default.publisher(for: Notification.Name.feedIconDidBecomeAvailable)) { _ in
-				uuid = UUID()
-			}
+			
+			
 		}
+		.task {
+			let settings = await UNUserNotificationCenter.current().notificationSettings()
+			self.authorisationStatus = settings.authorizationStatus
+		}
+		.onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification), perform: { _ in
+			Task {
+				let settings = await UNUserNotificationCenter.current().notificationSettings()
+				self.authorisationStatus = settings.authorizationStatus
+			}
+		})
     }
 }
 

--- a/iOS/Account/AccountNotificationInspectorView.swift
+++ b/iOS/Account/AccountNotificationInspectorView.swift
@@ -11,13 +11,13 @@ import UserNotifications
 import Account
 
 struct AccountNotificationInspectorView: View {
-	
+
 	@Environment(\.dismiss) private var dismiss
 	@State private var uuid = UUID()
 	@State private var authorisationStatus: UNAuthorizationStatus = .notDetermined
-    
+
 	var account: Account!
-	
+
 	var body: some View {
 		NavigationStack {
 			if authorisationStatus == .notDetermined || authorisationStatus == .denied {
@@ -25,7 +25,7 @@ struct AccountNotificationInspectorView: View {
 					ContentUnavailableView("Notifications Disabled",
 										   systemImage: "bell.slash",
 										   description: Text("Enable Notifications in Settings", comment: "Enable Notifications in Settings"))
-					
+
 					Button {
 						UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
 					} label: {
@@ -77,8 +77,6 @@ struct AccountNotificationInspectorView: View {
 					uuid = UUID()
 				}
 			}
-			
-			
 		}
 		.task {
 			let settings = await UNUserNotificationCenter.current().notificationSettings()
@@ -92,4 +90,3 @@ struct AccountNotificationInspectorView: View {
 		})
     }
 }
-

--- a/iOS/Account/AccountNotificationInspectorView.swift
+++ b/iOS/Account/AccountNotificationInspectorView.swift
@@ -1,0 +1,50 @@
+//
+//  AccountNotificationInspectorView.swift
+//  NetNewsWire-iOS
+//
+//  Created by Stuart Breckenridge on 07/02/2026.
+//  Copyright © 2026 Ranchero Software. All rights reserved.
+//
+
+import SwiftUI
+import UserNotifications
+import Account
+
+struct AccountNotificationInspectorView: View {
+	
+	@Environment(\.dismiss) private var dismiss
+    
+	var account: Account!
+	
+	var body: some View {
+		NavigationStack {
+			List(account.flattenedFeeds().sorted(by: { a, b in
+				a.nameForDisplay < b.nameForDisplay
+			}), id: \.feedID) { feed in
+				Toggle(isOn: Binding(get: { feed.isNotifyAboutNewArticles ?? false }, set: { feed.isNotifyAboutNewArticles = $0 })) {
+					HStack {
+						if feed.smallIcon != nil {
+							Image(uiImage: feed.smallIcon!.image)
+								.resizable()
+								.frame(width: 24, height: 24)
+								.clipShape(RoundedRectangle(cornerRadius: 4.0, style: .continuous))
+						}
+						Text(verbatim: feed.nameForDisplay)
+						Spacer()
+					}
+				}
+				.tint(.accentColor)
+			}
+			.navigationTitle(Text("New Article Notifications", comment: "New Article Notifications"))
+			.navigationBarTitleDisplayMode(.inline)
+			.toolbar {
+				ToolbarItem(placement: .topBarTrailing) {
+					Button(role: .close) {
+						dismiss()
+					}
+				}
+			}
+		}
+    }
+}
+

--- a/iOS/MainFeed/MainFeedCollectionViewController.swift
+++ b/iOS/MainFeed/MainFeedCollectionViewController.swift
@@ -856,6 +856,8 @@ extension MainFeedCollectionViewController: UIContextMenuInteractionDelegate {
 			var menuElements = [UIMenuElement]()
 			menuElements.append(UIMenu(title: "", options: .displayInline, children: [self.getAccountInfoAction(account: account)]))
 
+			menuElements.append(UIMenu(title: "", options: .displayInline, children: [self.getAccountNotificationsAction(account: account)]))
+			
 			if let markAllAction = self.markAllAsReadAction(account: account, contentView: interaction.view) {
 				menuElements.append(UIMenu(title: "", options: .displayInline, children: [markAllAction]))
 			}
@@ -1098,6 +1100,14 @@ extension MainFeedCollectionViewController {
 		let title = NSLocalizedString("Get Info", comment: "Get Info")
 		let action = UIAction(title: title, image: Assets.Images.info) { [weak self] _ in
 			self?.coordinator.showAccountInspector(for: account)
+		}
+		return action
+	}
+	
+	func getAccountNotificationsAction(account: Account) -> UIAction {
+		let title = NSLocalizedString("Notifications", comment: "Notifications")
+		let action = UIAction(title: title, image: UIImage(systemName: "bell.badge")) { [weak self] _ in
+			self?.coordinator.showNotificationInspector(for: account)
 		}
 		return action
 	}

--- a/iOS/MainFeed/MainFeedCollectionViewController.swift
+++ b/iOS/MainFeed/MainFeedCollectionViewController.swift
@@ -857,7 +857,7 @@ extension MainFeedCollectionViewController: UIContextMenuInteractionDelegate {
 			menuElements.append(UIMenu(title: "", options: .displayInline, children: [self.getAccountInfoAction(account: account)]))
 
 			menuElements.append(UIMenu(title: "", options: .displayInline, children: [self.getAccountNotificationsAction(account: account)]))
-			
+
 			if let markAllAction = self.markAllAsReadAction(account: account, contentView: interaction.view) {
 				menuElements.append(UIMenu(title: "", options: .displayInline, children: [markAllAction]))
 			}
@@ -1103,7 +1103,7 @@ extension MainFeedCollectionViewController {
 		}
 		return action
 	}
-	
+
 	func getAccountNotificationsAction(account: Account) -> UIAction {
 		let title = NSLocalizedString("Notifications", comment: "Notifications")
 		let action = UIAction(title: title, image: UIImage(systemName: "bell.badge")) { [weak self] _ in

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -1348,7 +1348,7 @@ struct SidebarItemNode: Hashable, Sendable {
 		accountInspectorController.account = account
 		rootSplitViewController.present(accountInspectorNavController, animated: true)
 	}
-	
+
 	func showNotificationInspector(for account: Account) {
 		let hostingController = UIHostingController(rootView: AccountNotificationInspectorView(account: account))
 		hostingController.modalPresentationStyle = .formSheet

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -14,6 +14,7 @@ import Articles
 import RSCore
 import RSTree
 import SafariServices
+import SwiftUI
 
 enum SearchScope: Int {
 	case timeline = 0
@@ -1346,6 +1347,12 @@ struct SidebarItemNode: Hashable, Sendable {
 		accountInspectorController.isModal = true
 		accountInspectorController.account = account
 		rootSplitViewController.present(accountInspectorNavController, animated: true)
+	}
+	
+	func showNotificationInspector(for account: Account) {
+		let hostingController = UIHostingController(rootView: AccountNotificationInspectorView(account: account))
+		hostingController.modalPresentationStyle = .formSheet
+		rootSplitViewController.present(hostingController, animated: true)
 	}
 
 	func showFeedInspector() {


### PR DESCRIPTION
Fixes #4039 

- Adds a new "Notifications" menu item when long-pressing on an account.
- Presents either a redirect to Settings (if notifications aren't authorised) or a list of Feeds + toggles for that Account.
- Allows users to quickly toggle notifications on and off per feed.
- Adds an `IconImageView` wrapper around `IconImage`.

Across 10 feeds, this design is **67.5%** more efficient:
- Per-feed notification enablement requires four gestures to enable a notification: long-press, tap Get Info, enable notification, dismiss. 10 feeds = 40 gestures.
- Account-level design for 10 feeds: long-press account, tap Notifications, 10 toggles, dismiss = 13 gestures

<img width="4881" height="2894" alt="Notifications" src="https://github.com/user-attachments/assets/791fdae0-d778-42ae-b67c-e29622e419ba" />
