### PR TITLE
fix: Prevent image stretching from inline height styles in default stylesheet

### DIFF
--- a/Shared/Article Rendering/stylesheet.css
+++ b/Shared/Article Rendering/stylesheet.css
@@ -252,7 +252,7 @@ pre code {
 
 img, figure, video, div, object {
 	max-width: 100%;
-	height: auto;
+	height: auto !important;
 	margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary

- Add `!important` to `height: auto` in the default article stylesheet to override inline height styles on `<img>` elements

When RSS feeds include `<img>` tags with inline `style="width: 2048px; height: 2730px;"` attributes, the default stylesheet's `height: auto` is overridden by the higher-specificity inline style. This causes images to appear vertically stretched when `max-width: 100%` constrains the width but the height remains at the inline value.

All five theme stylesheets (NewsFax, Hyperlegible, Appanoose, Promenade, Sepia) already use `height: auto !important` for this rule — this PR aligns the default stylesheet (`Shared/Article Rendering/stylesheet.css`) with the same fix.

Fixes #5094

## Test plan

- [ ] Open an RSS feed containing `<img>` tags with large fixed width/height inline styles
- [ ] Verify images display with correct aspect ratio (not vertically stretched)
- [ ] Verify images still resize responsively with `max-width: 100%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)