### PR TITLE
Fix style of italic and emphasized text in articleTitle

### DIFF
--- a/Shared/Article Rendering/stylesheet.css
+++ b/Shared/Article Rendering/stylesheet.css
@@ -421,6 +421,10 @@ a.footnote:hover,
 		color: var(--secondary-accent-color);
 	}
 
+	a :is(i, em) {
+		color: inherit;
+	}
+
 	.externalLink a {
 		font-size: inherit;
 	}
@@ -516,6 +520,10 @@ a.footnote:hover,
 
 	body a, body a:visited, body a * {
 		color: var(--accent-color);
+	}
+
+	a :is(i, em) {
+		color: inherit;
 	}
 
 	a u {


### PR DESCRIPTION
`body a *` is overriding the color of `<i>` and `<em>` in `articleTitle`.

```
body a, body a:visited, body a :not(i, em) * {
		color: var(--secondary-accent-color);
	}
```

Also works.

(“Hyperlegible” is the only preinstalled theme that doesn’t do this.)