### PR TITLE
fix: youtube embed 153 error

### DIFF
--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -615,7 +615,17 @@ private extension WebViewController {
 //		try? html.write(to: fileURL, atomically: true, encoding: .utf8)
 //		print("article.html written to \(fileURL.path)")
 
-		webView.loadHTMLString(html, baseURL: ArticleRenderer.page.baseURL)
+		webView.loadHTMLString(html, baseURL: loadBaseURL(for: rendering.baseURL))
+	}
+
+	private func loadBaseURL(for renderingBaseURL: String) -> URL {
+		if let url = URL(string: renderingBaseURL),
+			let scheme = url.scheme?.lowercased(),
+			scheme == "http" || scheme == "https" {
+			return url
+		}
+
+		return URL(string: "https://netnewswire.com/")!
 	}
 
 	func finalScrollPosition(scrollingUp: Bool) -> CGFloat {

--- a/iOS/Resources/page.html
+++ b/iOS/Resources/page.html
@@ -5,13 +5,9 @@
 		<style>
 			[[style]]
 		</style>
-		<script src="main.js"></script>
-		<script src="main_ios.js"></script>
-		<script src="newsfoot.js" async="async"></script>
 		<script type="text/javascript">
 			document.addEventListener("DOMContentLoaded", function(event) {
 				window.scrollTo(0, [[windowScrollY]]);
-				processPage();
 			})
 		</script>
 		<base href="[[baseURL]]">
@@ -20,4 +16,3 @@
 		[[body]]
 	</body>
 </html>
-


### PR DESCRIPTION
fix #4860. This is created with help from Codex. I am not familiar with Swift. 

## Changes

- Use `http://` or `https://` instead of `file://` ([Youtube doc](https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity) says you need referer set)
	- fall back to `https://netnewswire.com`
- Remove redundant script tags in `page.html`. They're set already at https://github.com/Ranchero-Software/NetNewsWire/blob/ab53b92d3568203deea25a4fecff89fd95435e72/Shared/Article%20Rendering/WebViewConfiguration.swift#L59-L64
- Remove redundant `processPage()` in `page.html`. It's already added in https://github.com/Ranchero-Software/NetNewsWire/blob/ab53b92d3568203deea25a4fecff89fd95435e72/Shared/Article%20Rendering/main.js#L172-L174

Note: This PR does not add the ‎`referrerpolicy="strict-origin-when-cross-origin"` attribute, so YouTube will still return error 153 if it’s missing.  I think it's the feed owner's job to do that.

## Screenshots

| Before | After |
|---|---|
| ![Before](https://github.com/user-attachments/assets/69987f4b-494c-4907-8582-c642b3900d97) | ![After](https://github.com/user-attachments/assets/941a7220-5aad-42e6-bba3-ea51d5b05251) |

### Test feed

```xml
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
  <channel>
    <title>Minimal YouTube Embed Test Feed</title>
    <link>https://example.com/</link>
    <description>One-item feed for NetNewsWire YouTube embed testing</description>
    <language>en-us</language>
    <lastBuildDate>Sun, 15 Feb 2026 12:00:00 GMT</lastBuildDate>

    <item>
      <title>YouTube Embed Test Item</title>
      <link>https://example.com/test-item</link>
      <guid isPermaLink="false">minimal-youtube-test-item-1</guid>
      <pubDate>Sun, 15 Feb 2026 12:00:00 GMT</pubDate>
      <description><![CDATA[
        <p>Testing two embedded videos:</p>
        <p>1) No-cookie embed (Me at the zoo)</p>
        <iframe
          width="560"
          height="315"
          src="https://www.youtube-nocookie.com/embed/jNQXAC9IVRw"
          title="YouTube video player"
          frameborder="0"
          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
          referrerpolicy="strict-origin-when-cross-origin"
          allowfullscreen>
        </iframe>

        <p>2) Regular YouTube embed (Gangnam Style)</p>
        <iframe
          width="560"
          height="315"
          src="https://www.youtube.com/embed/9bZkp7q19f0"
          title="YouTube video player"
          frameborder="0"
          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
          referrerpolicy="strict-origin-when-cross-origin"
          allowfullscreen>
        </iframe>
      ]]></description>
      <content:encoded><![CDATA[
        <p>Testing two embedded videos:</p>
        <p>1) No-cookie embed (Me at the zoo)</p>
        <iframe
          width="560"
          height="315"
          src="https://www.youtube-nocookie.com/embed/jNQXAC9IVRw"
          title="YouTube video player"
          frameborder="0"
          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
          referrerpolicy="strict-origin-when-cross-origin"
          allowfullscreen>
        </iframe>

        <p>2) Regular YouTube embed (Gangnam Style)</p>
        <iframe
          width="560"
          height="315"
          src="https://www.youtube.com/embed/9bZkp7q19f0"
          title="YouTube video player"
          frameborder="0"
          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
          referrerpolicy="strict-origin-when-cross-origin"
          allowfullscreen>
        </iframe>
      ]]></content:encoded>
    </item>
  </channel>
</rss>

```