### PR TITLE
🩹 Fixes swipe-back gesture in full screen mode

### DIFF
--- a/iOS/Article/ArticleViewController.swift
+++ b/iOS/Article/ArticleViewController.swift
@@ -109,11 +109,6 @@ final class ArticleViewController: UIViewController {
 		articleExtractorButton.addTarget(self, action: #selector(toggleArticleExtractor(_:)), for: .touchUpInside)
 		toolbarItems?.insert(UIBarButtonItem(customView: articleExtractorButton), at: 6)
 
-		if let parentNavController = navigationController?.parent as? UINavigationController {
-			poppableDelegate.navigationController = parentNavController
-			parentNavController.interactivePopGestureRecognizer?.delegate = poppableDelegate
-		}
-
 		pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: [:])
 		pageViewController.delegate = self
 		pageViewController.dataSource = self
@@ -183,6 +178,10 @@ final class ArticleViewController: UIViewController {
 		navigationController?.navigationBar.topItem?.subtitle = nil
 		coordinator.isArticleViewControllerPending = false
 		searchBar.shouldBeginEditing = true
+		if let parentNavController = navigationController?.parent as? UINavigationController {
+			poppableDelegate.navigationController = parentNavController
+			parentNavController.interactivePopGestureRecognizer?.delegate = poppableDelegate
+		}
 	}
 
 	override func viewWillDisappear(_ animated: Bool) {
@@ -191,6 +190,7 @@ final class ArticleViewController: UIViewController {
 			endFind()
 			searchBar.shouldBeginEditing = false
 		}
+		currentWebViewController?.showBars()
 	}
 
 	override func viewSafeAreaInsetsDidChange() {


### PR DESCRIPTION
<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
No actionable comments were generated in the recent review. 🎉

---


<!-- walkthrough_start -->

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

The ArticleViewController lifecycle methods were reorganized: poppable delegate hookup was moved from viewDidLoad to viewDidAppear, and UI bar restoration logic was added to viewWillDisappear. These changes adjust the timing of gesture recognizer delegate configuration and UI state restoration during view transitions.

## Changes

|Cohort / File(s)|Summary|
|---|---|
|**View Lifecycle Reorganization** <br> `iOS/Article/ArticleViewController.swift`|Moved poppable delegate configuration from viewDidLoad to viewDidAppear for parent navigation controller gesture recognition. Added showBars() call in viewWillDisappear to restore UI state on view dismissal.|

## Estimated code review effort

🎯 2 (Simple) | ⏱️ ~8 minutes

</details>

<!-- walkthrough_end -->


<!-- pre_merge_checks_walkthrough_start -->

<details>
<summary>🚥 Pre-merge checks | ✅ 2</summary>

<details>
<summary>✅ Passed checks (2 passed)</summary>

|     Check name    | Status   | Explanation                                                                                                                                                                                      |
| :---------------: | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Description Check | ✅ Passed | Check skipped - CodeRabbit’s high-level summary is enabled.                                                                                                                                      |
|    Title check    | ✅ Passed | The title 'Fixes swipe-back gesture in full screen mode' accurately describes the main change: enabling interactive pop gesture recognition by moving poppable delegate hookup to viewDidAppear. |

</details>

<sub>✏️ Tip: You can configure your own custom pre-merge checks in the settings.</sub>

</details>

<!-- pre_merge_checks_walkthrough_end -->

<!-- tips_start -->

---



<sub>Comment `@coderabbitai help` to get the list of available commands and usage tips.</sub>

<!-- tips_end -->

<!-- internal state start -->


<!-- DwQgtGAEAqAWCWBnSTIEMB26CuAXA9mAOYCmGJATmriQCaQDG+Ats2bgFyQAOFk+AIwBWJBrngA3EsgEBPRvlqU0AgfFwA6NPEgQAfACgjoCEejqANiS4AxeAA9pkRAHd43EmAFoGAa0ikiLjYFCQoWABm2BYWzgyhZJDMiiQGAHLYzAKUXABMBgCqAEoAMlywuLjciBwA9LVE6rDYAhpMzLVB2GgUuAKhfmQU8LSktWkkuBMuiADq8KG13NEWtfkFiDnOwT19A75DI6QGAMr4IQxh/ZgMsFwRDtK1AKwADACcAOwG0D2kuJBrhhblxmNoMKdcNRsDV+B4IUUSBJ4CQXJRYQYSioSBYMQBhULUOjoTiQXKvXIANjAFLAAEZPtA6QBmDjPVlUgBaRn0xnAUDI9HwERwBGIZGUNHo7TYGFJvH4wlE4ikMnkTCUVFU6i0Ol5JigcFQqEwosIpHIVClClY7C4VBczkyYIo8jkCk1KjUmm0ujAhj5pgM8AA8idagBBXrwBhWSPR2MkABqKJcePwcoo+BilA0rngEU4BgARKWDABicuQCMASXFlqJ9EQzp68mFjFgmECPMgiOSUno8Aw6ngaAs8AAXtR4Bn+CLcLAwtx8NxuCorJAlFYiETILB8PhfNhuJAIlnmJBkaiACIjEr4ND0FyLrDUKG3IdEdAJjckey4KgxHwPgmEzbNEA0AwoAjWglHofdD2POdIAXJcVzXAQNy3EgdxoFD8BQxceB6dhIAwNBkVwmcsFAgDsysPgh0vVNb1oCNVxIHoABpIDIddP3CGhAJVNCT0CYJQkgAZ8CIYdxFnCJgMIpcSLlMiKPgKjZ1orMcwoSCoBDLArxceYYlvRA0A47jeIwZtJO8ChkBI5x9xcYzR0YEJQjlWYSAEFNUXTMC9IAfjzNyACEekQAAKABKfCpOkAhJIKGttl3Z9EisDSMC/VDmNRAzIBDKQqBiBQQtPCx8EdRAEELZAyHssJCqHISfBEngVwCFKQjCbDcLCVBQIeIgBvoNBC0oZSisdKyPBi9AMHoUIgmAsJ23SwFlvwBgGBCZBZz/HUjCMStqwsTr5LspLCqUWMemnDNjpFP9l16YklOWTCY1s8RxGkHs0gIj7gKlJYWnHBhnE08iJLCW4uycJQaDEOhIIrKsAFlMALFLIDsDcI3IixZAnSgjBKIcnGR/K6C4ABqZ5ajAZ4jAAUSCeAwWtDUwlCEzeIiRTei4HG6HgTISzLKD/UDAVVuQtA8HNCUrWJGU7SktB6pbV1AXVFItW9XU/UMA0bWYdQAH0RkQW2hdTOhbaCXYLcVyAAA5aGeOkSBIZkGG9kgABZKXeSkIneCIQ+eBgIjD5k6QESkKU4ylsneckSHeMPPYMK2ZTth2naRF3aFtwVPat3gSFttgKFIW3blEXxHfd3pC4AbwMSBIGLJAAAUiki2rBlodNbTlYf8CCOhi3uMdNi4/vB4a84LFocf9t8Uel9PFeSDXgeh8QMrKGGWCyEPiJj9PwfaBGIpsAwa99pOADP0QPFFz8O+D917FmfrQV+GBzC4CsH/duh8ALYBPsA0B4DrzSHiO4W6MCAHL1xIgs+44MAHFoDWRAzZpBfwoIfUsj9iwWDQEELBvhETNmuogQ+ABtdeA8+4D14YPNufg0hoDYFQ1BiB0HcFupARhxZH58OLO7YIbCuDwLwXwweH06EI2olQxhzhfDuA8PQKA6YlBFC9OoQAmATIAQEQWAYArBSFiM2VgrYUDNXIphTGsiuG8OLMkJQVCXA9GHPlHx6jB7AU0kOMcjChEiK4CAtBwxJE6N8QAXzkZAHh6jiwCN8PEkgVDIEbnyeE3JiiYRwIoAgrJZ9NGYBehgYpRFAYbgAOR2EcMgfMHgvA+H8OJAa4RTwrDiAkLAASSDtPQAdEIRJyabmSfAbIyBCpgiYvTUgXA+J/XyoJZQYhJCiT6l0SS0lZIjlnO6fsAllyrnXINHEOFdwISPCeAg81WLsSWvpcp8iplBJCZ+f5fjpIYHGgNQBuC6mROGI0MmcThFFMSW0opGT14AF0aF0KCKPEpKLB7MjDt7Z4Mc0CUk+HSOk5JaBoBTs8T4nxXi0DpJSOgzKvgkDJZ8FQtBeWqEpGHd4rx/IMloMyCIdIw6sv9nSMl0rKTFgMOkr29dG6UBbvkx2Nd9T8jNLbNcMIG6KJNVCbuvIDA91ofQ3Aw9VabDYrgREJk6DTxtrgdMb9cBL1eKqou+rVYEENQ6s1RJq7K30EAA== -->

<!-- internal state end -->