### PR TITLE
♿️ Mark timeline cell as an accessibilityElement

### DIFF
--- a/iOS/MainTimeline/Cells/MainTimelineCollectionViewCell.swift
+++ b/iOS/MainTimeline/Cells/MainTimelineCollectionViewCell.swift
@@ -68,6 +68,7 @@ class MainTimelineCollectionViewCell: UICollectionViewCell {
 	override func awakeFromNib() {
 		MainActor.assumeIsolated {
 			super.awakeFromNib()
+			isAccessibilityElement = true
 			indicatorView.alpha = 0.0
 			feedIcon?.translatesAutoresizingMaskIntoConstraints = false
 			configureStackView()


### PR DESCRIPTION
Ensure that collection view cells in the timeline are treated as accessibility elements.