### PR TITLE
Add paths to duplicate browser names in Settings

### DIFF
--- a/Mac/Preferences/General/GeneralPrefencesViewController.swift
+++ b/Mac/Preferences/General/GeneralPrefencesViewController.swift
@@ -64,6 +64,7 @@ final class GeneralPreferencesViewController: NSViewController {
 		guard let menuItem = defaultBrowserPopup.selectedItem else {
 			return
 		}
+
 		let bundleID = menuItem.representedObject as? String
 		AppDefaults.shared.defaultBrowserID = bundleID
 		updateBrowserPopup()
@@ -151,11 +152,36 @@ private extension GeneralPreferencesViewController {
 		menu.addItem(item)
 		menu.addItem(NSMenuItem.separator())
 
+		let baseFont = NSFont.menuFont(ofSize: 0)
+		let smallFont = NSFont.menuFont(ofSize: baseFont.pointSize - 2)
+
+		let duplicates = MacWebBrowser.duplicateBrowsersNames(in: allBrowsers)
+
 		for browser in allBrowsers {
 			guard let name = browser.name else { continue }
 
 			let item = NSMenuItem(title: name, action: nil, keyEquivalent: "")
-			item.representedObject = browser.bundleIdentifier
+			item.representedObject = browser.bundlePath
+
+			// override title with attributedTitle if browser name has duplicates
+			if duplicates.contains(name) {
+				let title = NSMutableAttributedString(
+					string: name,
+					attributes: [
+						.font: NSFont.menuFont(ofSize: 0)
+					]
+				)
+
+				title.append(NSAttributedString(
+					string: " - \(MacWebBrowser.middleTruncPath(of: browser.url))",
+					attributes: [
+						.font: smallFont,
+						.foregroundColor: NSColor.secondaryLabelColor
+					]
+				))
+
+				item.attributedTitle = title
+			}
 
 			let icon = browser.icon ?? NSWorkspace.shared.icon(for: UTType.applicationBundle)
 			icon.size = NSSize(width: 16.0, height: 16.0)

--- a/Modules/RSWeb/Sources/RSWeb/MacWebBrowser.swift
+++ b/Modules/RSWeb/Sources/RSWeb/MacWebBrowser.swift
@@ -41,12 +41,38 @@ import UniformTypeIdentifiers
 		let browserAppURLs = Set(httpsAppURLs).intersection(Set(htmlAppURLs))
 
 		return browserAppURLs.compactMap { MacWebBrowser(url: $0) }.sorted {
-			if let leftName = $0.name, let rightName = $1.name {
-				return leftName < rightName
+			if let leftName = $0.name, let leftPath = $0.bundlePath, let rightName = $1.name, let rightPath = $1.bundlePath {
+				return (leftName, leftPath) < (rightName, rightPath)
 			}
 
 			return false
 		}
+	}
+
+	// Returns an array of browser names that have duplicates
+	public static func duplicateBrowsersNames(in browsers: [MacWebBrowser]) -> [String?] {
+		let duplicateBrowserNames = Dictionary(grouping: browsers, by: { $0.name })
+			.filter { $1.count > 1 }
+			.map { $0.key }
+
+		return duplicateBrowserNames
+	}
+
+	public static func middleTruncPath(of url: URL) -> String {
+		let pathComponents = url.pathComponents
+		let ellipses = "…"
+		let pathThreshold = 4
+
+		// index 0 is `/` with absolute path
+		let pathStart = "\(pathComponents[0])\(pathComponents[1])"
+
+		// truncate middle with ellipses if path components exceed threshold
+		if pathComponents.count > pathThreshold {
+			let pathEnd = pathComponents[pathComponents.count - 2]
+			return "\(pathStart)/\(ellipses)/\(pathEnd)"
+		}
+
+		return pathStart
 	}
 
 	/// The filesystem URL of the default web browser.
@@ -96,9 +122,18 @@ import UniformTypeIdentifiers
 		return Bundle(url: url)?.bundleIdentifier
 	}()
 
-	/// The bundle identifier of the web browser.
+	/// The bundle identifier of the web browser (not unique if there are duplicate browsers)
 	public var bundleIdentifier: String? {
 		return _bundleIdentifier
+	}
+
+	private lazy var _bundlePath: String? = {
+		return Bundle(url: url)?.bundlePath
+	}()
+
+	/// The bundle path of the web browser
+	public var bundlePath: String? {
+		return _bundlePath
 	}
 
 	/// Initializes a `MacWebBrowser` with a URL on disk.


### PR DESCRIPTION
This change adds an informative path name if duplicate browsers are present in `Settings > Browser`

**Notable changes:**

- visible path name for duplicate browsers, middle truncation if path is long
- add `bundlePath` computed property
- use `bundlePath` over `bundleIdentifier`in  `representedObject` to make menu items more unique

`swiftlint` was performed on these specific files.

<img width="573" height="699" alt="Screenshot 2026-03-24 at 10 43 04" src="https://github.com/user-attachments/assets/10149174-987c-485c-b834-794e1303c3e1" />


closes #4747 