### PR TITLE
Allow WKWebView to go fullscreen

### DIFF
--- a/Shared/Article Rendering/WebViewConfiguration.swift
+++ b/Shared/Article Rendering/WebViewConfiguration.swift
@@ -36,6 +36,7 @@ private extension WebViewConfiguration {
 		let preferences = WKPreferences()
 		preferences.javaScriptCanOpenWindowsAutomatically = false
 		preferences.minimumFontSize = 12
+		preferences.isElementFullscreenEnabled = true
 
 		return preferences
 	}


### PR DESCRIPTION
To support things like YouTube video embeds going fullscreen.

The built in behavoiur for multiple windows / monitors is pretty good, here's a video of it in action:


https://github.com/user-attachments/assets/17064a39-848b-4997-bf62-aa52e396020c

