### PR TITLE
🐛 Dial down the hyphenation of article titles.

### DIFF
--- a/iOS/MainTimeline/Cells/MainTimelineCollectionViewCell.swift
+++ b/iOS/MainTimeline/Cells/MainTimelineCollectionViewCell.swift
@@ -44,6 +44,7 @@ class MainTimelineCollectionViewCell: UICollectionViewCell {
 	}()
 	private static let headlineBaseParagraphStyle: NSParagraphStyle = {
 		let style = (baseWrappingParagraphStyle.mutableCopy() as! NSMutableParagraphStyle)
+		style.hyphenationFactor = 0.5
 		return style
 	}()
 	private static let summaryBaseParagraphStyle: NSParagraphStyle = {


### PR DESCRIPTION
Overrides baseParagraphStyle for titles only.