### PR TITLE
Fix default browser detection using malformed URL NSWorkspace.urlForA…

### DIFF
--- a/Mac/Preferences/General/GeneralPrefencesViewController.swift
+++ b/Mac/Preferences/General/GeneralPrefencesViewController.swift
@@ -142,9 +142,9 @@ private extension GeneralPreferencesViewController {
 		let defaultBrowser = MacWebBrowser.default
 
 		let defaultBrowserFormat = NSLocalizedString("System Default (%@)", comment: "Default browser item title format")
-		let defaultBrowserTitle = String(format: defaultBrowserFormat, defaultBrowser.name!)
+		let defaultBrowserTitle = String(format: defaultBrowserFormat, defaultBrowser.name ?? "")
 		let item = NSMenuItem(title: defaultBrowserTitle, action: nil, keyEquivalent: "")
-		let icon = defaultBrowser.icon!
+		let icon = defaultBrowser.icon ?? NSWorkspace.shared.icon(for: UTType.applicationBundle)
 		icon.size = NSSize(width: 16.0, height: 16.0)
 		item.image = icon
 
@@ -163,7 +163,12 @@ private extension GeneralPreferencesViewController {
 			menu.addItem(item)
 		}
 
-		defaultBrowserPopup.selectItem(at: defaultBrowserPopup.indexOfItem(withRepresentedObject: AppDefaults.shared.defaultBrowserID))
+		if let savedID = AppDefaults.shared.defaultBrowserID {
+			let index = defaultBrowserPopup.indexOfItem(withRepresentedObject: savedID)
+			defaultBrowserPopup.selectItem(at: index == -1 ? 0 : index)
+		} else {
+			defaultBrowserPopup.selectItem(at: 0)
+		}
 	}
 
 	func updateNotificationSettings() {

--- a/Modules/RSWeb/Sources/RSWeb/MacWebBrowser.swift
+++ b/Modules/RSWeb/Sources/RSWeb/MacWebBrowser.swift
@@ -51,7 +51,7 @@ import UniformTypeIdentifiers
 
 	/// The filesystem URL of the default web browser.
 	private class var defaultBrowserURL: URL? {
-		return NSWorkspace.shared.urlForApplication(toOpen: URL(string: "https:///")!)
+		return NSWorkspace.shared.urlForApplication(toOpen: URL(string: "https://apple.com/")!)
 	}
 
 	/// The user's default web browser.


### PR DESCRIPTION
Fix default browser detection using malformed URL NSWorkspace.urlForApplication(toOpen:) was called with "https:///"

(malformed, no host), which caused macOS to sometimes return Safari regardless of the actual system default browser.

Fixed by using a valid HTTPS URL (https://apple.com/) so the system correctly resolves the default handler.

Also fixed the browser popup selection logic to explicitly handle the nil-defaultBrowserID case, and removed force-unwraps on icon/name.

Fixes #5220