### PR TITLE
Add text-autospace to article view for proper CJK rendering

### DIFF
--- a/Shared/Article Rendering/stylesheet.css
+++ b/Shared/Article Rendering/stylesheet.css
@@ -154,6 +154,10 @@ body > .systemMessage {
 	letter-spacing: 0em;
 }
 
+.articleTitle, .articleDateline, .articleDatelineTitle, .articleBody {
+	text-autospace: normal;
+}
+
 .articleBody {
 	margin-top: 20px;
 	line-height: 1.6em;


### PR DESCRIPTION
Hi team! Love using NetNewsWire and I use it everyday! Also first time submitting a PR! I noticed `text-autospace` has been supported by major browsers recently and this will make CJK rendering prettier and simpler - a lot of bloggers currently insert spaces manually to achieve the effect, but this is not ideal. 

I'm not sure where's the best place to add this so currently I added to the article-content classes rather than directly applying to body or article. 

Thanks! Let me know your thoughts! 

[text-autospace - CSS | MDN ](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-autospace)

## Summary

Adds `text-autospace: normal` to the article-content classes (`.articleTitle`, `.articleDateline`, `.articleDatelineTitle`, `.articleBody`) in the shared article-rendering stylesheet, so WebKit inserts the standard 1/4em gap between CJK characters and adjacent Latin alphanumerics/symbols. This matches conventional CJK typography and noticeably improves legibility for articles that mix scripts (common in Chinese/Japanese tech blogs that reference English brand names, library names, or numbers inline).

## Before / After
Notice there now is a gap between CJK text and alphanumeric text. 

||Before (without text-autospace)|After (with text-autospace)|
|-|-|-|
|macOS|<img width="1336" height="1288" alt="text-autospace-after" src="https://github.com/user-attachments/assets/49dfa0f9-1460-47b2-aa55-f379f944197d" />|<img width="1336" height="1290" alt="text-autospace-before" src="https://github.com/user-attachments/assets/18ecc9f3-4a39-48b8-a8f9-8c0b0026500c" />|
|iOS|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-08 at 15 38 13" src="https://github.com/user-attachments/assets/e19ee2ad-a637-45ff-8aa4-a61473334dfc" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-08 at 15 37 20" src="https://github.com/user-attachments/assets/238b5bca-ae83-46b3-8db0-df0d7961552f" />|

## Why declare it explicitly

`normal` is the spec default in CSS Text 4, but WebKit currently ships with an initial value of `no-autospace` for backward compatibility, so the property must be set explicitly to take effect.

## Compatibility

`text-autospace` is supported in WebKit starting Safari 18.2 / macOS 15.2 / iOS 18.2 (late 2024). On older OS versions the declaration is silently ignored — no layout regression.

## Scope

The rule is scoped to the four article-content classes used in `Shared/Article Rendering/template.html` rather than `body` or `:root`, to keep the change confined to user-generated article content where mixed-script text actually occurs. The header/feed-link chrome is unaffected.

## Test plan

- [x] Verified visually on macOS with a Chinese article — extra breathing room appears around Latin/numeric runs in both headings and body text.
- [x] Verified visually on iOS with a Chinese article.