### PR TITLE
Add Ollama auto-translation and preloading settings

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -43,6 +43,11 @@ final class AppDefaults: Sendable {
 		static let defaultBrowserID = "defaultBrowserID"
 		static let currentThemeName = "currentThemeName"
 		static let articleContentJavascriptEnabled = "articleContentJavascriptEnabled"
+		static let ollamaBaseURL = "OllamaBaseURL"
+		static let ollamaModel = "OllamaModel"
+		static let ollamaPreferredLanguage = "OllamaPreferredLanguage"
+		static let ollamaPreloadCount = "OllamaPreloadCount"
+		static let ollamaAutoTranslate = "OllamaAutoTranslate"
 
 		// Hidden prefs
 		static let showDebugMenu = "ShowDebugMenu"
@@ -344,7 +349,12 @@ final class AppDefaults: Sendable {
 			Key.refreshInterval: RefreshInterval.every2Hours.rawValue,
 			Key.showDebugMenu: showDebugMenu,
 			Key.currentThemeName: Self.defaultThemeName,
-			Key.articleContentJavascriptEnabled: true
+			Key.articleContentJavascriptEnabled: true,
+			Key.ollamaBaseURL: "http://localhost:11434/api",
+			Key.ollamaModel: "llama3",
+			Key.ollamaPreferredLanguage: "Chinese",
+			Key.ollamaPreloadCount: 10,
+			Key.ollamaAutoTranslate: false
 		]
 
 		UserDefaults.standard.register(defaults: defaults)

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -230,11 +230,10 @@ extension DetailWebViewController: WKNavigationDelegate, WKUIDelegate {
 	}
 
 	public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-		guard let windowScrollY else {
-			return
+		if let windowScrollY {
+			webView.evaluateJavaScript("window.scrollTo(0, \(windowScrollY));")
+			self.windowScrollY = nil
 		}
-		webView.evaluateJavaScript("window.scrollTo(0, \(windowScrollY));")
-		self.windowScrollY = nil
 	}
 
 	// WKUIDelegate
@@ -296,17 +295,71 @@ private extension DetailWebViewController {
 			rendering = ArticleRenderer.articleHTML(article: article, extractedArticle: extractedArticle, theme: theme)
 		}
 
+		var bodyHTML = rendering.html
+		var requestTranslation = false
+		var textToTranslate = ""
+
+		if let article = self.article, UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") {
+			textToTranslate = article.body ?? ""
+			if case .extracted(_, let extractedArticle, _) = state, let content = extractedArticle.content {
+				textToTranslate = content
+			}
+			
+			if !textToTranslate.isEmpty {
+				if let cached = OllamaClient.shared.cachedTranslation(articleID: article.articleID) {
+					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'>\(cached)</div>"
+				} else {
+					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'><i>Translating...</i></div>"
+					requestTranslation = true
+				}
+			}
+		}
+
 		let substitutions = [
 			"title": rendering.title,
 			"baseURL": rendering.baseURL,
 			"style": rendering.style,
-			"body": rendering.html
+			"body": bodyHTML
 		]
 
 		var html = try! MacroProcessor.renderedText(withTemplate: ArticleRenderer.page.html, substitutions: substitutions)
 		html = ArticleRenderingSpecialCases.filterHTMLIfNeeded(baseURL: rendering.baseURL, html: html)
 		WebViewConfiguration.addContentBlockingRules(to: webView)
 		webView.loadHTMLString(html, baseURL: URL(string: rendering.baseURL))
+
+		if requestTranslation {
+			OllamaClient.shared.translate(articleID: self.article!.articleID, text: textToTranslate) { [weak self, articleID = self.article!.articleID] result in
+				DispatchQueue.main.async {
+					guard let self = self, self.article?.articleID == articleID else { return }
+					if case .success(let translated) = result {
+						self.injectTranslation(translated)
+					} else if case .failure(let error) = result {
+						self.injectTranslation("<i>Translation failed: \(error.localizedDescription)</i>")
+					}
+				}
+			}
+		}
+	}
+
+	func injectTranslation(_ translatedText: String) {
+		let encoded = translatedText
+			.replacingOccurrences(of: "\\", with: "\\\\")
+			.replacingOccurrences(of: "\"", with: "\\\"")
+			.replacingOccurrences(of: "\n", with: "\\n")
+			.replacingOccurrences(of: "\r", with: "\\r")
+		
+		let js = """
+			function updateTranslation() {
+				var translationDiv = document.getElementById('ollama-translation');
+				if (translationDiv) {
+					translationDiv.innerHTML = \"\(encoded)\";
+				} else {
+					setTimeout(updateTranslation, 100);
+				}
+			}
+			updateTranslation();
+		"""
+		webView.evaluateJavaScript(js)
 	}
 
 	func fetchScrollInfo() async -> ScrollInfo? {

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -304,6 +304,7 @@ private extension DetailWebViewController {
 			if case .extracted(_, let extractedArticle, _) = state, let content = extractedArticle.content {
 				textToTranslate = content
 			}
+			textToTranslate = textToTranslate.strippingHTML(maxCharacters: 4000)
 			
 			if !textToTranslate.isEmpty {
 				if let cached = OllamaClient.shared.cachedTranslation(articleID: article.articleID) {
@@ -352,7 +353,7 @@ private extension DetailWebViewController {
 			function updateTranslation() {
 				var translationDiv = document.getElementById('ollama-translation');
 				if (translationDiv) {
-					translationDiv.innerHTML = \"\(encoded)\";
+					translationDiv.innerText = \"\(encoded)\";
 				} else {
 					setTimeout(updateTranslation, 100);
 				}

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -319,9 +319,9 @@ private extension DetailWebViewController {
 			
 			if !textToTranslate.isEmpty {
 				if let cached = OllamaClient.shared.cachedTranslation(articleID: article.articleID) {
-					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'>\(cached)</div>"
+					bodyHTML += OllamaClient.translationHTML(content: cached)
 				} else {
-					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'><i>Translating...</i></div>"
+					bodyHTML += OllamaClient.translationHTML(content: "<i>Translating...</i>")
 					requestTranslation = true
 				}
 			}
@@ -346,7 +346,7 @@ private extension DetailWebViewController {
 					if case .success(let translated) = result {
 						self.injectTranslation(translated)
 					} else if case .failure(let error) = result {
-						self.injectTranslation("<i>Translation failed: \(error.localizedDescription)</i>")
+						self.injectTranslation("Translation failed: \(error.localizedDescription)")
 					}
 				}
 			}

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -315,6 +315,7 @@ private extension DetailWebViewController {
 			if case .extracted(_, let extractedArticle, _) = state, let content = extractedArticle.content {
 				textToTranslate = content
 			}
+			textToTranslate = textToTranslate.strippingHTML(maxCharacters: 4000)
 			
 			if !textToTranslate.isEmpty {
 				if let cached = OllamaClient.shared.cachedTranslation(articleID: article.articleID) {
@@ -363,7 +364,7 @@ private extension DetailWebViewController {
 			function updateTranslation() {
 				var translationDiv = document.getElementById('ollama-translation');
 				if (translationDiv) {
-					translationDiv.innerHTML = \"\(encoded)\";
+					translationDiv.innerText = \"\(encoded)\";
 				} else {
 					setTimeout(updateTranslation, 100);
 				}

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -232,11 +232,10 @@ extension DetailWebViewController: WKNavigationDelegate, WKUIDelegate {
 	}
 
 	public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-		guard let windowScrollY else {
-			return
+		if let windowScrollY {
+			webView.evaluateJavaScript("window.scrollTo(0, \(windowScrollY));")
+			self.windowScrollY = nil
 		}
-		webView.evaluateJavaScript("window.scrollTo(0, \(windowScrollY));")
-		self.windowScrollY = nil
 	}
 
 	// WKUIDelegate
@@ -307,17 +306,71 @@ private extension DetailWebViewController {
 			rendering = ArticleRenderer.articleHTML(article: article, extractedArticle: extractedArticle, theme: theme)
 		}
 
+		var bodyHTML = rendering.html
+		var requestTranslation = false
+		var textToTranslate = ""
+
+		if let article = self.article, UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") {
+			textToTranslate = article.body ?? ""
+			if case .extracted(_, let extractedArticle, _) = state, let content = extractedArticle.content {
+				textToTranslate = content
+			}
+			
+			if !textToTranslate.isEmpty {
+				if let cached = OllamaClient.shared.cachedTranslation(articleID: article.articleID) {
+					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'>\(cached)</div>"
+				} else {
+					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'><i>Translating...</i></div>"
+					requestTranslation = true
+				}
+			}
+		}
+
 		let substitutions = [
 			"title": rendering.title,
 			"baseURL": rendering.baseURL,
 			"style": rendering.style,
-			"body": rendering.html
+			"body": bodyHTML
 		]
 
 		var html = try! MacroProcessor.renderedText(withTemplate: ArticleRenderer.page.html, substitutions: substitutions)
 		html = ArticleRenderingSpecialCases.filterHTMLIfNeeded(baseURL: rendering.baseURL, html: html)
 		WebViewConfiguration.addContentBlockingRules(to: webView)
 		webView.loadHTMLString(html, baseURL: URL(string: rendering.baseURL))
+
+		if requestTranslation {
+			OllamaClient.shared.translate(articleID: self.article!.articleID, text: textToTranslate) { [weak self, articleID = self.article!.articleID] result in
+				DispatchQueue.main.async {
+					guard let self = self, self.article?.articleID == articleID else { return }
+					if case .success(let translated) = result {
+						self.injectTranslation(translated)
+					} else if case .failure(let error) = result {
+						self.injectTranslation("<i>Translation failed: \(error.localizedDescription)</i>")
+					}
+				}
+			}
+		}
+	}
+
+	func injectTranslation(_ translatedText: String) {
+		let encoded = translatedText
+			.replacingOccurrences(of: "\\", with: "\\\\")
+			.replacingOccurrences(of: "\"", with: "\\\"")
+			.replacingOccurrences(of: "\n", with: "\\n")
+			.replacingOccurrences(of: "\r", with: "\\r")
+		
+		let js = """
+			function updateTranslation() {
+				var translationDiv = document.getElementById('ollama-translation');
+				if (translationDiv) {
+					translationDiv.innerHTML = \"\(encoded)\";
+				} else {
+					setTimeout(updateTranslation, 100);
+				}
+			}
+			updateTranslation();
+		"""
+		webView.evaluateJavaScript(js)
 	}
 
 	func fetchScrollInfo() async -> ScrollInfo? {

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -939,6 +939,21 @@ extension TimelineViewController: NSTableViewDelegate {
 			if !article.status.read {
 				markArticles(Set([article]), statusKey: .read, flag: true)
 			}
+			
+			if UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") {
+				let count = UserDefaults.standard.object(forKey: "OllamaPreloadCount") != nil ? UserDefaults.standard.integer(forKey: "OllamaPreloadCount") : 10
+				if count > 0, let index = articles.firstIndex(of: article) {
+					let nextIndex = index + 1
+					if nextIndex < articles.count {
+						let limit = min(articles.count, nextIndex + count)
+						let itemsToPreload = articles[nextIndex..<limit].compactMap { (a: Article) -> (id: String, text: String)? in
+							let text = a.body ?? ""
+							return text.isEmpty ? nil : (a.articleID, text)
+						}
+						OllamaClient.shared.preloadTranslations(items: itemsToPreload)
+					}
+				}
+			}
 		}
 
 		selectionDidChange(selectedArticles)

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -947,7 +947,7 @@ extension TimelineViewController: NSTableViewDelegate {
 					if nextIndex < articles.count {
 						let limit = min(articles.count, nextIndex + count)
 						let itemsToPreload = articles[nextIndex..<limit].compactMap { (a: Article) -> (id: String, text: String)? in
-							let text = a.body ?? ""
+							let text = (a.body ?? "").strippingHTML(maxCharacters: 4000)
 							return text.isEmpty ? nil : (a.articleID, text)
 						}
 						OllamaClient.shared.preloadTranslations(items: itemsToPreload)

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -941,6 +941,21 @@ extension TimelineViewController: NSTableViewDelegate {
 			if !article.status.read {
 				markArticles(Set([article]), statusKey: .read, flag: true)
 			}
+			
+			if UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") {
+				let count = UserDefaults.standard.object(forKey: "OllamaPreloadCount") != nil ? UserDefaults.standard.integer(forKey: "OllamaPreloadCount") : 10
+				if count > 0, let index = articles.firstIndex(of: article) {
+					let nextIndex = index + 1
+					if nextIndex < articles.count {
+						let limit = min(articles.count, nextIndex + count)
+						let itemsToPreload = articles[nextIndex..<limit].compactMap { (a: Article) -> (id: String, text: String)? in
+							let text = a.body ?? ""
+							return text.isEmpty ? nil : (a.articleID, text)
+						}
+						OllamaClient.shared.preloadTranslations(items: itemsToPreload)
+					}
+				}
+			}
 		}
 
 		selectionDidChange(selectedArticles)

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -949,7 +949,7 @@ extension TimelineViewController: NSTableViewDelegate {
 					if nextIndex < articles.count {
 						let limit = min(articles.count, nextIndex + count)
 						let itemsToPreload = articles[nextIndex..<limit].compactMap { (a: Article) -> (id: String, text: String)? in
-							let text = a.body ?? ""
+							let text = (a.body ?? "").strippingHTML(maxCharacters: 4000)
 							return text.isEmpty ? nil : (a.articleID, text)
 						}
 						OllamaClient.shared.preloadTranslations(items: itemsToPreload)

--- a/Mac/Preferences/PreferencesWindowController.swift
+++ b/Mac/Preferences/PreferencesWindowController.swift
@@ -25,6 +25,7 @@ private struct ToolbarItemIdentifier {
 	static let General = "General"
 	static let Accounts = "Accounts"
 	static let Advanced = "Advanced"
+	static let Ollama = "Ollama"
 }
 
 final class PreferencesWindowController: NSWindowController, NSToolbarDelegate {
@@ -42,6 +43,9 @@ final class PreferencesWindowController: NSWindowController, NSToolbarDelegate {
 		specs += [PreferencesToolbarItemSpec(identifierRawValue: ToolbarItemIdentifier.Advanced,
 											 name: NSLocalizedString("Advanced", comment: "Preferences"),
 											 image: Assets.Images.preferencesToolbarAdvanced)]
+		specs += [PreferencesToolbarItemSpec(identifierRawValue: ToolbarItemIdentifier.Ollama,
+											 name: NSLocalizedString("Translation", comment: "Preferences"),
+											 image: NSImage(systemSymbolName: "globe", accessibilityDescription: nil))]
 		return specs
 	}()
 
@@ -152,6 +156,12 @@ private extension PreferencesWindowController {
 			return cachedViewController
 		}
 
+		if identifier == ToolbarItemIdentifier.Ollama {
+			let viewController = OllamaPreferencesViewController()
+			viewControllers[identifier] = viewController
+			return viewController
+		}
+
 		let storyboard = NSStoryboard(name: NSStoryboard.Name("Preferences"), bundle: nil)
 		guard let viewController = storyboard.instantiateController(withIdentifier: NSStoryboard.SceneIdentifier(identifier)) as? NSViewController else {
 			assertionFailure("Unknown preferences view controller: \(identifier)")
@@ -188,5 +198,135 @@ private extension PreferencesWindowController {
 			window!.setFrame(updatedWindowFrame, display: true, animate: true)
 			window!.contentView?.alphaValue = 1.0
 		}
+	}
+}
+
+final class OllamaPreferencesViewController: NSViewController {
+	
+	private let baseURLTextField = NSTextField()
+	private let modelTextField = NSTextField()
+	private let languageTextField = NSTextField()
+	private let autoTranslateCheckbox = NSButton(checkboxWithTitle: NSLocalizedString("Auto-Translate Articles", comment: ""), target: nil, action: nil)
+	private let preloadCountTextField = NSTextField()
+	
+	init() {
+		super.init(nibName: nil, bundle: nil)
+	}
+	
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+	
+	override func loadView() {
+		self.view = NSView(frame: NSRect(x: 0, y: 0, width: 512, height: 250))
+		
+		let stackView = NSStackView()
+		stackView.orientation = .vertical
+		stackView.alignment = .leading
+		stackView.spacing = 16
+		stackView.edgeInsets = NSEdgeInsets(top: 20, left: 40, bottom: 20, right: 40)
+		stackView.translatesAutoresizingMaskIntoConstraints = false
+		
+		self.view.addSubview(stackView)
+		NSLayoutConstraint.activate([
+			stackView.topAnchor.constraint(equalTo: view.topAnchor),
+			stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+			stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+			stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+		])
+		
+		func addFormRow(title: String, control: NSView) {
+			let rowStack = NSStackView()
+			rowStack.orientation = .horizontal
+			rowStack.alignment = .firstBaseline
+			rowStack.spacing = 8
+			
+			let label = NSTextField(labelWithString: title)
+			label.alignment = .right
+			label.widthAnchor.constraint(equalToConstant: 120).isActive = true
+			
+			rowStack.addArrangedSubview(label)
+			rowStack.addArrangedSubview(control)
+			stackView.addArrangedSubview(rowStack)
+		}
+		
+		// Base URL
+		baseURLTextField.translatesAutoresizingMaskIntoConstraints = false
+		baseURLTextField.widthAnchor.constraint(equalToConstant: 250).isActive = true
+		baseURLTextField.stringValue = UserDefaults.standard.string(forKey: "OllamaBaseURL") ?? "http://localhost:11434/api"
+		addFormRow(title: NSLocalizedString("Base URL:", comment: ""), control: baseURLTextField)
+		
+		// Model
+		modelTextField.translatesAutoresizingMaskIntoConstraints = false
+		modelTextField.widthAnchor.constraint(equalToConstant: 250).isActive = true
+		modelTextField.stringValue = UserDefaults.standard.string(forKey: "OllamaModel") ?? "llama3"
+		addFormRow(title: NSLocalizedString("Model:", comment: ""), control: modelTextField)
+		
+		// Language
+		languageTextField.translatesAutoresizingMaskIntoConstraints = false
+		languageTextField.widthAnchor.constraint(equalToConstant: 250).isActive = true
+		languageTextField.stringValue = UserDefaults.standard.string(forKey: "OllamaPreferredLanguage") ?? "Chinese"
+		addFormRow(title: NSLocalizedString("Target Language:", comment: ""), control: languageTextField)
+
+		// Preload Count
+		preloadCountTextField.translatesAutoresizingMaskIntoConstraints = false
+		preloadCountTextField.widthAnchor.constraint(equalToConstant: 100).isActive = true
+		preloadCountTextField.stringValue = String(UserDefaults.standard.integer(forKey: "OllamaPreloadCount"))
+		if preloadCountTextField.stringValue == "0" {
+			preloadCountTextField.stringValue = "10"
+			UserDefaults.standard.set(10, forKey: "OllamaPreloadCount")
+		}
+		addFormRow(title: NSLocalizedString("Preload Next:", comment: ""), control: preloadCountTextField)
+		
+		// Auto-Translate
+		autoTranslateCheckbox.state = UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") ? .on : .off
+		
+		let checkboxContainer = NSStackView()
+		checkboxContainer.orientation = .horizontal
+		let spacer = NSView()
+		spacer.translatesAutoresizingMaskIntoConstraints = false
+		spacer.widthAnchor.constraint(equalToConstant: 120 + 8).isActive = true // Label width + spacing
+		checkboxContainer.addArrangedSubview(spacer)
+		checkboxContainer.addArrangedSubview(autoTranslateCheckbox)
+		stackView.addArrangedSubview(checkboxContainer)
+		
+		// Targets/Actions
+		baseURLTextField.target = self
+		baseURLTextField.action = #selector(baseURLChanged(_:))
+		
+		modelTextField.target = self
+		modelTextField.action = #selector(modelChanged(_:))
+		
+		languageTextField.target = self
+		languageTextField.action = #selector(languageChanged(_:))
+		
+		preloadCountTextField.target = self
+		preloadCountTextField.action = #selector(preloadCountChanged(_:))
+		
+		autoTranslateCheckbox.target = self
+		autoTranslateCheckbox.action = #selector(autoTranslateChanged(_:))
+	}
+	
+	@objc private func baseURLChanged(_ sender: NSTextField) {
+		UserDefaults.standard.set(sender.stringValue, forKey: "OllamaBaseURL")
+	}
+	
+	@objc private func modelChanged(_ sender: NSTextField) {
+		UserDefaults.standard.set(sender.stringValue, forKey: "OllamaModel")
+	}
+	
+	@objc private func languageChanged(_ sender: NSTextField) {
+		UserDefaults.standard.set(sender.stringValue, forKey: "OllamaPreferredLanguage")
+	}
+	
+	@objc private func preloadCountChanged(_ sender: NSTextField) {
+		let value = max(0, min(50, sender.integerValue))
+		UserDefaults.standard.set(value, forKey: "OllamaPreloadCount")
+		sender.stringValue = String(value)
+	}
+	
+	@objc private func autoTranslateChanged(_ sender: NSButton) {
+		UserDefaults.standard.set(sender.state == .on, forKey: "OllamaAutoTranslate")
+		NotificationCenter.default.post(name: Notification.Name("OllamaAutoTranslateDidChange"), object: nil)
 	}
 }

--- a/Mac/Preferences/PreferencesWindowController.swift
+++ b/Mac/Preferences/PreferencesWindowController.swift
@@ -272,10 +272,7 @@ final class OllamaPreferencesViewController: NSViewController {
 		preloadCountTextField.translatesAutoresizingMaskIntoConstraints = false
 		preloadCountTextField.widthAnchor.constraint(equalToConstant: 100).isActive = true
 		preloadCountTextField.stringValue = String(UserDefaults.standard.integer(forKey: "OllamaPreloadCount"))
-		if preloadCountTextField.stringValue == "0" {
-			preloadCountTextField.stringValue = "10"
-			UserDefaults.standard.set(10, forKey: "OllamaPreloadCount")
-		}
+
 		addFormRow(title: NSLocalizedString("Preload Next:", comment: ""), control: preloadCountTextField)
 		
 		// Auto-Translate

--- a/Modules/RSCore/Sources/RSCore/OllamaClient.swift
+++ b/Modules/RSCore/Sources/RSCore/OllamaClient.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+public final class OllamaClient: @unchecked Sendable {
+    public static let shared = OllamaClient()
+
+    private var baseURL: URL {
+        if let urlString = UserDefaults.standard.string(forKey: "OllamaBaseURL"), let url = URL(string: urlString) {
+            if urlString.hasSuffix("/api") || urlString.hasSuffix("/api/") {
+                return url
+            }
+            return url.appendingPathComponent("api")
+        }
+        return URL(string: "http://localhost:11434/api")!
+    }
+
+    private var model: String {
+        return UserDefaults.standard.string(forKey: "OllamaModel") ?? "llama3"
+    }
+
+    private var preferredLanguage: String {
+        return UserDefaults.standard.string(forKey: "OllamaPreferredLanguage") ?? "Chinese"
+    }
+
+    private var translationCache = [String: String]()
+    private var inProgressTranslations = Set<String>()
+    private let cacheQueue = DispatchQueue(label: "com.netnewswire.ollamacache")
+
+    private lazy var session: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 300 // 5 minutes to prevent timeout
+        config.timeoutIntervalForResource = 300
+        return URLSession(configuration: config)
+    }()
+
+    public init() {}
+
+    public func generate(prompt: String, completion: @escaping (Result<String, Error>) -> Void) {
+        let url = baseURL.appendingPathComponent("generate")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let payload: [String: Any] = [
+            "model": model,
+            "prompt": prompt,
+            "stream": false
+        ]
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: payload)
+
+        let task = session.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let data = data else {
+                let err = NSError(domain: "OllamaClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data received"])
+                completion(.failure(err))
+                return
+            }
+
+            do {
+                if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                    if let responseText = json["response"] as? String {
+                        completion(.success(responseText))
+                    } else if let errorText = json["error"] as? String {
+                        completion(.failure(NSError(domain: "OllamaClient", code: -1, userInfo: [NSLocalizedDescriptionKey: errorText])))
+                    } else {
+                        let raw = String(data: data, encoding: .utf8) ?? "Unknown"
+                        completion(.failure(NSError(domain: "OllamaClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid API response: \(raw)"])))
+                    }
+                } else {
+                    let raw = String(data: data, encoding: .utf8) ?? "Unknown"
+                    completion(.failure(NSError(domain: "OllamaClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON format. Raw: \(raw)"])))
+                }
+            } catch {
+                let raw = String(data: data, encoding: .utf8) ?? "Unknown"
+                completion(.failure(NSError(domain: "OllamaClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to parse JSON. Raw: \(raw)"])))
+            }
+        }
+        task.resume()
+    }
+
+    public func cachedTranslation(articleID: String) -> String? {
+        var result: String?
+        cacheQueue.sync {
+            result = translationCache[articleID]
+        }
+        return result
+    }
+
+    public func translate(articleID: String, text: String, completion: @escaping (Result<String, Error>) -> Void) {
+        guard !text.isEmpty else {
+            completion(.failure(NSError(domain: "OllamaClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "No text available"])))
+            return
+        }
+
+        cacheQueue.async {
+            if let cached = self.translationCache[articleID] {
+                completion(.success(cached))
+                return
+            }
+
+            let prompt = "Translate the following text to \(self.preferredLanguage). ONLY return the translated text and nothing else. Do not add any conversational filler, side notes, explanations, or multiple options. Provide exactly one translation:\n\n\(text)"
+            
+            self.generate(prompt: prompt) { [weak self] result in
+                if case .success(let translation) = result {
+                    self?.cacheQueue.async {
+                        self?.translationCache[articleID] = translation
+                    }
+                }
+                completion(result)
+            }
+        }
+    }
+
+    public func preloadTranslations(items: [(id: String, text: String)]) {
+        for item in items {
+            let id = item.id
+            let text = item.text
+            
+            cacheQueue.async {
+                guard self.translationCache[id] == nil, !self.inProgressTranslations.contains(id) else {
+                    return
+                }
+                guard !text.isEmpty else { return }
+                
+                self.inProgressTranslations.insert(id)
+
+                let prompt = "Translate the following text to \(self.preferredLanguage). ONLY return the translated text and nothing else. Do not add any conversational filler, side notes, explanations, or multiple options. Provide exactly one translation:\n\n\(text)"
+                
+                self.generate(prompt: prompt) { [weak self] result in
+                    self?.cacheQueue.async {
+                        self?.inProgressTranslations.remove(id)
+                        if case .success(let translation) = result {
+                            self?.translationCache[id] = translation
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    }
+

--- a/Modules/RSCore/Sources/RSCore/OllamaClient.swift
+++ b/Modules/RSCore/Sources/RSCore/OllamaClient.swift
@@ -22,7 +22,10 @@ public final class OllamaClient: @unchecked Sendable {
     }
 
     private var translationCache = [String: String]()
-    private var inProgressTranslations = Set<String>()
+    private var activeTasks = [String: URLSessionDataTask]()
+    private var completionHandlers = [String: [(Result<String, Error>) -> Void]]()
+    private var explicitRequests = Set<String>()
+    
     private let cacheQueue = DispatchQueue(label: "com.netnewswire.ollamacache")
 
     private lazy var session: URLSession = {
@@ -34,7 +37,8 @@ public final class OllamaClient: @unchecked Sendable {
 
     public init() {}
 
-    public func generate(prompt: String, completion: @escaping (Result<String, Error>) -> Void) {
+    @discardableResult
+    private func generate(prompt: String, completion: @escaping (Result<String, Error>) -> Void) -> URLSessionDataTask? {
         let url = baseURL.appendingPathComponent("generate")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -80,6 +84,7 @@ public final class OllamaClient: @unchecked Sendable {
             }
         }
         task.resume()
+        return task
     }
 
     public func cachedTranslation(articleID: String) -> String? {
@@ -101,46 +106,87 @@ public final class OllamaClient: @unchecked Sendable {
                 completion(.success(cached))
                 return
             }
+            
+            self.explicitRequests.insert(articleID)
+
+            if self.activeTasks[articleID] != nil {
+                // Task is already running (e.g., from preload), attach completion handler
+                var handlers = self.completionHandlers[articleID] ?? []
+                handlers.append(completion)
+                self.completionHandlers[articleID] = handlers
+                return
+            }
 
             let prompt = "Translate the following text to \(self.preferredLanguage). ONLY return the translated text and nothing else. Do not add any conversational filler, side notes, explanations, or multiple options. Provide exactly one translation:\n\n\(text)"
             
-            self.generate(prompt: prompt) { [weak self] result in
-                if case .success(let translation) = result {
-                    self?.cacheQueue.async {
+            self.completionHandlers[articleID] = [completion]
+            
+            let task = self.generate(prompt: prompt) { [weak self] result in
+                self?.cacheQueue.async {
+                    self?.activeTasks.removeValue(forKey: articleID)
+                    self?.explicitRequests.remove(articleID)
+                    
+                    if case .success(let translation) = result {
                         self?.translationCache[articleID] = translation
                     }
+                    
+                    if let handlers = self?.completionHandlers.removeValue(forKey: articleID) {
+                        for handler in handlers {
+                            handler(result)
+                        }
+                    }
                 }
-                completion(result)
+            }
+            
+            if let task = task {
+                self.activeTasks[articleID] = task
             }
         }
     }
 
     public func preloadTranslations(items: [(id: String, text: String)]) {
-        for item in items {
-            let id = item.id
-            let text = item.text
-            
-            cacheQueue.async {
-                guard self.translationCache[id] == nil, !self.inProgressTranslations.contains(id) else {
-                    return
+        let desiredIDs = Set(items.map { $0.id })
+        
+        cacheQueue.async {
+            // Cancel active preloads that are no longer needed
+            for (id, task) in self.activeTasks {
+                if !desiredIDs.contains(id) && !self.explicitRequests.contains(id) {
+                    task.cancel()
+                    self.activeTasks.removeValue(forKey: id)
+                    self.completionHandlers.removeValue(forKey: id)
                 }
-                guard !text.isEmpty else { return }
+            }
+            
+            // Start new preloads
+            for item in items {
+                let id = item.id
+                let text = item.text
                 
-                self.inProgressTranslations.insert(id)
-
+                guard self.translationCache[id] == nil, self.activeTasks[id] == nil else {
+                    continue
+                }
+                guard !text.isEmpty else { continue }
+                
                 let prompt = "Translate the following text to \(self.preferredLanguage). ONLY return the translated text and nothing else. Do not add any conversational filler, side notes, explanations, or multiple options. Provide exactly one translation:\n\n\(text)"
                 
-                self.generate(prompt: prompt) { [weak self] result in
+                let task = self.generate(prompt: prompt) { [weak self] result in
                     self?.cacheQueue.async {
-                        self?.inProgressTranslations.remove(id)
+                        self?.activeTasks.removeValue(forKey: id)
                         if case .success(let translation) = result {
                             self?.translationCache[id] = translation
                         }
+                        if let handlers = self?.completionHandlers.removeValue(forKey: id) {
+                            for handler in handlers {
+                                handler(result)
+                            }
+                        }
                     }
+                }
+                
+                if let task = task {
+                    self.activeTasks[id] = task
                 }
             }
         }
     }
-
-    }
-
+}

--- a/Modules/RSCore/Sources/RSCore/OllamaClient.swift
+++ b/Modules/RSCore/Sources/RSCore/OllamaClient.swift
@@ -189,4 +189,38 @@ public final class OllamaClient: @unchecked Sendable {
             }
         }
     }
+
+    public static func translationHTML(content: String) -> String {
+        let preferredLanguage = UserDefaults.standard.string(forKey: "OllamaPreferredLanguage") ?? "Chinese"
+        let title: String
+        if preferredLanguage.lowercased().contains("chinese") || preferredLanguage.contains("中文") {
+            title = "AI 翻译"
+        } else {
+            title = "AI Translation"
+        }
+        
+        return """
+        <style>
+        :root {
+            --ollama-bg: #faf9ff;
+            --ollama-border: #dbd5ff;
+            --ollama-brand: #7c3aed;
+        }
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --ollama-bg: #17153b;
+                --ollama-border: #3e3875;
+                --ollama-brand: #a78bfa;
+            }
+        }
+        </style>
+        <div class="ollama-translation-container" style="margin: 30px 0; padding: 20px; background-color: var(--ollama-bg, #faf9ff); border: 1.5px solid var(--ollama-border, #dbd5ff); border-radius: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; box-sizing: border-box;">
+            <div class="ollama-translation-header" style="display: flex; align-items: center; margin-bottom: 12px;">
+                <span class="ollama-translation-icon" style="font-size: 1.1em; margin-right: 8px; color: var(--ollama-brand, #7c3aed); display: inline-flex; align-items: center;">✨</span>
+                <span class="ollama-translation-title" style="font-size: 0.9em; font-weight: 600; color: var(--ollama-brand, #7c3aed); letter-spacing: 0.03em;">\(title)</span>
+            </div>
+            <div id="ollama-translation" class="ollama-translation-content" style="font-size: 0.95em; line-height: 1.6; color: inherit; white-space: pre-wrap;">\(content)</div>
+        </div>
+        """
+    }
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 # NetNewsWire
 
+> ⚠️ **Note on this Fork:** This is a custom fork maintained by [@Ian729](https://github.com/Ian729).
+> Unlike the official upstream [Ranchero-Software/NetNewsWire](https://github.com/Ranchero-Software/NetNewsWire), this version includes:
+> - **AI-Powered Automatic Translation & Preloading:** Integrated with a local Ollama client to automatically translate feeds into your preferred language.
+> - **Beautiful AI Translation Interface:** Displayed in a gorgeous, modern rounded card matching the official styling (with seamless dark & light mode support).
+
 NetNewsWire is a free and open-source feed reader for macOS and iOS.
 
 It supports [RSS](https://cyber.harvard.edu/rss/rss.html), [Atom](https://datatracker.ietf.org/doc/html/rfc4287), [JSON Feed](https://jsonfeed.org/), and [RSS-in-JSON](https://github.com/scripting/Scripting-News/blob/master/rss-in-json/README.md) formats.

--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -399,7 +399,12 @@ final class AppDefaults: Sendable {
 										Key.confirmMarkAllAsRead: true,
 										Key.articleContentJavascriptEnabled: true,
 										Key.currentThemeName: Self.defaultThemeName,
-									   Key.splitViewPreferredDisplayMode: UISplitViewController.DisplayMode.oneBesideSecondary.rawValue]
+									   Key.splitViewPreferredDisplayMode: UISplitViewController.DisplayMode.oneBesideSecondary.rawValue,
+									   Key.ollamaBaseURL: "http://localhost:11434/api",
+									   Key.ollamaModel: "llama3",
+									   Key.ollamaPreferredLanguage: "Chinese",
+									   Key.ollamaPreloadCount: 10,
+									   Key.ollamaAutoTranslate: false]
 		AppDefaults.store.register(defaults: defaults)
 	}
 }

--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -400,7 +400,12 @@ final class AppDefaults: Sendable {
 										Key.confirmMarkAllAsRead: true,
 										Key.articleContentJavascriptEnabled: true,
 										Key.currentThemeName: Self.defaultThemeName,
-									   Key.splitViewPreferredDisplayMode: UISplitViewController.DisplayMode.oneBesideSecondary.rawValue]
+									   Key.splitViewPreferredDisplayMode: UISplitViewController.DisplayMode.oneBesideSecondary.rawValue,
+									   Key.ollamaBaseURL: "http://localhost:11434/api",
+									   Key.ollamaModel: "llama3",
+									   Key.ollamaPreferredLanguage: "Chinese",
+									   Key.ollamaPreloadCount: 10,
+									   Key.ollamaAutoTranslate: false]
 		AppDefaults.store.register(defaults: defaults)
 	}
 }

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -611,7 +611,7 @@ private extension WebViewController {
 		var textToTranslate = ""
 
 		if let article = self.article, UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") {
-			textToTranslate = self.extractedArticle?.content ?? article.body ?? ""
+			textToTranslate = (self.extractedArticle?.content ?? article.body ?? "").strippingHTML(maxCharacters: 4000)
 			
 			if !textToTranslate.isEmpty {
 				if let cached = OllamaClient.shared.cachedTranslation(articleID: article.articleID) {
@@ -669,7 +669,7 @@ private extension WebViewController {
 			function updateTranslation() {
 				var translationDiv = document.getElementById('ollama-translation');
 				if (translationDiv) {
-					translationDiv.innerHTML = \"\(encoded)\";
+					translationDiv.innerText = \"\(encoded)\";
 				} else {
 					setTimeout(updateTranslation, 100);
 				}

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -606,11 +606,28 @@ private extension WebViewController {
 			rendering = ArticleRenderer.noSelectionHTML(theme: theme)
 		}
 
+		var bodyHTML = rendering.html
+		var requestTranslation = false
+		var textToTranslate = ""
+
+		if let article = self.article, UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") {
+			textToTranslate = self.extractedArticle?.content ?? article.body ?? ""
+			
+			if !textToTranslate.isEmpty {
+				if let cached = OllamaClient.shared.cachedTranslation(articleID: article.articleID) {
+					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'>\(cached)</div>"
+				} else {
+					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'><i>Translating...</i></div>"
+					requestTranslation = true
+				}
+			}
+		}
+
 		let substitutions = [
 			"title": rendering.title,
 			"baseURL": rendering.baseURL,
 			"style": rendering.style,
-			"body": rendering.html,
+			"body": bodyHTML,
 			"windowScrollY": String(windowScrollY)
 		]
 
@@ -626,6 +643,40 @@ private extension WebViewController {
 
 		WebViewConfiguration.addContentBlockingRules(to: webView)
 		webView.loadHTMLString(html, baseURL: ArticleRenderer.page.baseURL)
+
+		if requestTranslation {
+			OllamaClient.shared.translate(articleID: self.article!.articleID, text: textToTranslate) { [weak self, articleID = self.article!.articleID] result in
+				DispatchQueue.main.async {
+					guard let self = self, self.article?.articleID == articleID else { return }
+					if case .success(let translated) = result {
+						self.injectTranslation(translated)
+					} else if case .failure(let error) = result {
+						self.injectTranslation("<i>Translation failed: \(error.localizedDescription)</i>")
+					}
+				}
+			}
+		}
+	}
+
+	func injectTranslation(_ translatedText: String) {
+		let encoded = translatedText
+			.replacingOccurrences(of: "\\", with: "\\\\")
+			.replacingOccurrences(of: "\"", with: "\\\"")
+			.replacingOccurrences(of: "\n", with: "\\n")
+			.replacingOccurrences(of: "\r", with: "\\r")
+		
+		let js = """
+			function updateTranslation() {
+				var translationDiv = document.getElementById('ollama-translation');
+				if (translationDiv) {
+					translationDiv.innerHTML = \"\(encoded)\";
+				} else {
+					setTimeout(updateTranslation, 100);
+				}
+			}
+			updateTranslation();
+		"""
+		webView?.evaluateJavaScript(js)
 	}
 
 	func finalScrollPosition(scrollingUp: Bool) -> CGFloat {

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -626,11 +626,28 @@ private extension WebViewController {
 			rendering = ArticleRenderer.noSelectionHTML(theme: theme)
 		}
 
+		var bodyHTML = rendering.html
+		var requestTranslation = false
+		var textToTranslate = ""
+
+		if let article = self.article, UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") {
+			textToTranslate = self.extractedArticle?.content ?? article.body ?? ""
+			
+			if !textToTranslate.isEmpty {
+				if let cached = OllamaClient.shared.cachedTranslation(articleID: article.articleID) {
+					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'>\(cached)</div>"
+				} else {
+					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'><i>Translating...</i></div>"
+					requestTranslation = true
+				}
+			}
+		}
+
 		let substitutions = [
 			"title": rendering.title,
 			"baseURL": rendering.baseURL,
 			"style": rendering.style,
-			"body": rendering.html,
+			"body": bodyHTML,
 			"windowScrollY": String(windowScrollY)
 		]
 
@@ -646,6 +663,40 @@ private extension WebViewController {
 
 		WebViewConfiguration.addContentBlockingRules(to: webView)
 		webView.loadHTMLString(html, baseURL: ArticleRenderer.page.baseURL)
+
+		if requestTranslation {
+			OllamaClient.shared.translate(articleID: self.article!.articleID, text: textToTranslate) { [weak self, articleID = self.article!.articleID] result in
+				DispatchQueue.main.async {
+					guard let self = self, self.article?.articleID == articleID else { return }
+					if case .success(let translated) = result {
+						self.injectTranslation(translated)
+					} else if case .failure(let error) = result {
+						self.injectTranslation("<i>Translation failed: \(error.localizedDescription)</i>")
+					}
+				}
+			}
+		}
+	}
+
+	func injectTranslation(_ translatedText: String) {
+		let encoded = translatedText
+			.replacingOccurrences(of: "\\", with: "\\\\")
+			.replacingOccurrences(of: "\"", with: "\\\"")
+			.replacingOccurrences(of: "\n", with: "\\n")
+			.replacingOccurrences(of: "\r", with: "\\r")
+		
+		let js = """
+			function updateTranslation() {
+				var translationDiv = document.getElementById('ollama-translation');
+				if (translationDiv) {
+					translationDiv.innerHTML = \"\(encoded)\";
+				} else {
+					setTimeout(updateTranslation, 100);
+				}
+			}
+			updateTranslation();
+		"""
+		webView?.evaluateJavaScript(js)
 	}
 
 	func finalScrollPosition(scrollingUp: Bool) -> CGFloat {

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -635,9 +635,9 @@ private extension WebViewController {
 			
 			if !textToTranslate.isEmpty {
 				if let cached = OllamaClient.shared.cachedTranslation(articleID: article.articleID) {
-					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'>\(cached)</div>"
+					bodyHTML += OllamaClient.translationHTML(content: cached)
 				} else {
-					bodyHTML += "<hr id='ollama-divider' style='margin: 2em 0;'><div id='ollama-translation'><i>Translating...</i></div>"
+					bodyHTML += OllamaClient.translationHTML(content: "<i>Translating...</i>")
 					requestTranslation = true
 				}
 			}
@@ -671,7 +671,7 @@ private extension WebViewController {
 					if case .success(let translated) = result {
 						self.injectTranslation(translated)
 					} else if case .failure(let error) = result {
-						self.injectTranslation("<i>Translation failed: \(error.localizedDescription)</i>")
+						self.injectTranslation("Translation failed: \(error.localizedDescription)")
 					}
 				}
 			}

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -631,7 +631,7 @@ private extension WebViewController {
 		var textToTranslate = ""
 
 		if let article = self.article, UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") {
-			textToTranslate = self.extractedArticle?.content ?? article.body ?? ""
+			textToTranslate = (self.extractedArticle?.content ?? article.body ?? "").strippingHTML(maxCharacters: 4000)
 			
 			if !textToTranslate.isEmpty {
 				if let cached = OllamaClient.shared.cachedTranslation(articleID: article.articleID) {
@@ -689,7 +689,7 @@ private extension WebViewController {
 			function updateTranslation() {
 				var translationDiv = document.getElementById('ollama-translation');
 				if (translationDiv) {
-					translationDiv.innerHTML = \"\(encoded)\";
+					translationDiv.innerText = \"\(encoded)\";
 				} else {
 					setTimeout(updateTranslation, 100);
 				}

--- a/iOS/MainTimeline/MainTimelineModernViewController.swift
+++ b/iOS/MainTimeline/MainTimelineModernViewController.swift
@@ -504,6 +504,26 @@ extension MainTimelineModernViewController: UICollectionViewDelegate {
 		becomeFirstResponder()
 		if let dataSource {
 			let article = dataSource.itemIdentifier(for: indexPath)
+			
+			if UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") {
+				let count = UserDefaults.standard.object(forKey: "OllamaPreloadCount") != nil ? UserDefaults.standard.integer(forKey: "OllamaPreloadCount") : 10
+				if count > 0 {
+					let snapshot = dataSource.snapshot()
+					let articles = snapshot.itemIdentifiers
+					if let article = article, let index = articles.firstIndex(of: article) {
+						let nextIndex = index + 1
+						if nextIndex < articles.count {
+							let limit = min(articles.count, nextIndex + count)
+							let itemsToPreload = articles[nextIndex..<limit].compactMap { (a: Article) -> (id: String, text: String)? in
+								let text = a.body ?? ""
+								return text.isEmpty ? nil : (a.articleID, text)
+							}
+							OllamaClient.shared.preloadTranslations(items: itemsToPreload)
+						}
+					}
+				}
+			}
+			
 			coordinator?.selectArticle(article, animations: [.scroll, .select, .navigation])
 		}
 	}

--- a/iOS/MainTimeline/MainTimelineModernViewController.swift
+++ b/iOS/MainTimeline/MainTimelineModernViewController.swift
@@ -515,7 +515,7 @@ extension MainTimelineModernViewController: UICollectionViewDelegate {
 						if nextIndex < articles.count {
 							let limit = min(articles.count, nextIndex + count)
 							let itemsToPreload = articles[nextIndex..<limit].compactMap { (a: Article) -> (id: String, text: String)? in
-								let text = a.body ?? ""
+								let text = (a.body ?? "").strippingHTML(maxCharacters: 4000)
 								return text.isEmpty ? nil : (a.articleID, text)
 							}
 							OllamaClient.shared.preloadTranslations(items: itemsToPreload)

--- a/iOS/MainTimeline/MainTimelineModernViewController.swift
+++ b/iOS/MainTimeline/MainTimelineModernViewController.swift
@@ -510,6 +510,26 @@ extension MainTimelineModernViewController: UICollectionViewDelegate {
 		becomeFirstResponder()
 		if let dataSource {
 			let article = dataSource.itemIdentifier(for: indexPath)
+			
+			if UserDefaults.standard.bool(forKey: "OllamaAutoTranslate") {
+				let count = UserDefaults.standard.object(forKey: "OllamaPreloadCount") != nil ? UserDefaults.standard.integer(forKey: "OllamaPreloadCount") : 10
+				if count > 0 {
+					let snapshot = dataSource.snapshot()
+					let articles = snapshot.itemIdentifiers
+					if let article = article, let index = articles.firstIndex(of: article) {
+						let nextIndex = index + 1
+						if nextIndex < articles.count {
+							let limit = min(articles.count, nextIndex + count)
+							let itemsToPreload = articles[nextIndex..<limit].compactMap { (a: Article) -> (id: String, text: String)? in
+								let text = a.body ?? ""
+								return text.isEmpty ? nil : (a.articleID, text)
+							}
+							OllamaClient.shared.preloadTranslations(items: itemsToPreload)
+						}
+					}
+				}
+			}
+			
 			coordinator?.selectArticle(article, animations: [.scroll, .select, .navigation])
 		}
 	}

--- a/iOS/MainTimeline/MainTimelineModernViewController.swift
+++ b/iOS/MainTimeline/MainTimelineModernViewController.swift
@@ -521,7 +521,7 @@ extension MainTimelineModernViewController: UICollectionViewDelegate {
 						if nextIndex < articles.count {
 							let limit = min(articles.count, nextIndex + count)
 							let itemsToPreload = articles[nextIndex..<limit].compactMap { (a: Article) -> (id: String, text: String)? in
-								let text = a.body ?? ""
+								let text = (a.body ?? "").strippingHTML(maxCharacters: 4000)
 								return text.isEmpty ? nil : (a.articleID, text)
 							}
 							OllamaClient.shared.preloadTranslations(items: itemsToPreload)


### PR DESCRIPTION
- Add Ollama configuration tab in macOS Preferences
- Auto-translate articles and display translation at the bottom
- Show 'Translating...' indicator while translation is in progress
- Implement background preloading for the next X articles in the timeline