### PR TITLE
🐛 Fix full-screen article view

### DIFF
--- a/iOS/Article/ArticleViewController.swift
+++ b/iOS/Article/ArticleViewController.swift
@@ -227,14 +227,6 @@ final class ArticleViewController: UIViewController {
 		view.layoutIfNeeded()
 	}
 
-	override func willTransition(to newCollection: UITraitCollection, with coordinator: any UIViewControllerTransitionCoordinator) {
-		// We only want to show bars when rotating to horizontalSizeClass == .regular
-		// (i.e., big) iPhones to resolve crash #4483.
-		if traitCollection.userInterfaceIdiom == .phone && newCollection.horizontalSizeClass == .regular {
-			currentWebViewController?.showBars()
-		}
-	}
-
 	func updateUI() {
 
 		guard let article = article else {

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -38,7 +38,7 @@ final class WebViewController: UIViewController {
 
 	private lazy var contextMenuInteraction = UIContextMenuInteraction(delegate: self)
 	private var isFullScreenAvailable: Bool {
-		return AppDefaults.shared.articleFullscreenAvailable && traitCollection.userInterfaceIdiom == .phone && coordinator.isRootSplitCollapsed
+		return AppDefaults.shared.articleFullscreenAvailable && traitCollection.userInterfaceIdiom == .phone
 	}
 	private lazy var articleIconSchemeHandler = ArticleIconSchemeHandler(coordinator: coordinator)
 	private lazy var transition = ImageTransition(controller: self)


### PR DESCRIPTION
Remove the split view collapse check from the full-screen availability condition and drop the trait collection transition override that forced bars to appear on rotation. Fixes #5145.