### PR TITLE
Add Korean localization support

### DIFF
--- a/Intents/ko.lproj/Intents.strings
+++ b/Intents/ko.lproj/Intents.strings
@@ -1,0 +1,56 @@
+/* (No Comment) */
+"4xjRes" = "URL을 입력해야 합니다.";
+
+/* (No Comment) */
+"5CYbGL" = "‘${folderName}’에 해당하는 항목이 ${count}개 있습니다.";
+
+/* (No Comment) */
+"BCHr23" = "URL";
+
+/* (No Comment) */
+"CSrgUY" = "계정 이름";
+
+/* (No Comment) */
+"dkSFD2" = "${accountName}의 ${folderName}에 ${url} 추가";
+
+/* (No Comment) */
+"ef5kBt" = "유효한 폴더 이름이 필요합니다.";
+
+/* (No Comment) */
+"ExjqcE" = "NetNewsWire와 통신할 수 없습니다.";
+
+/* (No Comment) */
+"fWs3li" = "어느 것인가요?";
+
+/* (No Comment) */
+"gEzXaM" = "어느 것인가요?";
+
+/* (No Comment) */
+"HHiZUh" = "확인차 묻겠습니다. ‘${accountName}’ 말씀이신가요?";
+
+/* (No Comment) */
+"IbqUVS" = "‘${accountName}’에 해당하는 항목이 ${count}개 있습니다.";
+
+/* (No Comment) */
+"IuAbef" = "웹 피드 추가";
+
+/* (No Comment) */
+"JGkCuS" = "유효한 계정 이름이 필요합니다.";
+
+/* (No Comment) */
+"jLLidQ" = "추가하려는 ${url}은 무엇인가요?";
+
+/* (No Comment) */
+"k5GTo0" = "확인차 묻겠습니다. ‘${folderName}’ 말씀이신가요?";
+
+/* (No Comment) */
+"kaKsEY" = "${accountName}에 ${url} 추가";
+
+/* (No Comment) */
+"oV681v" = "웹 피드 추가";
+
+/* (No Comment) */
+"uSfloN" = "NetNewsWire와 통신할 수 없습니다.";
+
+/* (No Comment) */
+"zXhMPF" = "폴더 이름";

--- a/Mac/MainWindow/AddFeed/FolderTreeMenu.swift
+++ b/Mac/MainWindow/AddFeed/FolderTreeMenu.swift
@@ -15,7 +15,7 @@ import Account
 
 	@MainActor static func createFolderPopupMenu(with rootNode: Node, restrictToSpecialAccounts: Bool = false) -> NSMenu {
 
-		let menu = NSMenu(title: "Folders")
+		let menu = NSMenu(title: NSLocalizedString("Folders", comment: "Add feed destination folder popup menu title"))
 		menu.autoenablesItems = false
 
 		for childNode in rootNode.childNodes {

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -995,7 +995,8 @@ extension TimelineViewController: NSTableViewDelegate {
 
 		switch edge {
 		case .leading:
-			let action = NSTableViewRowAction(style: .regular, title: article.status.read ? "Unread" : "Read") { (_, _) in
+			let actionTitle = article.status.read ? NSLocalizedString("Unread", comment: "Swipe action title to mark an article unread") : NSLocalizedString("Read", comment: "Swipe action title to mark an article read")
+			let action = NSTableViewRowAction(style: .regular, title: actionTitle) { (_, _) in
 				self.toggleArticleRead(article)
 				tableView.rowActionsVisible = false
 			}
@@ -1003,7 +1004,8 @@ extension TimelineViewController: NSTableViewDelegate {
 			return [action]
 
 		case .trailing:
-			let action = NSTableViewRowAction(style: .regular, title: article.status.starred ? "Unstar" : "Star") { (_, _) in
+			let actionTitle = article.status.starred ? NSLocalizedString("Unstar", comment: "Swipe action title to remove a star from an article") : NSLocalizedString("Star", comment: "Swipe action title to star an article")
+			let action = NSTableViewRowAction(style: .regular, title: actionTitle) { (_, _) in
 				self.toggleArticleStarred(article)
 				tableView.rowActionsVisible = false
 			}

--- a/Mac/Preferences/Accounts/AccountsDetailView.swift
+++ b/Mac/Preferences/Accounts/AccountsDetailView.swift
@@ -8,6 +8,16 @@
 import SwiftUI
 import Account
 
+private enum AccountsDetailLocalizedStrings {
+	static let type = NSLocalizedString("Type:", comment: "Account details type label")
+	static let active = NSLocalizedString("Active", comment: "Account details active toggle")
+	static let name = NSLocalizedString("Name:", comment: "Account details name label")
+	static let nameHelp = NSLocalizedString("The name can be anything you want. You can even use emoji. 🎸", comment: "Account details name help text")
+	static let credentials = NSLocalizedString("Credentials", comment: "Account details credentials button")
+	static let syncUnreadContent = NSLocalizedString("Sync content of unread articles", comment: "Account details sync unread content toggle")
+	static let syncUnreadContentHelp = NSLocalizedString("Syncing article content increases iCloud storage use, sync time, and battery use.\n\nArticle status and the content of starred articles are always synced.", comment: "Account details sync unread content help text")
+}
+
 struct AccountsDetailView: View {
 
 	let account: Account
@@ -38,7 +48,7 @@ struct AccountsDetailView: View {
 		VStack(alignment: .leading, spacing: 0) {
 			Grid(alignment: .leading, verticalSpacing: 0) {
 				GridRow(alignment: .firstTextBaseline) {
-					Text("Type:")
+					Text(AccountsDetailLocalizedStrings.type)
 						.gridColumnAlignment(.trailing)
 					Text(account.defaultName)
 				}
@@ -46,7 +56,7 @@ struct AccountsDetailView: View {
 				GridRow {
 					Color.clear
 						.gridCellUnsizedAxes([.horizontal, .vertical])
-					Toggle("Active", isOn: $isActive)
+					Toggle(AccountsDetailLocalizedStrings.active, isOn: $isActive)
 						.onChange(of: isActive) {
 							account.isActive = isActive
 						}
@@ -54,7 +64,7 @@ struct AccountsDetailView: View {
 				}
 
 				GridRow(alignment: .firstTextBaseline) {
-					Text("Name:")
+					Text(AccountsDetailLocalizedStrings.name)
 					TextField("", text: $accountName)
 						.frame(width: 150)
 						.onSubmit {
@@ -69,7 +79,7 @@ struct AccountsDetailView: View {
 				GridRow {
 					Color.clear
 						.gridCellUnsizedAxes([.horizontal, .vertical])
-					Text("The name can be anything you want. You can even use emoji. 🎸")
+					Text(AccountsDetailLocalizedStrings.nameHelp)
 						.foregroundStyle(.secondary)
 						.fixedSize(horizontal: false, vertical: true)
 						.padding(.top, 1)
@@ -79,7 +89,7 @@ struct AccountsDetailView: View {
 					GridRow {
 						Color.clear
 							.gridCellUnsizedAxes([.horizontal, .vertical])
-						Button("Credentials") {
+						Button(AccountsDetailLocalizedStrings.credentials) {
 							onCredentials?()
 						}
 						.padding(.top, 12)
@@ -88,13 +98,13 @@ struct AccountsDetailView: View {
 			}
 
 			if account.type == .cloudKit {
-				Toggle("Sync content of unread articles", isOn: $syncUnreadContent)
+				Toggle(AccountsDetailLocalizedStrings.syncUnreadContent, isOn: $syncUnreadContent)
 					.onChange(of: syncUnreadContent) {
 						AccountManager.shared.syncArticleContentForUnreadArticles = syncUnreadContent
 					}
 					.padding(.top, 12)
 
-				Text("Syncing article content increases iCloud storage use, sync time, and battery use.\n\nArticle status and the content of starred articles are always synced.")
+				Text(AccountsDetailLocalizedStrings.syncUnreadContentHelp)
 					.foregroundStyle(.secondary)
 					.fixedSize(horizontal: false, vertical: true)
 					.padding(.top, 4)

--- a/Mac/Preferences/Accounts/AccountsPreferencesViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsPreferencesViewController.swift
@@ -68,9 +68,10 @@ final class AccountsPreferencesViewController: NSViewController {
 
 		let alert = NSAlert()
 		alert.alertStyle = .warning
-		let deletePrompt = NSLocalizedString("Delete", comment: "Delete")
-		alert.messageText = "\(deletePrompt) “\(accountName)”?"
-		alert.informativeText = NSLocalizedString("Are you sure you want to delete the account “\(accountName)”? This cannot be undone.", comment: "Delete text")
+		let deleteTitleFormat = NSLocalizedString("Delete “%@”?", comment: "Delete account alert title")
+		alert.messageText = String.localizedStringWithFormat(deleteTitleFormat, accountName)
+		let deleteInformativeTextFormat = NSLocalizedString("Are you sure you want to delete the account “%@”? This cannot be undone.", comment: "Delete account alert text")
+		alert.informativeText = String.localizedStringWithFormat(deleteInformativeTextFormat, accountName)
 
 		alert.addButton(withTitle: NSLocalizedString("Delete", comment: "Delete Account"))
 		alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "Cancel Delete Account"))

--- a/Mac/Preferences/Accounts/AddAccountsView.swift
+++ b/Mac/Preferences/Accounts/AddAccountsView.swift
@@ -10,6 +10,13 @@ import SwiftUI
 import Account
 import RSCore
 
+private enum AddAccountsLocalizedStrings {
+	static let chooseAccountType = NSLocalizedString("Choose an account type to add…", comment: "Add account picker title")
+	static let cancel = NSLocalizedString("Cancel", comment: "Cancel add account button")
+	static let continueButton = NSLocalizedString("Continue", comment: "Continue add account button")
+	static let addAccountHelp = NSLocalizedString("Add Account", comment: "Add account button help")
+}
+
 enum AddAccountSections: Int, CaseIterable {
 	case local = 0
 	case icloud
@@ -83,7 +90,7 @@ struct AddAccountsView: View {
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: 8) {
-			Text("Choose an account type to add…")
+			Text(AddAccountsLocalizedStrings.chooseAccountType)
 				.font(.headline)
 				.padding()
 
@@ -101,19 +108,19 @@ struct AddAccountsView: View {
 				Button(action: {
 					parent?.dismiss(nil)
 				}, label: {
-					Text("Cancel")
+					Text(AddAccountsLocalizedStrings.cancel)
 						.frame(width: 76)
 				})
-				.help("Cancel")
+				.help(AddAccountsLocalizedStrings.cancel)
 				.keyboardShortcut(.cancelAction)
 				Button(action: {
 					addAccountDelegate?.presentSheetForAccount(selectedAccount)
 					parent?.dismiss(nil)
 				}, label: {
-					Text("Continue")
+					Text(AddAccountsLocalizedStrings.continueButton)
 						.frame(width: 76)
 				})
-				.help("Add Account")
+				.help(AddAccountsLocalizedStrings.addAccountHelp)
 				.keyboardShortcut(.defaultAction)
 			}
 			.padding(.top, 12)
@@ -127,7 +134,7 @@ struct AddAccountsView: View {
 
 	var localAccount: some View {
 		VStack(alignment: .leading) {
-			Text("Local")
+			Text(AddAccountSections.local.sectionHeader)
 				.font(.headline)
 				.padding(.horizontal)
 
@@ -158,7 +165,7 @@ struct AddAccountsView: View {
 
 	var icloudAccount: some View {
 		VStack(alignment: .leading) {
-			Text("iCloud")
+			Text(AddAccountSections.icloud.sectionHeader)
 				.font(.headline)
 				.padding(.horizontal)
 				.padding(.top, 8)
@@ -190,7 +197,7 @@ struct AddAccountsView: View {
 	@ViewBuilder
 	var webAccounts: some View {
 		VStack(alignment: .leading) {
-			Text("Web")
+			Text(AddAccountSections.web.sectionHeader)
 				.font(.headline)
 				.padding(.horizontal)
 				.padding(.top, 8)
@@ -228,7 +235,7 @@ struct AddAccountsView: View {
 
 	var selfhostedAccounts: some View {
 		VStack(alignment: .leading) {
-			Text("Self-hosted")
+			Text(AddAccountSections.selfhosted.sectionHeader)
 				.font(.headline)
 				.padding(.horizontal)
 				.padding(.top, 8)

--- a/Mac/Resources/ko.lproj/InfoPlist.strings
+++ b/Mac/Resources/ko.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* Bundle name */
+"CFBundleName" = "NetNewsWire";
+
+/* No comment provided by engineer. */
+"NetNewsWire Theme" = "NetNewsWire 테마";
+
+/* Privacy - AppleEvents Sending Usage Description */
+"NSAppleEventsUsageDescription" = "NetNewsWire는 기사를 공유하기로 선택하면 Mac의 다른 앱과 통신합니다.";
+
+/* Copyright (human-readable) */
+"NSHumanReadableCopyright" = "저작권 © 2002-2026 Brent Simmons. 모든 권리 보유.";
+
+/* No comment provided by engineer. */
+"OPML" = "OPML";

--- a/Mac/Resources/ko.lproj/Localizable.strings
+++ b/Mac/Resources/ko.lproj/Localizable.strings
@@ -1,0 +1,715 @@
+/* No Text */
+"(No Text)" = "(텍스트 없음)";
+
+/* Status bar progress */
+"%@ of %@" = "%2$@ 중 %1$@";
+
+/* Unread */
+"%d unread" = "읽지 않은 항목 %d개";
+
+/* Alert informative text when adding a Feedly account and waiting for authorization from the user. */
+"A web browser will open the Feedly login for you to authorize access." = "액세스 승인을 위해 웹 브라우저에서 Feedly 로그인 페이지가 열립니다.";
+
+/* Preferences */
+"Accounts" = "계정";
+
+/* Account details active toggle */
+"Active" = "활성";
+
+/* Add account button help */
+"Add Account" = "계정 추가";
+
+/* Add Account Explainer */
+"Add an account by clicking the + button." = "+ 버튼을 클릭하여 계정을 추가하세요.";
+
+/* Add Item */
+"Add Item" = "항목 추가";
+
+/* Preferences */
+"Advanced" = "고급";
+
+/* All Unread pseudo-feed title */
+"All Unread" = "전체 읽지 않음";
+
+/* Feed finder */
+"Already subscribed" = "이미 구독 중";
+
+/* Always Use Reader View */
+"Always Use Reader View" = "항상 리더 보기 사용";
+
+/* Feed delete text */
+"Are you sure you want to delete the “%@” feed?" = "“%@” 피드를 정말 삭제하시겠습니까?";
+
+/* Folder delete text */
+"Are you sure you want to delete the “%@” folder?" = "“%@” 폴더를 정말 삭제하시겠습니까?";
+
+/* Items delete text */
+"Are you sure you want to delete the %d selected items?" = "선택한 %d개 항목을 정말 삭제하시겠습니까?";
+
+/* Delete account alert text */
+"Are you sure you want to delete the account “%@”? This cannot be undone." = "계정 “%@”을 삭제하시겠습니까? 이 작업은 실행 취소할 수 없습니다.";
+
+/* Article */
+"Article" = "기사";
+
+/* Article content records section header */
+"Article Content Records" = "기사 콘텐츠 레코드";
+
+/* Article Theme */
+"Article Theme" = "기사 테마";
+
+/* Author's Website */
+"Author‘s website:" = "작성자 웹사이트:";
+
+/* Account name */
+"BazQux" = "BazQux";
+
+/* Feed finder */
+"Can’t add a feed because no feed was found." = "피드를 찾지 못해 추가할 수 없습니다.";
+
+/* CloudKit account setup failure description — iCloud Drive not enabled. */
+"Can’t Add iCloud Account" = "iCloud 계정을 추가할 수 없음";
+
+/* Feed finder */
+"Can’t add this feed because of a download error: “%@”" = "다운로드 오류로 인해 이 피드를 추가할 수 없습니다: “%@”";
+
+/* Feed finder */
+"Can’t add this feed because you’ve already subscribed to it." = "이미 구독 중인 피드이므로 이 피드를 추가할 수 없습니다.";
+
+/* Cancel
+Cancel Delete Account
+Cancel Install Theme
+Cancel add account button
+Cancel button */
+"Cancel" = "취소";
+
+/* Scan status text when canceled */
+"Canceled." = "취소되었습니다.";
+
+/* Export OPML */
+"Choose a location for the exported OPML file." = "내보낼 OPML 파일의 위치를 선택하세요.";
+
+/* NNW3 Import */
+"Choose a Subscriptions.plist file:" = "Subscriptions.plist 파일을 선택하세요:";
+
+/* Add account picker title */
+"Choose an account type to add…" = "추가할 계정 유형을 선택하세요…";
+
+/* Clean Up
+Clean Up button title
+Clean up alert button */
+"Clean Up" = "정리";
+
+/* Clean up alert title */
+"Clean Up iCloud Records" = "iCloud 레코드 정리";
+
+/* Cleanup status text when canceled */
+"Cleanup canceled." = "정리가 취소되었습니다.";
+
+/* Cleanup error message */
+"Cleanup failed to complete, but you may be able to clean up more if you wait a few minutes and try again.\n\nClick Refresh to see your updated stats." = "정리를 완료하지 못했습니다. 몇 분 기다렸다가 다시 시도하면 더 정리될 수 있습니다.\n\n새로 고침을 클릭하면 업데이트된 통계를 볼 수 있습니다.";
+
+/* Progress bar accessibility label */
+"Cleanup progress" = "정리 진행률";
+
+/* Close */
+"Close" = "닫기";
+
+/* Status icon accessibility description */
+"Completed" = "완료됨";
+
+/* Continue add account button */
+"Continue" = "계속";
+
+/* Command */
+"Copy Article URL" = "기사 URL 복사";
+
+/* Copy Contents button */
+"Copy Contents" = "내용 복사";
+
+/* Command */
+"Copy External URL" = "외부 URL 복사";
+
+/* Command */
+"Copy Feed URL" = "피드 URL 복사";
+
+/* Command */
+"Copy Home Page URL" = "홈페이지 URL 복사";
+
+/* Scan error alert title */
+"Couldn’t complete the iCloud scan because of an error:" = "오류로 인해 iCloud 스캔을 완료하지 못했습니다:";
+
+/* Add Account
+Create */
+"Create" = "생성";
+
+/* Account Local */
+"Create a local account on your Mac." = "Mac에 로컬 계정을 생성합니다.";
+
+/* Account details credentials button */
+"Credentials" = "자격 증명";
+
+/* Default */
+"Default" = "기본";
+
+/* Command
+Delete Account */
+"Delete" = "삭제";
+
+/* Delete account alert title */
+"Delete “%@”?" = "“%@”을 삭제할까요?";
+
+/* Delete Feed
+command */
+"Delete Feed" = "피드 삭제";
+
+/* command */
+"Delete Feeds" = "피드 삭제";
+
+/* command */
+"Delete Feeds and Folders" = "피드 및 폴더 삭제";
+
+/* Delete Folder
+command */
+"Delete Folder" = "폴더 삭제";
+
+/* command */
+"Delete Folders" = "폴더 삭제";
+
+/* Delete Items */
+"Delete Items" = "항목 삭제";
+
+/* Cleanup phase text */
+"Deleting read content records…" = "읽은 콘텐츠 레코드를 삭제하는 중…";
+
+/* Cleanup phase text */
+"Deleting unread content records…" = "읽지 않은 콘텐츠 레코드를 삭제하는 중…";
+
+/* Dismiss */
+"Dismiss" = "닫기";
+
+/* No BazQux */
+"Don’t have a BazQux account?" = "BazQux 계정이 없으신가요?";
+
+/* No FreshRSS */
+"Don’t have a FreshRSS instance?" = "FreshRSS 인스턴스가 없으신가요?";
+
+/* No OldReader */
+"Don’t have a The Old Reader account?" = "The Old Reader 계정이 없으신가요?";
+
+/* No Inoreader */
+"Don’t have an Inoreader account?" = "Inoreader 계정이 없으신가요?";
+
+/* Feed finder */
+"Download Error" = "다운로드 오류";
+
+/* Notifications */
+"Enable Notifications" = "알림 활성화";
+
+/* Error - Reader View */
+"Error - Reader View" = "오류 - 리더 보기";
+
+/* Error Log window title */
+"Error Log" = "오류 로그";
+
+/* Error log privacy warning */
+"Errors may contain feed URLs and other information you may not want to share publicly." = "오류에는 공개적으로 공유하고 싶지 않을 수 있는 피드 URL 및 기타 정보가 포함될 수 있습니다.";
+
+/* Every 2 Hours */
+"Every 2 Hours" = "2시간마다";
+
+/* Every 4 Hours */
+"Every 4 Hours" = "4시간마다";
+
+/* Every 8 Hours */
+"Every 8 Hours" = "8시간마다";
+
+/* Every 30 Minutes */
+"Every 30 Minutes" = "30분마다";
+
+/* Every Hour */
+"Every Hour" = "1시간마다";
+
+/* Export OPML */
+"Export OPML" = "OPML 내보내기";
+
+/* Export OPML */
+"Export to:" = "내보내기 위치:";
+
+/* XX-Large */
+"Extra Extra Large" = "아주 크게";
+
+/* X-Large */
+"Extra Large" = "매우 크게";
+
+/* Feed Inspector window title */
+"Feed Inspector" = "피드 인스펙터";
+
+/* Feed finder */
+"Feed not found" = "피드를 찾을 수 없음";
+
+/* Account name */
+"Feedbin" = "Feedbin";
+
+/* Account name */
+"Feedly" = "Feedly";
+
+/* No FreshRSS Button */
+"Find out more" = "자세히 알아보기";
+
+/* Feed finder */
+"Finding feed…" = "피드를 찾는 중…";
+
+/* Folder Inspector window title */
+"Folder Inspector" = "폴더 인스펙터";
+
+/* Add feed destination folder popup menu title */
+"Folders" = "폴더";
+
+/* Account name */
+"FreshRSS" = "FreshRSS";
+
+/* Preferences */
+"General" = "일반";
+
+/* Help button accessibility label */
+"Help — opens in browser" = "도움말 — 브라우저에서 열림";
+
+/* Command */
+"Hide Read Articles" = "읽은 기사 숨기기";
+
+/* Command */
+"Hide Read Feeds" = "읽은 피드 숨기기";
+
+/* FreshRSS API Helper */
+"https://fresh.rss.net/api/greader.php" = "https://fresh.rss.net/api/greader.php";
+
+/* Account name
+iCloud Account */
+"iCloud" = "iCloud";
+
+/* Cleanup phase text when completed */
+"iCloud storage cleanup completed." = "iCloud 저장 공간 정리가 완료되었습니다.";
+
+/* iCloud Storage Stats window title */
+"iCloud Storage Stats" = "iCloud 저장 공간 통계";
+
+/* Account name */
+"Inoreader" = "Inoreader";
+
+/* Inspector window title */
+"Inspector" = "인스펙터";
+
+/* Install Theme */
+"Install Theme" = "테마 설치";
+
+/* Theme message text */
+"Install theme “%@” by %@?" = "%2$@의 테마 “%1$@”을 설치하시겠습니까?";
+
+/* Invalid API URL */
+"Invalid API URL." = "올바르지 않은 API URL입니다.";
+
+/* Credentials Error */
+"Invalid email/password combination." = "이메일/비밀번호 조합이 올바르지 않습니다.";
+
+/* window title */
+"Keyboard Shortcuts" = "키보드 단축키";
+
+/* Credentials Error */
+"Keychain error while storing credentials." = "자격 증명을 저장하는 동안 키체인 오류가 발생했습니다.";
+
+/* Large */
+"Large" = "크게";
+
+/* Link */
+"Link:" = "링크:";
+
+/* Local Account */
+"Local" = "로컬";
+
+/* Local Account */
+"Local accounts do not sync feeds across devices" = "로컬 계정은 기기 간에 피드를 동기화하지 않습니다";
+
+/* Manually */
+"Manually" = "수동";
+
+/* Command */
+"Mark Above as Read" = "위를 읽음으로 표시";
+
+/* Command
+Mark All as Read */
+"Mark All as Read" = "모두 읽음으로 표시";
+
+/* Command */
+"Mark All as Read in “%@”" = "“%@”에서 모두 읽음으로 표시";
+
+/* Command
+Mark as Read */
+"Mark as Read" = "읽음으로 표시";
+
+/* Command
+Mark as Starred */
+"Mark as Starred" = "별표 표시";
+
+/* Command */
+"Mark as Unread" = "읽지 않음으로 표시";
+
+/* Command */
+"Mark as Unstarred" = "별표 해제";
+
+/* Command */
+"Mark Below as Read" = "아래를 읽음으로 표시";
+
+/* Mark Read
+command */
+"Mark Read" = "읽음 표시";
+
+/* command */
+"Mark Starred" = "별표 표시";
+
+/* command */
+"Mark Unread" = "읽지 않음 표시";
+
+/* command */
+"Mark Unstarred" = "별표 해제";
+
+/* Medium */
+"Medium" = "보통";
+
+/* Multiple */
+"Multiple" = "여러 항목";
+
+/* Account details name label */
+"Name:" = "이름:";
+
+/* Credentials Error */
+"Network error. Try again later." = "네트워크 오류입니다. 나중에 다시 시도하세요.";
+
+/* Command */
+"New Feed" = "새 피드";
+
+/* New Feed */
+"New Feed…" = "새 피드…";
+
+/* Command */
+"New Folder" = "새 폴더";
+
+/* New Folder */
+"New Folder…" = "새 폴더…";
+
+/* Account name */
+"NewsBlur" = "NewsBlur";
+
+/* Next Unread */
+"Next Unread" = "다음 읽지 않은 기사";
+
+/* Notifications are not enabled. */
+"Notifications are not enabled" = "알림이 활성화되어 있지 않습니다";
+
+/* OK
+OK button */
+"OK" = "확인";
+
+/* Open */
+"Open" = "열기";
+
+/* Command */
+"Open Home Page" = "홈페이지 열기";
+
+/* Command
+Open in Browser */
+"Open in Browser" = "브라우저에서 열기";
+
+/* Open in Browser in Background menu item title */
+"Open in Browser in Background" = "브라우저를 백그라운드에서 열기";
+
+/* Open in Browser in Foreground menu item title */
+"Open in Browser in Foreground" = "브라우저를 포그라운드에서 열기";
+
+/* Open Settings button */
+"Open Settings" = "설정 열기";
+
+/* CloudKit account setup recovery suggestion */
+"Open Settings to configure iCloud and enable iCloud Drive." = "설정을 열어 iCloud를 구성하고 iCloud Drive를 활성화하세요.";
+
+/* Open System Preferences */
+"Open System Preferences" = "시스템 환경설정 열기";
+
+/* Open System Settings button */
+"Open System Settings" = "시스템 설정 열기";
+
+/* CloudKit account setup recovery suggestion */
+"Open System Settings to configure iCloud and enable iCloud Drive." = "시스템 설정을 열어 iCloud를 구성하고 iCloud Drive를 활성화하세요.";
+
+/* Open Theme Folder */
+"Open Theme Folder" = "테마 폴더 열기";
+
+/* Overwrite */
+"Overwrite" = "덮어쓰기";
+
+/* Processing - Reader View */
+"Processing - Reader View" = "처리 중 - 리더 보기";
+
+/* Read row label
+Swipe action title to mark an article read */
+"Read" = "읽음";
+
+/* Read Articles Filter */
+"Read Articles Filter" = "읽은 기사 필터";
+
+/* Cleanup stat row label */
+"Read Content Deleted" = "읽은 콘텐츠 삭제됨";
+
+/* Singular label for read content records */
+"read content record" = "읽은 콘텐츠 레코드";
+
+/* Plural label for read content records */
+"read content records" = "읽은 콘텐츠 레코드";
+
+/* Reader View */
+"Reader View" = "리더 보기";
+
+/* Refresh
+Refresh button */
+"Refresh" = "새로고침";
+
+/* Refresh scan button */
+"Refresh Scan" = "스캔 새로고침";
+
+/* Command */
+"Rename" = "이름 변경";
+
+/* Rename sheet */
+"Rename %@ to:" = "%@의 새 이름:";
+
+/* Return to previous scan results button */
+"Return to Previous Scan Results" = "이전 스캔 결과로 돌아가기";
+
+/* Scan status text when completed */
+"Scan completed." = "스캔이 완료되었습니다.";
+
+/* Scan status text on error */
+"Scan failed. Numbers are incomplete." = "스캔에 실패했습니다. 수치가 완전하지 않습니다.";
+
+/* Spinner accessibility label */
+"Scanning" = "스캔 중";
+
+/* Scan status text while fetching */
+"Scanning iCloud storage" = "iCloud 저장 공간을 스캔하는 중";
+
+/* Search */
+"Search" = "검색";
+
+/* Search smart feed title prefix */
+"Search: " = "검색:";
+
+/* Search */
+"Search: %@" = "검색: %@";
+
+/* See articles in Folder */
+"See articles in  “%@”" = "“%@”의 기사 보기";
+
+/* First Unread */
+"See first unread article" = "첫 번째 읽지 않은 기사 보기";
+
+/* Command */
+"Select “%@” in Sidebar" = "사이드바에서 “%@” 선택";
+
+/* Selected - Reader View */
+"Selected - Reader View" = "선택됨 - 리더 보기";
+
+/* Self hosted Account */
+"Self-hosted" = "자체 호스팅";
+
+/* Self hosted Account */
+"Self-hosted accounts sync your feeds across all your devices" = "자체 호스팅 계정은 모든 기기에서 피드를 동기화합니다";
+
+/* Share
+Share button accessibility description */
+"Share" = "공유";
+
+/* Share… */
+"Share…" = "공유…";
+
+/* Show notifications for new articles */
+"Show notifications for new articles" = "새 기사 알림 표시";
+
+/* Command */
+"Show Read Articles" = "읽은 기사 보기";
+
+/* Command */
+"Show Read Feeds" = "읽은 피드 보기";
+
+/* BazQux */
+"Sign in to your BazQux account." = "BazQux 계정에 로그인하세요.";
+
+/* SignIn */
+"Sign in to your Feedbin account." = "Feedbin 계정에 로그인하세요.";
+
+/* FreshRSS */
+"Sign in to your FreshRSS account." = "FreshRSS 계정에 로그인하세요.";
+
+/* Inoreader */
+"Sign in to your Inoreader account." = "Inoreader 계정에 로그인하세요.";
+
+/* SignIn */
+"Sign in to your NewsBlur account." = "NewsBlur 계정에 로그인하세요.";
+
+/* The Old Reader */
+"Sign in to your The Old Reader account." = "The Old Reader 계정에 로그인하세요.";
+
+/* Small */
+"Small" = "작게";
+
+/* Smart Feed Inspector window title */
+"Smart Feed Inspector" = "스마트 피드 인스펙터";
+
+/* Smart Feeds group title */
+"Smart Feeds" = "스마트 피드";
+
+/* Star
+Swipe action title to star an article */
+"Star" = "별표";
+
+/* Starred pseudo-feed title
+Starred row label */
+"Starred" = "별표한 기사";
+
+/* Status records section header */
+"Status Records" = "상태 레코드";
+
+/* Account details sync unread content toggle */
+"Sync content of unread articles" = "읽지 않은 기사 콘텐츠 동기화";
+
+/* Account details sync unread content help text */
+"Syncing article content increases iCloud storage use, sync time, and battery use.\n\nArticle status and the content of starred articles are always synced." = "기사 콘텐츠를 동기화하면 iCloud 저장 공간 사용량, 동기화 시간, 배터리 사용량이 늘어납니다.\n\n기사 상태와 별표한 기사 콘텐츠는 항상 동기화됩니다.";
+
+/* Default browser item title format */
+"System Default (%@)" = "시스템 기본값 (%@)";
+
+/* Account details name help text */
+"The name can be anything you want. You can even use emoji. 🎸" = "이름은 원하는 대로 정할 수 있습니다. 이모지도 사용할 수 있습니다. 🎸";
+
+/* Account name */
+"The Old Reader" = "The Old Reader";
+
+/* Overwrite theme */
+"The theme “%@” already exists. Overwrite it?" = "테마 “%@”이 이미 있습니다. 덮어쓸까요?";
+
+/* Theme installed */
+"The theme “%@” has been installed." = "테마 “%@”이 설치되었습니다.";
+
+/* Theme download error */
+"Theme Error" = "테마 오류";
+
+/* Theme installed */
+"Theme installed" = "테마 설치 완료";
+
+/* Duplicate Error */
+"There is already a Feedbin account with that username created." = "해당 사용자 이름으로 생성된 Feedbin 계정이 이미 있습니다.";
+
+/* Duplicate Error */
+"There is already a NewsBlur account with that username created." = "해당 사용자 이름으로 생성된 NewsBlur 계정이 이미 있습니다.";
+
+/* Duplicate Error */
+"There is already an account of this type with that username created." = "해당 사용자 이름으로 생성된 이 유형의 계정이 이미 있습니다.";
+
+/* Clean up confirmation suffix */
+"This may take several minutes." = "몇 분 정도 걸릴 수 있습니다.";
+
+/* Decoding key missing */
+"This theme cannot be used because of data corruption in the Info.plist: %@." = "Info.plist의 데이터가 손상되어 이 테마를 사용할 수 없습니다: %@.";
+
+/* Decoding key missing */
+"This theme cannot be used because the the key—“%@”—is not found in the Info.plist." = "Info.plist에서 키—“%@”—를 찾을 수 없어 이 테마를 사용할 수 없습니다.";
+
+/* Type mismatch */
+"This theme cannot be used because the the type—“%@”—is mismatched in the Info.plist" = "Info.plist에서 타입—“%@”—이 일치하지 않아 이 테마를 사용할 수 없습니다";
+
+/* Decoding value missing */
+"This theme cannot be used because the the value—“%@”—is not found in the Info.plist." = "Info.plist에서 값—“%@”—를 찾을 수 없어 이 테마를 사용할 수 없습니다.";
+
+/* Clean up confirmation when plan is stale */
+"This will delete any not-starred content records.\n\nThis may take several minutes." = "별표하지 않은 콘텐츠 레코드가 모두 삭제됩니다.\n\n몇 분 정도 걸릴 수 있습니다.";
+
+/* Clean up confirmation when sync unread is on and plan is stale */
+"This will delete any read content records.\n\nThis may take several minutes." = "읽은 콘텐츠 레코드가 모두 삭제됩니다.\n\n몇 분 정도 걸릴 수 있습니다.";
+
+/* Clean up confirmation prefix */
+"This will delete:" = "삭제할 항목:";
+
+/* Timeline */
+"Timeline" = "타임라인";
+
+/* Add Account Explainer */
+"To add an account to NetNewsWire,\nclick its icon above.\n\nOr click the + button in the lower left." = "NetNewsWire에 계정을 추가하려면,\n위의 아이콘을 클릭하세요.\n\n또는 왼쪽 아래의 + 버튼을 클릭하세요.";
+
+/* To enable notifications, open Notifications in System Preferences, then find NetNewsWire in the list. */
+"To enable notifications, open Notifications in System Preferences, then find NetNewsWire in the list." = "알림을 켜려면 시스템 환경설정에서 알림을 연 다음 목록에서 NetNewsWire를 찾으세요.";
+
+/* Today pseudo-feed title */
+"Today" = "오늘";
+
+/* Total row label */
+"Total" = "합계";
+
+/* Account details type label */
+"Type:" = "유형:";
+
+/* Unknown Value */
+"Unknown" = "알 수 없음";
+
+/* Unread label for accessibility */
+"unread" = "읽지 않음";
+
+/* Swipe action title to mark an article unread
+Unread row label */
+"Unread" = "읽지 않음";
+
+/* Cleanup stat row label */
+"Unread Content Deleted" = "읽지 않은 콘텐츠 삭제됨";
+
+/* Singular label for unread content records */
+"unread content record" = "읽지 않은 콘텐츠 레코드";
+
+/* Plural label for unread content records */
+"unread content records" = "읽지 않은 콘텐츠 레코드";
+
+/* Bad account type */
+"Unrecognized account type." = "인식할 수 없는 계정 유형입니다.";
+
+/* Swipe action title to remove a star from an article */
+"Unstar" = "별표 해제";
+
+/* Update */
+"Update" = "업데이트";
+
+/* SignIn */
+"Update your Feedbin account credentials." = "Feedbin 계정 로그인 정보를 업데이트하세요.";
+
+/* SignIn */
+"Update your NewsBlur account credentials." = "NewsBlur 계정 로그인 정보를 업데이트하세요.";
+
+/* Credentials Error */
+"Username & password required." = "사용자 이름과 비밀번호가 필요합니다.";
+
+/* Credentials Error */
+"Username required." = "사용자 이름이 필요합니다.";
+
+/* Credentials Error */
+"Username, password & API URL are required." = "사용자 이름, 비밀번호 및 API URL이 필요합니다.";
+
+/* Alert title when adding a Feedly account and waiting for authorization from the user. */
+"Waiting for access to Feedly" = "Feedly 접근 권한을 기다리는 중";
+
+/* Web Account */
+"Web" = "웹";
+
+/* Web Account */
+"Web accounts sync your feeds across all your devices" = "웹 계정은 모든 기기에서 피드를 동기화합니다";
+
+/* Notifications are not enabled. */
+"You can enable NetNewsWire notifications in System Preferences." = "시스템 환경설정에서 NetNewsWire 알림을 켤 수 있습니다.";
+
+/* iCloud Account */
+"Your iCloud account syncs your feeds across your Mac and iOS devices" = "iCloud 계정은 Mac과 iOS 기기 간에 피드를 동기화합니다";

--- a/Mac/SafariExtension/ko.lproj/InfoPlist.strings
+++ b/Mac/SafariExtension/ko.lproj/InfoPlist.strings
@@ -1,0 +1,11 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "피드 구독";
+
+/* Bundle name */
+"CFBundleName" = "피드 구독";
+
+/* Copyright (human-readable) */
+"NSHumanReadableCopyright" = "저작권 © 2019-2026 Brent Simmons. 모든 권리 보유.";
+
+/* Human readable description */
+"NSHumanReadableDescription" = "이 확장 프로그램은 현재 페이지의 피드를 쉽게 구독할 수 있도록 Safari 도구 막대에 버튼을 추가합니다.";

--- a/Mac/SafariExtension/ko.lproj/SafariExtensionViewController.strings
+++ b/Mac/SafariExtension/ko.lproj/SafariExtensionViewController.strings
@@ -1,0 +1,2 @@
+/* Class = "NSTextFieldCell"; title = "Subscribe to Feed"; ObjectID = "2Ec-kd-q2K"; */
+"2Ec-kd-q2K.title" = "피드 구독";

--- a/Mac/ShareExtension/ShareViewController.swift
+++ b/Mac/ShareExtension/ShareViewController.swift
@@ -117,7 +117,7 @@ private extension ShareViewController {
 
 	func buildFolderPopupMenu() {
 
-		let menu = NSMenu(title: "Folders")
+		let menu = NSMenu(title: NSLocalizedString("Folders", comment: "Share extension destination folder popup menu title"))
 		menu.autoenablesItems = false
 
 		guard let extensionContainers = extensionContainers else {

--- a/Mac/ShareExtension/ko.lproj/InfoPlist.strings
+++ b/Mac/ShareExtension/ko.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "NetNewsWire";
+
+/* Bundle name */
+"CFBundleName" = "NetNewsWire 공유 확장 프로그램";
+
+/* Copyright (human-readable) */
+"NSHumanReadableCopyright" = "저작권 © 2002-2026 Brent Simmons. 모든 권리 보유.";

--- a/Mac/ShareExtension/ko.lproj/Localizable.strings
+++ b/Mac/ShareExtension/ko.lproj/Localizable.strings
@@ -1,0 +1,35 @@
+/* Every 2 Hours */
+"Every 2 Hours" = "2시간마다";
+
+/* Every 4 Hours */
+"Every 4 Hours" = "4시간마다";
+
+/* Every 8 Hours */
+"Every 8 Hours" = "8시간마다";
+
+/* Every 30 Minutes */
+"Every 30 Minutes" = "30분마다";
+
+/* Every Hour */
+"Every Hour" = "1시간마다";
+
+/* XX-Large */
+"Extra Extra Large" = "가장 크게";
+
+/* X-Large */
+"Extra Large" = "매우 크게";
+
+/* Share extension destination folder popup menu title */
+"Folders" = "폴더";
+
+/* Large */
+"Large" = "크게";
+
+/* Manually */
+"Manually" = "수동";
+
+/* Medium */
+"Medium" = "보통";
+
+/* Small */
+"Small" = "작게";

--- a/Mac/ShareExtension/ko.lproj/ShareViewController.strings
+++ b/Mac/ShareExtension/ko.lproj/ShareViewController.strings
@@ -1,0 +1,26 @@
+/* Class = "NSButtonCell"; title = "Send"; ObjectID = "2l4-PO-we5"; */
+"2l4-PO-we5.title" = "보내기";
+
+/* Class = "NSTextFieldCell"; title = "NetNewsWire"; ObjectID = "5Ed-E1-Gf1"; */
+"5Ed-E1-Gf1.title" = "NetNewsWire";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "6Up-t3-mwm"; */
+"6Up-t3-mwm.title" = "취소";
+
+/* Class = "NSTextFieldCell"; placeholderString = "Optional"; ObjectID = "27c-xz-zoJ"; */
+"27c-xz-zoJ.placeholderString" = "선택 사항";
+
+/* Class = "NSMenuItem"; title = "Item 3"; ObjectID = "Djb-KO-yjg"; */
+"Djb-KO-yjg.title" = "항목 3";
+
+/* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "jf0-bY-EUJ"; */
+"jf0-bY-EUJ.title" = "항목 2";
+
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "Piv-xr-hYI"; */
+"Piv-xr-hYI.title" = "이름:";
+
+/* Class = "NSTextFieldCell"; title = "Folder:"; ObjectID = "qp4-R2-aO5"; */
+"qp4-R2-aO5.title" = "폴더:";
+
+/* Class = "NSMenuItem"; title = "Item 1"; ObjectID = "wvm-BK-3HS"; */
+"wvm-BK-3HS.title" = "항목 1";

--- a/Mac/ko.lproj/AddFeedFromListSheet.strings
+++ b/Mac/ko.lproj/AddFeedFromListSheet.strings
@@ -1,0 +1,23 @@
+/* Class = "NSButtonCell"; title = "Add"; ObjectID = "6NK-Ql-drk"; */
+"6NK-Ql-drk.title" = "추가";
+
+/* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "APc-af-7Um"; */
+"APc-af-7Um.title" = "항목 2";
+
+/* Class = "NSTextFieldCell"; title = "Add feed(s)?"; ObjectID = "CRI-fB-GoB"; */
+"CRI-fB-GoB.title" = "피드를 추가하시겠습니까?";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "Dop-HC-6Q9"; */
+"Dop-HC-6Q9.title" = "취소";
+
+/* Class = "NSMenuItem"; title = "Item 3"; ObjectID = "j09-9b-bGs"; */
+"j09-9b-bGs.title" = "항목 3";
+
+/* Class = "NSTextFieldCell"; title = "Folder:"; ObjectID = "Kwx-7B-CIu"; */
+"Kwx-7B-CIu.title" = "폴더:";
+
+/* Class = "NSWindow"; title = "Add Feed"; ObjectID = "QvC-M9-y7g"; */
+"QvC-M9-y7g.title" = "피드 추가";
+
+/* Class = "NSMenuItem"; title = "Item 1"; ObjectID = "tLJ-zY-CcZ"; */
+"tLJ-zY-CcZ.title" = "항목 1";

--- a/Mac/ko.lproj/AddFeedSheet.strings
+++ b/Mac/ko.lproj/AddFeedSheet.strings
@@ -1,0 +1,32 @@
+/* Class = "NSButtonCell"; title = "Add"; ObjectID = "6NK-Ql-drk"; */
+"6NK-Ql-drk.title" = "추가";
+
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "8ca-Qp-BkT"; */
+"8ca-Qp-BkT.title" = "이름:";
+
+/* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "8jE-9v-BT2"; */
+"8jE-9v-BT2.title" = "URL:";
+
+/* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "APc-af-7Um"; */
+"APc-af-7Um.title" = "항목 2";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "Dop-HC-6Q9"; */
+"Dop-HC-6Q9.title" = "취소";
+
+/* Class = "NSMenuItem"; title = "Item 3"; ObjectID = "j09-9b-bGs"; */
+"j09-9b-bGs.title" = "항목 3";
+
+/* Class = "NSTextFieldCell"; title = "Folder:"; ObjectID = "Kwx-7B-CIu"; */
+"Kwx-7B-CIu.title" = "폴더:";
+
+/* Class = "NSTextFieldCell"; placeholderString = "Optional"; ObjectID = "pLP-pL-5R5"; */
+"pLP-pL-5R5.placeholderString" = "선택 사항";
+
+/* Class = "NSWindow"; title = "Add Feed"; ObjectID = "QvC-M9-y7g"; */
+"QvC-M9-y7g.title" = "피드 추가";
+
+/* Class = "NSMenuItem"; title = "Item 1"; ObjectID = "tLJ-zY-CcZ"; */
+"tLJ-zY-CcZ.title" = "항목 1";
+
+/* Class = "NSButtonCell"; title = "Open Feed Directory"; ObjectID = "wKl-a9-7FY"; */
+"wKl-a9-7FY.title" = "피드 디렉토리 열기";

--- a/Mac/ko.lproj/AddFolderSheet.strings
+++ b/Mac/ko.lproj/AddFolderSheet.strings
@@ -1,0 +1,23 @@
+/* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "Aat-NW-hPO"; */
+"Aat-NW-hPO.title" = "항목 2";
+
+/* Class = "NSMenuItem"; title = "Item 3"; ObjectID = "CVJ-R1-O8v"; */
+"CVJ-R1-O8v.title" = "항목 3";
+
+/* Class = "NSButtonCell"; title = "Add Folder"; ObjectID = "F5a-Q7-NMn"; */
+"F5a-Q7-NMn.title" = "폴더 추가";
+
+/* Class = "NSTextFieldCell"; title = "Folder Name:"; ObjectID = "k8o-om-Rgh"; */
+"k8o-om-Rgh.title" = "폴더 이름:";
+
+/* Class = "NSWindow"; title = "Add Folder"; ObjectID = "QvC-M9-y7g"; */
+"QvC-M9-y7g.title" = "폴더 추가";
+
+/* Class = "NSMenuItem"; title = "Item 1"; ObjectID = "SDZ-cp-t7j"; */
+"SDZ-cp-t7j.title" = "항목 1";
+
+/* Class = "NSTextFieldCell"; title = "Account:"; ObjectID = "t6T-ar-V3d"; */
+"t6T-ar-V3d.title" = "계정:";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "VXk-Yp-k6W"; */
+"VXk-Yp-k6W.title" = "취소";

--- a/Mac/ko.lproj/Main.strings
+++ b/Mac/ko.lproj/Main.strings
@@ -1,0 +1,386 @@
+/* Class = "NSMenu"; title = "Find"; ObjectID = "1b7-l0-nxx"; */
+"1b7-l0-nxx.title" = "찾기";
+
+/* Class = "NSMenuItem"; title = "Check for Updates…"; ObjectID = "1nF-7O-aKU"; */
+"1nF-7O-aKU.title" = "업데이트 확인…";
+
+/* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1UK-8n-QPP"; */
+"1UK-8n-QPP.title" = "도구 막대 사용자화…";
+
+/* Class = "NSMenuItem"; title = "NetNewsWire"; ObjectID = "1Xt-HY-uBw"; */
+"1Xt-HY-uBw.title" = "NetNewsWire";
+
+/* Class = "NSMenuItem"; title = "Transformations"; ObjectID = "2oI-Rn-ZJC"; */
+"2oI-Rn-ZJC.title" = "변환";
+
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "3IN-sU-3Bg"; */
+"3IN-sU-3Bg.title" = "맞춤법";
+
+/* Class = "NSMenu"; title = "Speech"; ObjectID = "3rS-ZA-NoH"; */
+"3rS-ZA-NoH.title" = "말하기";
+
+/* Class = "NSMenuItem"; title = "Find"; ObjectID = "4EN-yA-p0u"; */
+"4EN-yA-p0u.title" = "찾기";
+
+/* Class = "NSMenuItem"; title = "Open in Browser"; ObjectID = "4iQ-1v-dTa"; */
+"4iQ-1v-dTa.title" = "브라우저에서 열기";
+
+/* Class = "NSMenuItem"; title = "Enter Full Screen"; ObjectID = "4J7-dP-txa"; */
+"4J7-dP-txa.title" = "전체 화면으로 전환";
+
+/* Class = "NSMenuItem"; title = "Quit NetNewsWire"; ObjectID = "4sb-4s-VLi"; */
+"4sb-4s-VLi.title" = "NetNewsWire 종료";
+
+/* Class = "NSMenuItem"; title = "About NetNewsWire"; ObjectID = "5kV-Vb-QxS"; */
+"5kV-Vb-QxS.title" = "NetNewsWire 정보";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "5QF-Oa-p0T"; */
+"5QF-Oa-p0T.title" = "편집";
+
+/* Class = "NSMenuItem"; title = "Redo"; ObjectID = "6dh-zS-Vam"; */
+"6dh-zS-Vam.title" = "다시 실행";
+
+/* Class = "NSMenuItem"; title = "Mark Below as Read"; ObjectID = "8lZ-XI-I4y"; */
+"8lZ-XI-I4y.title" = "아래를 읽음으로 표시";
+
+/* Class = "NSMenuItem"; title = "All Unread"; ObjectID = "8ZT-ew-JNc"; */
+"8ZT-ew-JNc.title" = "읽지 않은 글 모두";
+
+/* Class = "NSMenuItem"; title = "Substitutions"; ObjectID = "9ic-FL-obx"; */
+"9ic-FL-obx.title" = "대치";
+
+/* Class = "NSMenuItem"; title = "Debug Search"; ObjectID = "9Ot-wC-s5U"; */
+"9Ot-wC-s5U.title" = "디버그 검색";
+
+/* Class = "NSMenuItem"; title = "Smart Copy/Paste"; ObjectID = "9yt-4B-nSM"; */
+"9yt-4B-nSM.title" = "스마트 복사/붙여넣기";
+
+/* Class = "NSMenuItem"; title = "Info"; ObjectID = "24r-2i-fXR"; */
+"24r-2i-fXR.title" = "정보";
+
+/* Class = "NSMenu"; title = "Article"; ObjectID = "57V-gv-vEw"; */
+"57V-gv-vEw.title" = "기사";
+
+/* Class = "NSMenuItem"; title = "Correct Spelling Automatically"; ObjectID = "78Y-hA-62v"; */
+"78Y-hA-62v.title" = "맞춤법 자동 수정";
+
+/* Class = "NSMenuItem"; title = "Window"; ObjectID = "aUF-d1-5bR"; */
+"aUF-d1-5bR.title" = "윈도우";
+
+/* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
+"AYu-sK-qS6.title" = "메인 메뉴";
+
+/* Class = "NSMenuItem"; title = "Release Notes"; ObjectID = "b5s-xg-B1w"; */
+"b5s-xg-B1w.title" = "릴리스 노트";
+
+/* Class = "NSMenuItem"; title = "Hide Read Articles"; ObjectID = "b10-sA-Yzi"; */
+"b10-sA-Yzi.title" = "읽은 기사 가리기";
+
+/* Class = "NSMenu"; title = "File"; ObjectID = "bib-Uj-vzu"; */
+"bib-Uj-vzu.title" = "파일";
+
+/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
+"BOF-NM-1cW.title" = "설정…";
+
+/* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "buJ-ug-pKt"; */
+"buJ-ug-pKt.title" = "선택한 내용으로 찾기";
+
+/* Class = "NSMenu"; title = "Transformations"; ObjectID = "c8a-y6-VQd"; */
+"c8a-y6-VQd.title" = "변환";
+
+/* Class = "NSMenuItem"; title = "Add NetNewsWire News Feed"; ObjectID = "cmP-uH-mS8"; */
+"cmP-uH-mS8.title" = "NetNewsWire 뉴스 피드 추가";
+
+/* Class = "NSMenuItem"; title = "Smart Links"; ObjectID = "cwL-P1-jid"; */
+"cwL-P1-jid.title" = "스마트 링크";
+
+/* Class = "NSMenuItem"; title = "Make Lower Case"; ObjectID = "d9M-CD-aMd"; */
+"d9M-CD-aMd.title" = "소문자로";
+
+/* Class = "NSMenuItem"; title = "iCloud Storage Stats"; ObjectID = "dLy-xR-u6N"; */
+"dLy-xR-u6N.title" = "iCloud 저장 공간 통계";
+
+/* Class = "NSMenuItem"; title = "File"; ObjectID = "dMs-cI-mzQ"; */
+"dMs-cI-mzQ.title" = "파일";
+
+/* Class = "NSMenuItem"; title = "Undo"; ObjectID = "dRJ-4n-Yzg"; */
+"dRJ-4n-Yzg.title" = "실행 취소";
+
+/* Class = "NSMenuItem"; title = "Spelling and Grammar"; ObjectID = "Dv1-io-Yv7"; */
+"Dv1-io-Yv7.title" = "맞춤법 및 문법";
+
+/* Class = "NSMenuItem"; title = "Close Window"; ObjectID = "DVo-aG-piG"; */
+"DVo-aG-piG.title" = "창 닫기";
+
+/* Class = "NSMenuItem"; title = "Hide Read Feeds"; ObjectID = "E9K-zV-nLv"; */
+"E9K-zV-nLv.title" = "읽은 피드 가리기";
+
+/* Class = "NSMenuItem"; title = "Open in Browser Inverted"; ObjectID = "EjD-X9-Pjf"; */
+"EjD-X9-Pjf.title" = "브라우저에서 반대 방식으로 열기";
+
+/* Class = "NSMenuItem"; title = "Error Log"; ObjectID = "erl-0g-Kw7"; */
+"erl-0g-Kw7.title" = "오류 로그";
+
+/* Class = "NSMenuItem"; title = "Enable Web Inspector"; ObjectID = "EwI-z4-ZA3"; */
+"EwI-z4-ZA3.title" = "웹 검사기 활성화";
+
+/* Class = "NSMenu"; title = "Help"; ObjectID = "F2S-fz-NVQ"; */
+"F2S-fz-NVQ.title" = "도움말";
+
+/* Class = "NSMenuItem"; title = "Mark as Read"; ObjectID = "Fc9-c7-2AY"; */
+"Fc9-c7-2AY.title" = "읽음으로 표시";
+
+/* Class = "NSMenu"; title = "Substitutions"; ObjectID = "FeM-D8-WVr"; */
+"FeM-D8-WVr.title" = "대치";
+
+/* Class = "NSMenuItem"; title = "NetNewsWire Help"; ObjectID = "FKE-Sm-Kum"; */
+"FKE-Sm-Kum.title" = "NetNewsWire 도움말";
+
+/* Class = "NSMenuItem"; title = "Copy External URL"; ObjectID = "fOF-99-6Iv"; */
+"fOF-99-6Iv.title" = "외부 URL 복사";
+
+/* Class = "NSMenuItem"; title = "Go"; ObjectID = "FPs-q4-hLT"; */
+"FPs-q4-hLT.title" = "이동";
+
+/* Class = "NSMenuItem"; title = "Paste"; ObjectID = "gVA-U4-sdL"; */
+"gVA-U4-sdL.title" = "붙여넣기";
+
+/* Class = "NSMenuItem"; title = "Test Crash Reporter Window"; ObjectID = "gVd-kQ-efj"; */
+"gVd-kQ-efj.title" = "충돌 보고기 창 테스트";
+
+/* Class = "NSMenuItem"; title = "Force Crash"; ObjectID = "gVt-cz-eoJ"; */
+"gVt-cz-eoJ.title" = "강제 충돌";
+
+/* Class = "NSMenuItem"; title = "View"; ObjectID = "H8h-7b-M4v"; */
+"H8h-7b-M4v.title" = "보기";
+
+/* Class = "NSMenuItem"; title = "Mark All as Read"; ObjectID = "HdN-Ks-cwh"; */
+"HdN-Ks-cwh.title" = "모두 읽음으로 표시";
+
+/* Class = "NSMenuItem"; title = "Show Spelling and Grammar"; ObjectID = "HFo-cy-zxI"; */
+"HFo-cy-zxI.title" = "맞춤법 및 문법 보기";
+
+/* Class = "NSMenuItem"; title = "Text Replacement"; ObjectID = "HFQ-gK-NFA"; */
+"HFQ-gK-NFA.title" = "텍스트 대치";
+
+/* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "hQb-2v-fYv"; */
+"hQb-2v-fYv.title" = "스마트 따옴표";
+
+/* Class = "NSMenu"; title = "View"; ObjectID = "HyV-fh-RgO"; */
+"HyV-fh-RgO.title" = "보기";
+
+/* Class = "NSMenuItem"; title = "Check Document Now"; ObjectID = "hz2-CU-CR7"; */
+"hz2-CU-CR7.title" = "문서 지금 검사";
+
+/* Class = "NSMenu"; title = "Services"; ObjectID = "hz9-B4-Xy5"; */
+"hz9-B4-Xy5.title" = "서비스";
+
+/* Class = "NSMenuItem"; title = "Import NNW 3 Subscriptions…"; ObjectID = "i8e-24-dto"; */
+"i8e-24-dto.title" = "NNW 3 구독 가져오기…";
+
+/* Class = "NSMenuItem"; title = "Oldest Article on Top"; ObjectID = "iii-kP-qoF"; */
+"iii-kP-qoF.title" = "오래된 기사를 위로";
+
+/* Class = "NSMenuItem"; title = "Clean Up Articles"; ObjectID = "J5h-uQ-57w"; */
+"J5h-uQ-57w.title" = "기사 정리";
+
+/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "Kd2-mp-pUS"; */
+"Kd2-mp-pUS.title" = "모두 보기";
+
+/* Class = "NSMenuItem"; title = "How To Support NetNewsWire"; ObjectID = "kfC-NQ-g3E"; */
+"kfC-NQ-g3E.title" = "NetNewsWire를 후원하는 방법";
+
+/* Class = "NSMenuItem"; title = "Show Sidebar"; ObjectID = "kIP-vf-haE"; */
+"kIP-vf-haE.title" = "사이드바 보기";
+
+/* Class = "NSMenuItem"; title = "Vacuum Databases"; ObjectID = "kLm-nR-v3X"; */
+"kLm-nR-v3X.title" = "데이터베이스 VACUUM";
+
+/* Class = "NSMenuItem"; title = "Today"; ObjectID = "L20-jv-7c9"; */
+"L20-jv-7c9.title" = "오늘";
+
+/* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "LE2-aR-0XJ"; */
+"LE2-aR-0XJ.title" = "모두 앞으로 가져오기";
+
+/* Class = "NSMenuItem"; title = "Main Window"; ObjectID = "LSZ-ci-Jb5"; */
+"LSZ-ci-Jb5.title" = "메인 창";
+
+/* Class = "NSMenuItem"; title = "Show iCloud Drive Missing Alert"; ObjectID = "m0T-w3-neT"; */
+"m0T-w3-neT.title" = "iCloud Drive 없음 경고 표시";
+
+/* Class = "NSMenuItem"; title = "Bug Tracker"; ObjectID = "mE2-pM-rQF"; */
+"mE2-pM-rQF.title" = "버그 추적기";
+
+/* Class = "NSMenuItem"; title = "Check Grammar With Spelling"; ObjectID = "mK6-2p-4JG"; */
+"mK6-2p-4JG.title" = "맞춤법 검사와 함께 문법 검사";
+
+/* Class = "NSMenuItem"; title = "Article Search…"; ObjectID = "nB2-mv-2i5"; */
+"nB2-mv-2i5.title" = "기사 검색…";
+
+/* Class = "NSMenuItem"; title = "Sort Articles By"; ObjectID = "nLP-fa-KUi"; */
+"nLP-fa-KUi.title" = "기사 정렬 기준";
+
+/* Class = "NSMenuItem"; title = "Services"; ObjectID = "NMo-om-nkz"; */
+"NMo-om-nkz.title" = "서비스";
+
+/* Class = "NSMenu"; title = "Debug"; ObjectID = "NOT-8E-ykF"; */
+"NOT-8E-ykF.title" = "디버그";
+
+/* Class = "NSMenu"; title = "Go"; ObjectID = "NQW-Ph-lw2"; */
+"NQW-Ph-lw2.title" = "이동";
+
+/* Class = "NSMenuItem"; title = "Discourse Forum"; ObjectID = "OKC-FV-V33"; */
+"OKC-FV-V33.title" = "Discourse 포럼";
+
+/* Class = "NSMenu"; title = "Sort Articles By"; ObjectID = "OlJ-93-6OP"; */
+"OlJ-93-6OP.title" = "기사 정렬 기준";
+
+/* Class = "NSMenuItem"; title = "Hide NetNewsWire"; ObjectID = "Olw-nP-bQN"; */
+"Olw-nP-bQN.title" = "NetNewsWire 가리기";
+
+/* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "OwM-mh-QMV"; */
+"OwM-mh-QMV.title" = "이전 찾기";
+
+/* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
+"OY7-WF-poV.title" = "최소화";
+
+/* Class = "NSMenuItem"; title = "Stop Speaking"; ObjectID = "Oyz-dy-DGm"; */
+"Oyz-dy-DGm.title" = "말하기 중지";
+
+/* Class = "NSMenuItem"; title = "Mark Above as Read"; ObjectID = "p1o-EG-Uo8"; */
+"p1o-EG-Uo8.title" = "위를 읽음으로 표시";
+
+/* Class = "NSMenuItem"; title = "Show Reader View"; ObjectID = "p5x-Xq-1fW"; */
+"p5x-Xq-1fW.title" = "리더 보기 표시";
+
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "pa3-QI-u2k"; */
+"pa3-QI-u2k.title" = "삭제";
+
+/* Class = "NSMenuItem"; title = "New Window"; ObjectID = "pGg-Gc-PU2"; */
+"pGg-Gc-PU2.title" = "새 윈도우";
+
+/* Class = "NSMenuItem"; title = "Refresh"; ObjectID = "Ppm-uh-K5n"; */
+"Ppm-uh-K5n.title" = "새로 고침";
+
+/* Class = "NSMenuItem"; title = "Website"; ObjectID = "q2Z-9K-GBd"; */
+"q2Z-9K-GBd.title" = "웹사이트";
+
+/* Class = "NSMenuItem"; title = "Next Unread"; ObjectID = "q3p-nE-m2k"; */
+"q3p-nE-m2k.title" = "다음 읽지 않은 글";
+
+/* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "q09-fT-Sye"; */
+"q09-fT-Sye.title" = "다음 찾기";
+
+/* Class = "NSMenuItem"; title = "GitHub Repository"; ObjectID = "QfD-Xw-sdF"; */
+"QfD-Xw-sdF.title" = "GitHub 저장소";
+
+/* Class = "NSMenuItem"; title = "Copy Article URL"; ObjectID = "qNk-By-jKp"; */
+"qNk-By-jKp.title" = "기사 URL 복사";
+
+/* Class = "NSMenuItem"; title = "Open Application Support Folder"; ObjectID = "QxZ-DC-21I"; */
+"QxZ-DC-21I.title" = "Application Support 폴더 열기";
+
+/* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "R4o-n2-Eq4"; */
+"R4o-n2-Eq4.title" = "확대/축소";
+
+/* Class = "NSMenuItem"; title = "Check Spelling While Typing"; ObjectID = "rbD-Rh-wIN"; */
+"rbD-Rh-wIN.title" = "입력하는 동안 맞춤법 검사";
+
+/* Class = "NSMenuItem"; title = "Smart Dashes"; ObjectID = "rgM-f4-ycn"; */
+"rgM-f4-ycn.title" = "스마트 대시";
+
+/* Class = "NSMenuItem"; title = "Import Subscriptions…"; ObjectID = "rSl-F4-qo7"; */
+"rSl-F4-qo7.title" = "구독 가져오기…";
+
+/* Class = "NSMenuItem"; title = "Select All"; ObjectID = "Ruw-6m-B2m"; */
+"Ruw-6m-B2m.title" = "모두 선택";
+
+/* Class = "NSMenuItem"; title = "Jump to Selection"; ObjectID = "S0p-oC-mLd"; */
+"S0p-oC-mLd.title" = "선택 항목으로 이동";
+
+/* Class = "NSMenuItem"; title = "Show Toolbar"; ObjectID = "snW-S8-Cw5"; */
+"snW-S8-Cw5.title" = "도구 막대 보기";
+
+/* Class = "NSMenu"; title = "Window"; ObjectID = "Td7-aD-5lo"; */
+"Td7-aD-5lo.title" = "윈도우";
+
+/* Class = "NSMenuItem"; title = "Newest Article on Top"; ObjectID = "TNS-TV-n0U"; */
+"TNS-TV-n0U.title" = "최신 기사를 위로";
+
+/* Class = "NSMenuItem"; title = "Data Detectors"; ObjectID = "tRr-pd-1PS"; */
+"tRr-pd-1PS.title" = "데이터 감지기";
+
+/* Class = "NSMenuItem"; title = "Article"; ObjectID = "TzI-3g-N0v"; */
+"TzI-3g-N0v.title" = "기사";
+
+/* Class = "NSMenuItem"; title = "Capitalize"; ObjectID = "UEZ-Bs-lqG"; */
+"UEZ-Bs-lqG.title" = "첫 글자 대문자로";
+
+/* Class = "NSMenuItem"; title = "Debug"; ObjectID = "UqE-mp-gtV"; */
+"UqE-mp-gtV.title" = "디버그";
+
+/* Class = "NSMenu"; title = "NetNewsWire"; ObjectID = "uQy-DD-JDr"; */
+"uQy-DD-JDr.title" = "NetNewsWire";
+
+/* Class = "NSMenuItem"; title = "Cut"; ObjectID = "uRl-iY-unG"; */
+"uRl-iY-unG.title" = "잘라내기";
+
+/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "Vdr-fp-XzO"; */
+"Vdr-fp-XzO.title" = "나머지 가리기";
+
+/* Class = "NSMenuItem"; title = "Refresh"; ObjectID = "Veh-SV-KWy"; */
+"Veh-SV-KWy.title" = "새로 고침";
+
+/* Class = "NSMenuItem"; title = "Make Upper Case"; ObjectID = "vmV-6d-7jI"; */
+"vmV-6d-7jI.title" = "대문자로";
+
+/* Class = "NSMenuItem"; title = "Mark as Starred"; ObjectID = "vvo-ZM-8kl"; */
+"vvo-ZM-8kl.title" = "별표 표시";
+
+/* Class = "NSMenuItem"; title = "Keyboard Shortcuts"; ObjectID = "w6o-j8-cda"; */
+"w6o-j8-cda.title" = "키보드 단축키";
+
+/* Class = "NSMenu"; title = "Edit"; ObjectID = "W48-6f-4Dl"; */
+"W48-6f-4Dl.title" = "편집";
+
+/* Class = "NSMenuItem"; title = "New Feed…"; ObjectID = "Was-JA-tGl"; */
+"Was-JA-tGl.title" = "새 피드…";
+
+/* Class = "NSMenuItem"; title = "Paste and Match Style"; ObjectID = "WeT-3V-zwk"; */
+"WeT-3V-zwk.title" = "스타일에 맞춰 붙여넣기";
+
+/* Class = "NSMenuItem"; title = "New Folder…"; ObjectID = "wkh-LX-Xp1"; */
+"wkh-LX-Xp1.title" = "새 폴더…";
+
+/* Class = "NSMenuItem"; title = "Help"; ObjectID = "wpr-3q-Mcd"; */
+"wpr-3q-Mcd.title" = "도움말";
+
+/* Class = "NSMenuItem"; title = "Copy"; ObjectID = "x3v-GG-iWU"; */
+"x3v-GG-iWU.title" = "복사";
+
+/* Class = "NSMenuItem"; title = "Open Image Cache Folder"; ObjectID = "x9L-mW-2vQ"; */
+"x9L-mW-2vQ.title" = "이미지 캐시 폴더 열기";
+
+/* Class = "NSMenuItem"; title = "Test Crash Log Sender"; ObjectID = "XJG-gO-OKi"; */
+"XJG-gO-OKi.title" = "충돌 로그 전송기 테스트";
+
+/* Class = "NSMenuItem"; title = "Speech"; ObjectID = "xrE-MZ-jX0"; */
+"xrE-MZ-jX0.title" = "말하기";
+
+/* Class = "NSMenuItem"; title = "Export Subscriptions…"; ObjectID = "Xy2-v8-Lj8"; */
+"Xy2-v8-Lj8.title" = "구독 내보내기…";
+
+/* Class = "NSMenuItem"; title = "Find…"; ObjectID = "Xz5-n4-O0W"; */
+"Xz5-n4-O0W.title" = "찾기…";
+
+/* Class = "NSMenuItem"; title = "Start Speaking"; ObjectID = "Ynk-f8-cLZ"; */
+"Ynk-f8-cLZ.title" = "말하기 시작";
+
+/* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "z6F-FW-3nz"; */
+"z6F-FW-3nz.title" = "대치 보기";
+
+/* Class = "NSMenuItem"; title = "Starred"; ObjectID = "ZRx-me-QXO"; */
+"ZRx-me-QXO.title" = "별표 표시한 글";
+
+/* Class = "NSMenuItem"; title = "Group By Feed"; ObjectID = "Zxm-O6-NRE"; */
+"Zxm-O6-NRE.title" = "피드별로 그룹화";

--- a/Mac/ko.lproj/Preferences.strings
+++ b/Mac/ko.lproj/Preferences.strings
@@ -1,0 +1,119 @@
+/* Class = "NSWindow"; title = "Preferences"; ObjectID = "2C0-LP-36T"; */
+"2C0-LP-36T.title" = "설정";
+
+/* Class = "NSMenuItem"; title = "Extra Extra Large"; ObjectID = "4Pi-2Y-XmV"; */
+"4Pi-2Y-XmV.title" = "가장 크게";
+
+/* Class = "NSTextFieldCell"; title = "Download:"; ObjectID = "6bb-c0-guo"; */
+"6bb-c0-guo.title" = "다운로드:";
+
+/* Class = "NSMenuItem"; title = "Every 4 hours"; ObjectID = "7e2-TV-hth"; */
+"7e2-TV-hth.title" = "4시간마다";
+
+/* Class = "NSMenuItem"; title = "Every 8 hours"; ObjectID = "7gV-gL-Nue"; */
+"7gV-gL-Nue.title" = "8시간마다";
+
+/* Class = "NSButtonCell"; title = "Check for Updates"; ObjectID = "AaA-Rr-UYD"; */
+"AaA-Rr-UYD.title" = "업데이트 확인";
+
+/* Class = "NSTextFieldCell"; title = "Article Content:"; ObjectID = "BJB-pP-mhQ"; */
+"BJB-pP-mhQ.title" = "기사 내용:";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "CcS-BO-sdv"; */
+"CcS-BO-sdv.title" = "테이블 뷰 셀";
+
+/* Class = "NSTextFieldCell"; title = "Browser:"; ObjectID = "CgU-dE-Qtb"; */
+"CgU-dE-Qtb.title" = "브라우저:";
+
+/* Class = "NSMenuItem"; title = "Large"; ObjectID = "ckZ-0Q-rNz"; */
+"ckZ-0Q-rNz.title" = "크게";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "Djh-3Q-J0Q"; */
+"Djh-3Q-J0Q.title" = "텍스트 셀";
+
+/* Class = "NSButtonCell"; title = "Check automatically"; ObjectID = "dm8-Xy-0Ba"; */
+"dm8-Xy-0Ba.title" = "자동으로 확인";
+
+/* Class = "NSMenuItem"; title = "Manually only"; ObjectID = "doa-Wq-4Uq"; */
+"doa-Wq-4Uq.title" = "수동으로만";
+
+/* Class = "NSTextFieldCell"; title = "Press the Shift key to do the opposite."; ObjectID = "EMq-9M-zTJ"; */
+"EMq-9M-zTJ.title" = "반대로 하려면 Shift 키를 누르세요.";
+
+/* Class = "NSTextFieldCell"; title = "Safari Extension:"; ObjectID = "Eth-o0-pWM"; */
+"Eth-o0-pWM.title" = "Safari 확장 프로그램:";
+
+/* Class = "NSTextFieldCell"; title = "Refresh Feeds:"; ObjectID = "F7c-lm-g97"; */
+"F7c-lm-g97.title" = "피드 새로 고침:";
+
+/* Class = "NSButtonCell"; title = "Release builds"; ObjectID = "F8M-rS-und"; */
+"F8M-rS-und.title" = "릴리스 빌드";
+
+/* Class = "NSTextFieldCell"; title = "If you’re not sure, choose Release builds. Test builds may have bugs, which may include crashing bugs and data loss."; ObjectID = "fOZ-zv-QTc"; */
+"fOZ-zv-QTc.title" = "확실하지 않다면 릴리스 빌드를 선택하세요. 테스트 빌드에는 충돌이나 데이터 손실을 포함한 버그가 있을 수 있습니다.";
+
+/* Class = "NSButtonCell"; title = "Test builds"; ObjectID = "Fuf-rU-D6M"; */
+"Fuf-rU-D6M.title" = "테스트 빌드";
+
+/* Class = "NSTextFieldCell"; title = "Some content, such as videos and embedded social media posts, may require JavaScript to work correctly."; ObjectID = "g2Q-oq-h2P"; */
+"g2Q-oq-h2P.title" = "동영상이나 임베드된 소셜 미디어 게시물 같은 일부 콘텐츠는 올바르게 작동하려면 JavaScript가 필요할 수 있습니다.";
+
+/* Class = "NSButtonCell"; title = "Enable JavaScript"; ObjectID = "GUo-0M-xMc"; */
+"GUo-0M-xMc.title" = "JavaScript 활성화";
+
+/* Class = "NSViewController"; title = "General"; ObjectID = "iuH-lz-18x"; */
+"iuH-lz-18x.title" = "일반";
+
+/* Class = "NSMenuItem"; title = "Medium"; ObjectID = "jMV-2o-5Oh"; */
+"jMV-2o-5Oh.title" = "보통";
+
+/* Class = "NSButtonCell"; title = "Send automatically"; ObjectID = "jnc-C5-4oI"; */
+"jnc-C5-4oI.title" = "자동으로 보내기";
+
+/* Class = "NSButtonCell"; title = "Privacy Policy"; ObjectID = "kSv-Wu-NYx"; */
+"kSv-Wu-NYx.title" = "개인정보 처리방침";
+
+/* Class = "NSTextFieldCell"; title = "Article Theme:"; ObjectID = "MQe-Za-N8J"; */
+"MQe-Za-N8J.title" = "기사 테마:";
+
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "o1h-xo-elW"; */
+"o1h-xo-elW.title" = "2시간마다";
+
+/* Class = "NSMenuItem"; title = "Safari"; ObjectID = "ObP-qK-qDJ"; */
+"ObP-qK-qDJ.title" = "Safari";
+
+/* Class = "NSMenuItem"; title = "Default"; ObjectID = "Pkl-EA-Goa"; */
+"Pkl-EA-Goa.title" = "기본";
+
+/* Class = "NSTextFieldCell"; title = "Crash logs:"; ObjectID = "qcq-fU-Ks0"; */
+"qcq-fU-Ks0.title" = "충돌 로그:";
+
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "Qjt-qr-WER"; */
+"Qjt-qr-WER.title" = "1시간마다";
+
+/* Class = "NSMenuItem"; title = "Extra Large"; ObjectID = "qMe-6g-Vme"; */
+"qMe-6g-Vme.title" = "매우 크게";
+
+/* Class = "NSMenuItem"; title = "Small"; ObjectID = "roB-Mu-Ht7"; */
+"roB-Mu-Ht7.title" = "작게";
+
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "rZU-Tg-xwo"; */
+"rZU-Tg-xwo.title" = "30분마다";
+
+/* Class = "NSButtonCell"; title = "Open feeds in default news reader"; ObjectID = "SkZ-tE-blK"; */
+"SkZ-tE-blK.title" = "기본 뉴스 리더에서 피드 열기";
+
+/* Class = "NSButtonCell"; title = "Open web pages in background in browser"; ObjectID = "t0a-LN-rCv"; */
+"t0a-LN-rCv.title" = "브라우저에서 웹 페이지를 백그라운드로 열기";
+
+/* Class = "NSButtonCell"; title = "Open feeds in NetNewsWire"; ObjectID = "uvx-O8-HvU"; */
+"uvx-O8-HvU.title" = "NetNewsWire에서 피드 열기";
+
+/* Class = "NSTextFieldCell"; title = "Article Text Size:"; ObjectID = "xQu-QV-91i"; */
+"xQu-QV-91i.title" = "기사 글자 크기:";
+
+/* Class = "NSButtonCell"; title = "Open Themes Folder"; ObjectID = "ySX-5i-SP1"; */
+"ySX-5i-SP1.title" = "테마 폴더 열기";
+
+/* Class = "NSTextFieldCell"; title = "App Updates:"; ObjectID = "zqG-X2-E9b"; */
+"zqG-X2-E9b.title" = "앱 업데이트:";

--- a/Mac/ko.lproj/RenameSheet.strings
+++ b/Mac/ko.lproj/RenameSheet.strings
@@ -1,0 +1,11 @@
+/* Class = "NSTextFieldCell"; title = "<<Rename prompt>>"; ObjectID = "7Os-lV-Jer"; */
+"7Os-lV-Jer.title" = "<<Rename prompt>>";
+
+/* Class = "NSButtonCell"; title = "Rename"; ObjectID = "gcS-uM-zjx"; */
+"gcS-uM-zjx.title" = "이름 변경";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "oe4-cJ-2V8"; */
+"oe4-cJ-2V8.title" = "취소";
+
+/* Class = "NSWindow"; title = "Rename"; ObjectID = "QvC-M9-y7g"; */
+"QvC-M9-y7g.title" = "이름 변경";

--- a/Mac/ko.lproj/UnifiedWindow.strings
+++ b/Mac/ko.lproj/UnifiedWindow.strings
@@ -1,0 +1,35 @@
+/* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "1F7-qu-7oN"; */
+"1F7-qu-7oN.title" = "항목 2";
+
+/* Class = "NSMenuItem"; title = "Sort"; ObjectID = "4BZ-ya-evy"; */
+"4BZ-ya-evy.title" = "정렬";
+
+/* Class = "NSMenuItem"; title = "Newest Article on Top"; ObjectID = "40c-kt-vhO"; */
+"40c-kt-vhO.title" = "최신 기사를 위로";
+
+/* Class = "NSOutlineView"; ibExternalAccessibilityDescription = "Feeds"; ObjectID = "cnV-kg-Dn2"; */
+"cnV-kg-Dn2.ibExternalAccessibilityDescription" = "피드";
+
+/* Class = "NSTextFieldCell"; title = "HEADER CELL"; ObjectID = "dRB-0K-qxz"; */
+"dRB-0K-qxz.title" = "헤더 셀";
+
+/* Class = "NSTextFieldCell"; title = "Label"; ObjectID = "dVE-XG-mlU"; */
+"dVE-XG-mlU.title" = "레이블";
+
+/* Class = "NSWindow"; title = "NetNewsWire"; ObjectID = "IQv-IB-iLA"; */
+"IQv-IB-iLA.title" = "NetNewsWire";
+
+/* Class = "NSMenuItem"; title = "Item 3"; ObjectID = "r9E-FO-GoU"; */
+"r9E-FO-GoU.title" = "항목 3";
+
+/* Class = "NSMenuItem"; title = "Oldest Article on Top"; ObjectID = "sOF-Ez-vIL"; */
+"sOF-Ez-vIL.title" = "오래된 기사를 위로";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "sXh-y7-12P"; */
+"sXh-y7-12P.title" = "텍스트 셀";
+
+/* Class = "NSMenuItem"; title = "Group by Feed"; ObjectID = "YSR-5C-Yjd"; */
+"YSR-5C-Yjd.title" = "피드별로 그룹화";
+
+/* Class = "NSMenuItem"; title = "Item 1"; ObjectID = "ZDH-CV-Y2s"; */
+"ZDH-CV-Y2s.title" = "항목 1";

--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -290,13 +290,17 @@
 		849C64601ED37A5D003D8FC0 /* NetNewsWire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NetNewsWire.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		849C64711ED37A5D003D8FC0 /* NetNewsWireTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NetNewsWireTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		84D2200922B0BC4B0019E085 /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
+		DBF0EFE02F95019A001F6B23 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Intents.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
 		842E25332DB9F9B800FF7DD8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				/Localized/SafariExtension/InfoPlist.strings,
 				/Localized/SafariExtension/SafariExtensionViewController.xib,
+				/Localized/ShareExtension/InfoPlist.strings,
+				/Localized/ShareExtension/Localizable.strings,
 				/Localized/ShareExtension/ShareViewController.xib,
 				Resources/Info.plist,
 				Resources/NetNewsWire.provisionprofile,
@@ -318,6 +322,7 @@
 		842E25352DB9F9B800FF7DD8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				/Localized/SafariExtension/InfoPlist.strings,
 				/Localized/SafariExtension/SafariExtensionViewController.xib,
 				"SafariExtension/netnewswire-subscribe-to-feed.js",
 				SafariExtension/SafariExtensionHandler.swift,
@@ -329,6 +334,8 @@
 		842E25362DB9F9B800FF7DD8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				/Localized/ShareExtension/InfoPlist.strings,
+				/Localized/ShareExtension/Localizable.strings,
 				/Localized/ShareExtension/ShareViewController.xib,
 				AppDefaults.swift,
 				ShareExtension/icon.icns,
@@ -361,6 +368,10 @@
 		84A6D03F2D1B4EC500F23315 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				/Localized/IntentsExtension/InfoPlist.strings,
+				/Localized/IntentsExtension/Localizable.strings,
+				/Localized/ShareExtension/InfoPlist.strings,
+				/Localized/ShareExtension/Localizable.strings,
 				/Localized/ShareExtension/MainInterface.storyboard,
 				IntentsExtension/Info.plist,
 				IntentsExtension/IntentHandler.swift,
@@ -377,6 +388,8 @@
 		84A6D0402D1B4EC500F23315 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				/Localized/ShareExtension/InfoPlist.strings,
+				/Localized/ShareExtension/Localizable.strings,
 				/Localized/ShareExtension/MainInterface.storyboard,
 				AppDefaults.swift,
 				Resources/Assets.xcassets,
@@ -391,6 +404,8 @@
 		84A6D0412D1B4EC500F23315 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				/Localized/IntentsExtension/InfoPlist.strings,
+				/Localized/IntentsExtension/Localizable.strings,
 				IntentsExtension/IntentHandler.swift,
 			);
 			target = 51314636235A7BBE00387FDC /* NetNewsWire iOS Intents Extension */;
@@ -984,6 +999,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ko,
 			);
 			mainGroup = 849C64571ED37A5D003D8FC0;
 			packageReferences = (
@@ -1338,6 +1354,7 @@
 			children = (
 				51314706235C41FC00387FDC /* Base */,
 				51314714235C420900387FDC /* en */,
+				DBF0EFE02F95019A001F6B23 /* ko */,
 			);
 			name = Intents.intentdefinition;
 			sourceTree = "<group>";

--- a/Shared/DefaultAccountNames.xcstrings
+++ b/Shared/DefaultAccountNames.xcstrings
@@ -57,6 +57,60 @@
               }
             }
           }
+        },
+        "ko" : {
+          "variations" : {
+            "device" : {
+              "appletv" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "나의 Apple TV"
+                }
+              },
+              "applevision" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "나의 Apple Vision"
+                }
+              },
+              "applewatch" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "나의 Apple Watch"
+                }
+              },
+              "ipad" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "나의 iPad"
+                }
+              },
+              "iphone" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "나의 iPhone"
+                }
+              },
+              "ipod" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "나의 iPod"
+                }
+              },
+              "mac" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "나의 Mac"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "나의 기기"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/Widget/Resources/Localizable.xcstrings
+++ b/Widget/Resources/Localizable.xcstrings
@@ -9,6 +9,12 @@
             "state" : "translated",
             "value" : "Summary"
           }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요약"
+          }
         }
       }
     },
@@ -19,6 +25,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "The Lock Screen Summary displays current article counts across the Smart Feeds. "
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잠금 화면 요약은 스마트 피드 전체의 현재 기사 수를 표시합니다."
           }
         }
       }
@@ -31,6 +43,12 @@
             "state" : "translated",
             "value" : "Starred"
           }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "별표한 기사"
+          }
         }
       }
     },
@@ -41,6 +59,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "There are no starred articles."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "별표한 기사가 없습니다."
           }
         }
       }
@@ -53,6 +77,12 @@
             "state" : "translated",
             "value" : "This widget displays your starred articles."
           }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 위젯은 별표한 기사를 표시합니다."
+          }
         }
       }
     },
@@ -63,6 +93,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Today"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘"
           }
         }
       }
@@ -75,6 +111,12 @@
             "state" : "translated",
             "value" : "There are no recent articles."
           }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 기사가 없습니다."
+          }
         }
       }
     },
@@ -85,6 +127,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This widget displays articles posted within the last 24 hours."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 위젯은 지난 24시간 동안 게시된 기사를 표시합니다."
           }
         }
       }
@@ -97,6 +145,12 @@
             "state" : "translated",
             "value" : "Unread"
           }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽지 않음"
+          }
         }
       }
     },
@@ -108,6 +162,12 @@
             "state" : "translated",
             "value" : "There are no unread articles."
           }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽지 않은 기사가 없습니다."
+          }
         }
       }
     },
@@ -118,6 +178,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This widget display unread articles."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 위젯은 읽지 않은 기사를 표시합니다."
           }
         }
       }

--- a/Widget/ko.lproj/InfoPlist.strings
+++ b/Widget/ko.lproj/InfoPlist.strings
@@ -1,0 +1,5 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "NetNewsWire 위젯";
+
+/* Bundle name */
+"CFBundleName" = "NetNewsWire iOS 위젯 확장";

--- a/iOS/Account/FeedbinAccountViewController.swift
+++ b/iOS/Account/FeedbinAccountViewController.swift
@@ -74,10 +74,10 @@ final class FeedbinAccountViewController: UITableViewController {
 	@IBAction func showHidePassword(_ sender: Any) {
 		if passwordTextField.isSecureTextEntry {
 			passwordTextField.isSecureTextEntry = false
-			showHideButton.setTitle("Hide", for: .normal)
+			showHideButton.setTitle(NSLocalizedString("Hide", comment: "Hide password"), for: .normal)
 		} else {
 			passwordTextField.isSecureTextEntry = true
-			showHideButton.setTitle("Show", for: .normal)
+			showHideButton.setTitle(NSLocalizedString("Show", comment: "Show password"), for: .normal)
 		}
 	}
 

--- a/iOS/Account/NewsBlurAccountViewController.swift
+++ b/iOS/Account/NewsBlurAccountViewController.swift
@@ -72,10 +72,10 @@ final class NewsBlurAccountViewController: UITableViewController {
 	@IBAction func showHidePassword(_ sender: Any) {
 		if passwordTextField.isSecureTextEntry {
 			passwordTextField.isSecureTextEntry = false
-			showHideButton.setTitle("Hide", for: .normal)
+			showHideButton.setTitle(NSLocalizedString("Hide", comment: "Hide password"), for: .normal)
 		} else {
 			passwordTextField.isSecureTextEntry = true
-			showHideButton.setTitle("Show", for: .normal)
+			showHideButton.setTitle(NSLocalizedString("Show", comment: "Show password"), for: .normal)
 		}
 	}
 
@@ -152,7 +152,7 @@ final class NewsBlurAccountViewController: UITableViewController {
 	}
 
 	private func showError(_ message: String) {
-		presentError(title: "Error", message: message)
+		presentError(title: NSLocalizedString("Error", comment: "Credentials Error"), message: message)
 	}
 
 	private func enableNavigation() {

--- a/iOS/Account/ReaderAPIAccountViewController.swift
+++ b/iOS/Account/ReaderAPIAccountViewController.swift
@@ -123,10 +123,10 @@ final class ReaderAPIAccountViewController: UITableViewController {
 	@IBAction func showHidePassword(_ sender: Any) {
 		if passwordTextField.isSecureTextEntry {
 			passwordTextField.isSecureTextEntry = false
-			showHideButton.setTitle("Hide", for: .normal)
+			showHideButton.setTitle(NSLocalizedString("Hide", comment: "Hide password"), for: .normal)
 		} else {
 			passwordTextField.isSecureTextEntry = true
-			showHideButton.setTitle("Show", for: .normal)
+			showHideButton.setTitle(NSLocalizedString("Show", comment: "Show password"), for: .normal)
 		}
 	}
 
@@ -280,7 +280,7 @@ final class ReaderAPIAccountViewController: UITableViewController {
 	}
 
 	private func showError(_ message: String) {
-		presentError(title: "Error", message: message)
+		presentError(title: NSLocalizedString("Error", comment: "Credentials Error"), message: message)
 	}
 
 	private func enableNavigation() {

--- a/iOS/Article/ArticleSearchBar.swift
+++ b/iOS/Article/ArticleSearchBar.swift
@@ -38,7 +38,8 @@ import UIKit
 	weak var delegate: SearchBarDelegate?
 
 	override var keyCommands: [UIKeyCommand]? {
-		return [UIKeyCommand(title: "Exit Find", action: #selector(donePressed(_:)), input: UIKeyCommand.inputEscape)]
+		let exitFindTitle = NSLocalizedString("Exit Find", comment: "Exit find")
+		return [UIKeyCommand(title: exitFindTitle, action: #selector(donePressed(_:)), input: UIKeyCommand.inputEscape)]
 	}
 
 	override init(frame: CGRect) {
@@ -129,14 +130,14 @@ private extension ArticleSearchBar {
 
 		prevButton = UIButton(type: .system)
 		prevButton.setImage(UIImage(systemName: "chevron.up"), for: .normal)
-		prevButton.accessibilityLabel = "Previous Result"
+		prevButton.accessibilityLabel = NSLocalizedString("Previous Result", comment: "Previous search result")
 		prevButton.isAccessibilityElement = true
 		prevButton.addTarget(self, action: #selector(previousPressed), for: .touchUpInside)
 		addArrangedSubview(prevButton)
 
 		nextButton = UIButton(type: .system)
 		nextButton.setImage(UIImage(systemName: "chevron.down"), for: .normal)
-		nextButton.accessibilityLabel = "Next Result"
+		nextButton.accessibilityLabel = NSLocalizedString("Next Result", comment: "Next search result")
 		nextButton.isAccessibilityElement = true
 		nextButton.addTarget(self, action: #selector(nextPressed), for: .touchUpInside)
 		addArrangedSubview(nextButton)

--- a/iOS/Inspector/AccountInspectorViewController.swift
+++ b/iOS/Inspector/AccountInspectorViewController.swift
@@ -224,7 +224,7 @@ extension AccountInspectorViewController {
 
 	override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
 		if displayedSections[section] == .syncContent {
-			return "Syncing article content increases iCloud storage use, sync time, and battery use.\n\nArticle status and the content of starred articles are always synced."
+			return NSLocalizedString("Syncing article content increases iCloud storage use, sync time, and battery use.\n\nArticle status and the content of starred articles are always synced.", comment: "Sync content footer text")
 		}
 		let storyboardIndex = displayedSections[section].rawValue
 		return super.tableView(tableView, titleForFooterInSection: storyboardIndex)

--- a/iOS/IntentsExtension/ko.lproj/InfoPlist.strings
+++ b/iOS/IntentsExtension/ko.lproj/InfoPlist.strings
@@ -1,0 +1,5 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "NetNewsWire iOS Intents 확장 프로그램";
+
+/* Bundle name */
+"CFBundleName" = "NetNewsWire iOS Intents 확장 프로그램";

--- a/iOS/IntentsExtension/ko.lproj/Localizable.strings
+++ b/iOS/IntentsExtension/ko.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+/* Communication failure */
+"Unable to communicate with NetNewsWire." = "NetNewsWire와 통신할 수 없습니다.";

--- a/iOS/Resources/ko.lproj/InfoPlist.strings
+++ b/iOS/Resources/ko.lproj/InfoPlist.strings
@@ -1,0 +1,11 @@
+/* Bundle name */
+"CFBundleName" = "NetNewsWire";
+
+/* No comment provided by engineer. */
+"NetNewsWire Theme" = "NetNewsWire 테마";
+
+/* Privacy - Photo Library Additions Usage Description */
+"NSPhotoLibraryAddUsageDescription" = "기사의 이미지를 저장하려면 권한을 허용해 주세요.";
+
+/* No comment provided by engineer. */
+"OPML" = "OPML";

--- a/iOS/Resources/ko.lproj/Localizable.strings
+++ b/iOS/Resources/ko.lproj/Localizable.strings
@@ -666,7 +666,7 @@ TOR SignUp */
 Starred article for accessibility
 Starred label
 Starred pseudo-feed title */
-"Starred" = "별표 표시됨";
+"Starred" = "별표한 기사";
 
 /* Status records header */
 "Status Records" = "상태 기록";

--- a/iOS/Resources/ko.lproj/Localizable.strings
+++ b/iOS/Resources/ko.lproj/Localizable.strings
@@ -1,0 +1,827 @@
+/* No Text */
+"(No Text)" = "(텍스트 없음)";
+
+/* No comment provided by engineer. */
+"[netnewswire.com](https://netnewswire.com/)" = "[netnewswire.com](https://netnewswire.com/)";
+
+/* Results selection and count */
+"%d of %d" = "%2$d개 중 %1$d개";
+
+/* 14 Unread */
+"%i Unread" = "읽지 않음 %i개";
+
+/* No comment provided by engineer. */
+"About NetNewsWire" = "NetNewsWire 정보";
+
+/* Account Error */
+"Account Error" = "계정 오류";
+
+/* Accounts
+Add Account */
+"Add Account" = "계정 추가";
+
+/* Add Feed */
+"Add Feed" = "피드 추가";
+
+/* Add Folder */
+"Add Folder" = "폴더 추가";
+
+/* All Articles */
+"All Articles" = "모든 기사";
+
+/* All Unread pseudo-feed title */
+"All Unread" = "전체 읽지 않음";
+
+/* Additional contributors */
+"and many more" = "그 밖에도 많은 분들";
+
+/* FreshRSS API Helper */
+"API URL: https://fresh.rss.net/api/greader.php" = "API URL: https://fresh.rss.net/api/greader.php";
+
+/* No comment provided by engineer. */
+"App Icon" = "앱 아이콘";
+
+/* Feed delete text */
+"Are you sure you want to delete the “%@” feed?" = "피드 “%@”을 삭제하시겠습니까?";
+
+/* Folder delete text */
+"Are you sure you want to delete the “%@” folder?" = "폴더 “%@”을 삭제하시겠습니까?";
+
+/* Delete Theme Message */
+"Are you sure you want to delete the theme “%@”?." = "테마 “%@”을 삭제하시겠습니까?.";
+
+/* Log Out and Remove Account */
+"Are you sure you want to remove this account? NetNewsWire will no longer be able to access articles and feeds unless the account is added again." = "이 계정을 제거하시겠습니까? 계정을 다시 추가하지 않는 한 NetNewsWire에서 기사와 피드에 더 이상 접근할 수 없습니다.";
+
+/* Remove Account */
+"Are you sure you want to remove this account? This cannot be undone." = "이 계정을 제거하시겠습니까? 이 작업은 되돌릴 수 없습니다.";
+
+/* Article content records header */
+"Article Content Records" = "기사 콘텐츠 레코드";
+
+/* Article Search */
+"Article Search" = "기사 검색";
+
+/* Authors website */
+"Author’s website:\n%@" = "작성자 웹사이트:\n%@";
+
+/* Automatic */
+"Automatic" = "자동";
+
+/* Account name
+BazQux */
+"BazQux" = "BazQux";
+
+/* No comment provided by engineer. */
+"By Brent Simmons and the Ranchero Software team" = "Brent Simmons와 Ranchero Software 팀 제작";
+
+/* CloudKit account setup failure description — iCloud Drive not enabled. */
+"Can’t Add iCloud Account" = "iCloud 계정을 추가할 수 없음";
+
+/* Cancel
+Cancel button */
+"Cancel" = "취소";
+
+/* Scan canceled text */
+"Canceled." = "취소되었습니다.";
+
+/* Import Account */
+"Choose an account to receive the imported feeds and folders" = "가져온 피드와 폴더를 받을 계정을 선택하세요";
+
+/* Export Account */
+"Choose an account with the subscriptions to export" = "내보낼 구독이 있는 계정을 선택하세요";
+
+/* Clean Up
+Clean up alert button */
+"Clean Up" = "정리";
+
+/* Clean up alert title */
+"Clean Up iCloud Records" = "iCloud 레코드 정리";
+
+/* Clean up button */
+"Clean Up…" = "정리…";
+
+/* Cleanup status text when canceled */
+"Cleanup canceled." = "정리가 취소되었습니다.";
+
+/* Cleanup error message */
+"Cleanup failed to complete, but you may be able to clean up more if you wait a few minutes and try again." = "정리를 완료하지 못했습니다. 몇 분 기다렸다가 다시 시도하면 더 정리할 수 있을지도 모릅니다.";
+
+/* Close */
+"Close" = "닫기";
+
+/* Close Image */
+"Close Image" = "이미지 닫기";
+
+/* Disclosure button collapsed state for accessibility */
+"Collapsed" = "접힘";
+
+/* No comment provided by engineer. */
+"Contributing Developers" = "기여한 개발자";
+
+/* Copy Article URL */
+"Copy Article URL" = "기사 URL 복사";
+
+/* No comment provided by engineer. */
+"Copy Contents" = "내용 복사";
+
+/* Copy External URL */
+"Copy External URL" = "외부 URL 복사";
+
+/* Copy Feed URL */
+"Copy Feed URL" = "피드 URL 복사";
+
+/* Copy Home Page URL */
+"Copy Home Page URL" = "홈페이지 URL 복사";
+
+/* No comment provided by engineer. */
+"Copyright © 2002-2026 Brent Simmons" = "저작권 © 2002-2026 Brent Simmons";
+
+/* No comment provided by engineer. */
+"Credits" = "크레딧";
+
+/* Dark */
+"Dark" = "다크";
+
+/* Deactivate */
+"Deactivate" = "비활성화";
+
+/* No comment provided by engineer. */
+"Dedication" = "헌정";
+
+/* Default */
+"Default" = "기본";
+
+/* Delete */
+"Delete" = "삭제";
+
+/* Delete feed
+command */
+"Delete Feed" = "피드 삭제";
+
+/* command */
+"Delete Feeds" = "피드 삭제";
+
+/* command */
+"Delete Feeds and Folders" = "피드 및 폴더 삭제";
+
+/* Delete folder
+command */
+"Delete Folder" = "폴더 삭제";
+
+/* command */
+"Delete Folders" = "폴더 삭제";
+
+/* Delete Theme */
+"Delete Theme?" = "테마를 삭제할까요?";
+
+/* Cleanup phase text */
+"Deleting read content records…" = "읽은 콘텐츠 레코드를 삭제하는 중…";
+
+/* Cleanup phase text */
+"Deleting unread content records…" = "읽지 않은 콘텐츠 레코드를 삭제하는 중…";
+
+/* Dismiss */
+"Dismiss" = "닫기";
+
+/* Done */
+"Done" = "완료";
+
+/* Duplicate Theme */
+"Duplicate Theme" = "테마 복제";
+
+/* Notifications */
+"Enable Notifications" = "알림 켜기";
+
+/* Credentials Error
+Error */
+"Error" = "오류";
+
+/* Error - Reader View */
+"Error - Reader View" = "오류 - 리더 보기";
+
+/* No comment provided by engineer. */
+"Error Log" = "오류 로그";
+
+/* No comment provided by engineer. */
+"Errors may contain feed URLs and other information you may not want to share publicly." = "오류에는 공개적으로 공유하고 싶지 않은 피드 URL 및 기타 정보가 포함될 수 있습니다.";
+
+/* Every 2 Hours */
+"Every 2 Hours" = "2시간마다";
+
+/* Every 4 Hours */
+"Every 4 Hours" = "4시간마다";
+
+/* Every 8 Hours */
+"Every 8 Hours" = "8시간마다";
+
+/* Every 30 Minutes */
+"Every 30 Minutes" = "30분마다";
+
+/* Every Hour */
+"Every Hour" = "매시간";
+
+/* Exit find */
+"Exit Find" = "찾기 종료";
+
+/* Disclosure button expanded state for accessibility */
+"Expanded" = "펼침";
+
+/* XX-Large */
+"Extra Extra Large" = "아주 크게";
+
+/* X-Large */
+"Extra Large" = "매우 크게";
+
+/* No comment provided by engineer. */
+"Featuring additional contributions from" = "추가 기여";
+
+/* Account name */
+"Feedbin" = "Feedbin";
+
+/* Account name */
+"Feedly" = "Feedly";
+
+/* No comment provided by engineer. */
+"Feedly Syncing" = "Feedly 동기화";
+
+/* Filter Read Articles */
+"Filter Read Articles" = "읽은 기사 필터링";
+
+/* Filter Read Feeds */
+"Filter Read Feeds" = "읽은 피드 필터링";
+
+/* Find in Article */
+"Find in Article" = "기사에서 찾기";
+
+/* FreshRSS SignUp */
+"Find Out More" = "자세히 알아보기";
+
+/* First Unread */
+"First Unread" = "첫 번째 읽지 않은 기사";
+
+/* Account name
+FreshRSS */
+"FreshRSS" = "FreshRSS";
+
+/* Get Feed Info */
+"Get Feed Info" = "피드 정보 가져오기";
+
+/* Get Info */
+"Get Info" = "정보 가져오기";
+
+/* Go To All Unread */
+"Go To All Unread" = "전체 읽지 않음으로 이동";
+
+/* Go to Feed */
+"Go to Feed" = "피드로 이동";
+
+/* Go To Settings */
+"Go To Settings" = "설정으로 이동";
+
+/* Go To Starred */
+"Go To Starred" = "별표 표시된 기사로 이동";
+
+/* Go To Today */
+"Go To Today" = "오늘로 이동";
+
+/* Help menu item */
+"Help" = "도움말";
+
+/* No comment provided by engineer. */
+"Help Book" = "도움말";
+
+/* Here */
+"Here" = "여기";
+
+/* Hide password */
+"Hide" = "숨기기";
+
+/* Help link */
+"How to Optimize iCloud Syncing" = "iCloud 동기화를 최적화하는 방법";
+
+/* Account name
+iCloud Account */
+"iCloud" = "iCloud";
+
+/* Cleanup phase text when completed */
+"iCloud storage cleanup completed." = "iCloud 저장 공간 정리가 완료되었습니다.";
+
+/* Navigation title for iCloud stats view */
+"iCloud Storage Stats" = "iCloud 저장 공간 통계";
+
+/* Icon Preview */
+"Icon Preview" = "아이콘 미리보기";
+
+/* Icon Size */
+"Icon Size" = "아이콘 크기";
+
+/* Import Failed */
+"Import Failed" = "가져오기 실패";
+
+/* Import Theme */
+"Import Theme" = "테마 가져오기";
+
+/* Account name
+Inoreader */
+"Inoreader" = "Inoreader";
+
+/* Install Theme */
+"Install Theme" = "테마 설치";
+
+/* Theme message text */
+"Install theme “%@” by %@?" = "%2$@의 테마 “%1$@”을 설치할까요?";
+
+/* Invalid API URL */
+"Invalid API URL." = "잘못된 API URL입니다.";
+
+/* Credentials Error */
+"Invalid email/password combination." = "이메일/비밀번호 조합이 올바르지 않습니다.";
+
+/* Credentials Error */
+"Invalid username/password combination." = "사용자 이름/비밀번호 조합이 올바르지 않습니다.";
+
+/* Credentials Error */
+"Keychain error while storing credentials." = "자격 증명을 저장하는 동안 키체인 오류가 발생했습니다.";
+
+/* Large */
+"Large" = "크게";
+
+/* Light */
+"Light" = "라이트";
+
+/* Link */
+"Link:" = "링크:";
+
+/* Local Account */
+"Local" = "로컬";
+
+/* Local Account */
+"Local accounts do not sync your feeds across devices" = "로컬 계정은 기기 간에 피드를 동기화하지 않습니다";
+
+/* Local */
+"Local accounts do not sync your feeds across devices." = "로컬 계정은 기기 간에 피드를 동기화하지 않습니다.";
+
+/* Manually */
+"Manually" = "수동";
+
+/* Mark Above as Read */
+"Mark Above as Read" = "위를 읽음으로 표시";
+
+/* Mark All as Read */
+"Mark All as Read" = "모두 읽음으로 표시";
+
+/* Command
+Mark All as Read in Feed */
+"Mark All as Read in “%@”" = "“%@”에서 모두 읽음으로 표시";
+
+/* Mark Article Unread */
+"Mark Article Unread" = "기사를 읽지 않음으로 표시";
+
+/* Mark as Read */
+"Mark as Read" = "읽음으로 표시";
+
+/* Mark As Read */
+"Mark As Read" = "읽음으로 표시";
+
+/* Mark as Starred */
+"Mark as Starred" = "별표로 표시";
+
+/* Mark as Unread */
+"Mark as Unread" = "읽지 않음으로 표시";
+
+/* Mark as Unstarred */
+"Mark as Unstarred" = "별표 해제 상태로 표시";
+
+/* Mark Below as Read */
+"Mark Below as Read" = "아래를 읽음으로 표시";
+
+/* command */
+"Mark Read" = "읽음 표시";
+
+/* command */
+"Mark Starred" = "별표 표시";
+
+/* command */
+"Mark Unread" = "읽지 않음 표시";
+
+/* command */
+"Mark Unstarred" = "별표 해제";
+
+/* Accessibility announcement */
+"Marked as Read" = "읽음으로 표시됨";
+
+/* Accessibility announcement */
+"Marked as Unread" = "읽지 않음으로 표시됨";
+
+/* Medium */
+"Medium" = "보통";
+
+/* More
+More menu label */
+"More" = "더 보기";
+
+/* Name */
+"Name" = "이름";
+
+/* No comment provided by engineer. */
+"NetNewsWire 7 is dedicated to everyone working to save democracy in the United States and around the world." = "NetNewsWire 7은 미국과 전 세계에서 민주주의를 지키기 위해 애쓰는 모든 분들께 바칩니다.";
+
+/* NetNewsWire News */
+"NetNewsWire News" = "NetNewsWire 뉴스";
+
+/* iCloud */
+"NetNewsWire will use your iCloud account to sync your subscriptions across your Mac and iOS devices." = "NetNewsWire는 iCloud 계정을 사용하여 Mac과 iOS 기기 간에 구독을 동기화합니다.";
+
+/* Credentials Error */
+"Network error. Try again later." = "네트워크 오류입니다. 나중에 다시 시도하세요.";
+
+/* New Feed */
+"New Feed" = "새 피드";
+
+/* New Folder */
+"New Folder" = "새 폴더";
+
+/* Account name */
+"NewsBlur" = "NewsBlur";
+
+/* No comment provided by engineer. */
+"NewsBlur Syncing" = "NewsBlur 동기화";
+
+/* No comment provided by engineer. */
+"Newsfoot (JS footnote displayer)" = "Newsfoot (JS 각주 표시기)";
+
+/* Next Article */
+"Next Article" = "다음 기사";
+
+/* Next search result */
+"Next Result" = "다음 결과";
+
+/* Next Unread */
+"Next Unread" = "다음 읽지 않은 기사";
+
+/* Next Unread Article */
+"Next Unread Article" = "다음 읽지 않은 기사";
+
+/* No comment provided by engineer. */
+"No Errors Logged" = "오류 기록 없음";
+
+/* No Icon Preview */
+"No Icon Preview" = "아이콘 미리보기 없음";
+
+/* No results */
+"No results" = "결과 없음";
+
+/* Notifications need to be enabled in the Settings app. */
+"Notifications need to be enabled in the Settings app." = "설정 앱에서 알림을 활성화해야 합니다.";
+
+/* Number of Lines */
+"Number of Lines" = "줄 수";
+
+/* OK */
+"OK" = "확인";
+
+/* Open */
+"Open" = "열기";
+
+/* Open Home Page */
+"Open Home Page" = "홈페이지 열기";
+
+/* Open in Browser */
+"Open in Browser" = "브라우저에서 열기";
+
+/* Open In Browser */
+"Open In Browser" = "브라우저에서 열기";
+
+/* Open Settings
+Open Settings button */
+"Open Settings" = "설정 열기";
+
+/* CloudKit account setup recovery suggestion */
+"Open Settings to configure iCloud and enable iCloud Drive." = "설정을 열어 iCloud를 구성하고 iCloud Drive를 활성화하세요.";
+
+/* Open System Settings button */
+"Open System Settings" = "시스템 설정 열기";
+
+/* CloudKit account setup recovery suggestion */
+"Open System Settings to configure iCloud and enable iCloud Drive." = "시스템 설정을 열어 iCloud를 구성하고 iCloud Drive를 활성화하세요.";
+
+/* OPML export error */
+"OPML Export Error" = "OPML 내보내기 오류";
+
+/* Overwrite */
+"Overwrite" = "덮어쓰기";
+
+/* Previous Article */
+"Previous Article" = "이전 기사";
+
+/* Previous search result */
+"Previous Result" = "이전 결과";
+
+/* Processing - Reader View */
+"Processing - Reader View" = "처리 중 - 리더 보기";
+
+/* Read label */
+"Read" = "읽음";
+
+/* Read content deleted label */
+"Read Content Deleted" = "읽은 콘텐츠 삭제";
+
+/* Singular label for read content records */
+"read content record" = "읽은 콘텐츠 기록";
+
+/* Plural label for read content records */
+"read content records" = "읽은 콘텐츠 기록";
+
+/* Reader View */
+"Reader View" = "리더 보기";
+
+/* Refresh
+Refresh button */
+"Refresh" = "새로 고침";
+
+/* Refresh scan button */
+"Refresh Scan" = "스캔 새로 고침";
+
+/* Remove */
+"Remove" = "제거";
+
+/* Remove Account */
+"Remove Account" = "계정 제거";
+
+/* Rename */
+"Rename" = "이름 변경";
+
+/* Rename feed */
+"Rename “%@”" = "“%@” 이름 변경";
+
+/* Return to scan results button */
+"Return to Previous Scan Results" = "이전 스캔 결과로 돌아가기";
+
+/* Scan completed text */
+"Scan completed." = "스캔이 완료되었습니다.";
+
+/* Scan failed text */
+"Scan failed." = "스캔에 실패했습니다.";
+
+/* Scan status text */
+"Scanning iCloud storage" = "iCloud 저장 공간 스캔 중";
+
+/* Search */
+"Search" = "검색";
+
+/* Search Articles */
+"Search Articles" = "기사 검색";
+
+/* Search smart feed title prefix */
+"Search: " = "검색:";
+
+/* See articles in Folder */
+"See articles in  “%@”" = "“%@”의 기사 보기";
+
+/* First Unread */
+"See first unread article" = "첫 번째 읽지 않은 기사 보기";
+
+/* Select Next Down */
+"Select Next Down" = "아래 다음 항목 선택";
+
+/* Select Next Up */
+"Select Next Up" = "위 다음 항목 선택";
+
+/* Selected - Filter Read Articles */
+"Selected - Filter Read Articles" = "선택됨 - 읽은 기사 필터링";
+
+/* Selected - Filter Read Feeds */
+"Selected - Filter Read Feeds" = "선택됨 - 읽은 피드 필터링";
+
+/* Selected - Mark Article Unread */
+"Selected - Mark Article Unread" = "선택됨 - 기사를 읽지 않음으로 표시";
+
+/* Selected - Reader View */
+"Selected - Reader View" = "선택됨 - 리더 보기";
+
+/* Selected - Star Article */
+"Selected - Star Article" = "선택됨 - 기사에 별표 표시";
+
+/* Self hosted Account */
+"Self-hosted" = "자체 호스팅";
+
+/* Self hosted Account */
+"Self-hosted accounts sync your feeds across all your devices" = "자체 호스팅 계정은 모든 기기에서 피드를 동기화합니다";
+
+/* Share */
+"Share" = "공유";
+
+/* Share stats menu item */
+"Share Stats" = "통계 공유";
+
+/* Show password */
+"Show" = "표시";
+
+/* Show Feed Article */
+"Show Feed Article" = "피드 기사 보기";
+
+/* Show Reader View */
+"Show Reader View" = "리더 보기 표시";
+
+/* Show Website */
+"Show Website" = "웹사이트 보기";
+
+/* BazQux */
+"Sign in to your BazQux account and sync your feeds across your devices. Your username and password will be encrypted and stored in Keychain.\n\nDon’t have a BazQux account?" = "BazQux 계정에 로그인하여 모든 기기에서 피드를 동기화하세요. 사용자 이름과 비밀번호는 암호화되어 키체인에 저장됩니다.\n\nBazQux 계정이 없으신가요?";
+
+/* Feedbin */
+"Sign in to your Feedbin account and sync your feeds across your devices. Your username and password will be encrypted and stored in Keychain.\n\nDon’t have a Feedbin account?" = "Feedbin 계정에 로그인하여 모든 기기에서 피드를 동기화하세요. 사용자 이름과 비밀번호는 암호화되어 키체인에 저장됩니다.\n\nFeedbin 계정이 없으신가요?";
+
+/* FreshRSS */
+"Sign in to your FreshRSS instance and sync your feeds across your devices. Your username and password will be encrypted and stored in Keychain.\n\nDon’t have an FreshRSS instance?" = "FreshRSS 인스턴스에 로그인하여 모든 기기에서 피드를 동기화하세요. 사용자 이름과 비밀번호는 암호화되어 키체인에 저장됩니다.\n\nFreshRSS 인스턴스가 없으신가요?";
+
+/* Inoreader */
+"Sign in to your Inoreader account and sync your feeds across your devices. Your username and password will be encrypted and stored in Keychain.\n\nDon’t have an Inoreader account?" = "Inoreader 계정에 로그인하여 모든 기기에서 피드를 동기화하세요. 사용자 이름과 비밀번호는 암호화되어 키체인에 저장됩니다.\n\nInoreader 계정이 없으신가요?";
+
+/* NewsBlur */
+"Sign in to your NewsBlur account and sync your feeds across your devices. Your username and password will be encrypted and stored in Keychain.\n\nDon’t have a NewsBlur account?" = "NewsBlur 계정에 로그인하여 모든 기기에서 피드를 동기화하세요. 사용자 이름과 비밀번호는 암호화되어 키체인에 저장됩니다.\n\nNewsBlur 계정이 없으신가요?";
+
+/* TOR */
+"Sign in to your The Old Reader account and sync your feeds across your devices. Your username and password will be encrypted and stored in Keychain.\n\nDon’t have a The Old Reader account?" = "The Old Reader 계정에 로그인하여 모든 기기에서 피드를 동기화하세요. 사용자 이름과 비밀번호는 암호화되어 키체인에 저장됩니다.\n\nThe Old Reader 계정이 없으신가요?";
+
+/* BazQux SignUp
+Inoreader SignUp
+TOR SignUp */
+"Sign Up Here" = "여기서 가입하기";
+
+/* Small */
+"Small" = "작게";
+
+/* Smart Feeds group title */
+"Smart Feeds" = "스마트 피드";
+
+/* Star */
+"Star" = "별표";
+
+/* Star Article */
+"Star Article" = "기사에 별표 표시";
+
+/* Accessibility announcement
+Starred article for accessibility
+Starred label
+Starred pseudo-feed title */
+"Starred" = "별표 표시됨";
+
+/* Status records header */
+"Status Records" = "상태 기록";
+
+/* Sync content footer text */
+"Syncing article content increases iCloud storage use, sync time, and battery use.\n\nArticle status and the content of starred articles are always synced." = "기사 내용을 동기화하면 iCloud 저장 공간 사용량과 동기화 시간, 배터리 사용량이 늘어납니다.\n\n기사 상태와 별표한 기사의 내용은 항상 동기화됩니다.";
+
+/* No comment provided by engineer. */
+"Thanks" = "감사의 말";
+
+/* No comment provided by engineer. */
+"Thanks to Sheila and my family; thanks to my friends in Seattle and around the globe; thanks to the ever-patient and ever-awesome NetNewsWire beta testers.\n\nThanks to [Gus Mueller](https://shapeof.com/) for [FMDB](https://github.com/ccgus/fmdb) by [Flying Meat Software](http://flyingmeat.com/). Thanks to [GitHub](https://github.com) and [Discourse](https://discourse.com) for making open source collaboration easy and fun. Thanks to [Ben Ubois](https://benubois.com/) at [Feedbin](https://feedbin.com) for all the extra help with syncing and article rendering — and [for hosting the server for the Reader view](https://feedbin.com/blog/2019/03/11/the-future-of-full-content/)." = "셰일라와 가족, 시애틀과 전 세계의 친구들, 그리고 늘 인내심 있고 멋진 NetNewsWire 베타 테스터 여러분께 감사드립니다.\n\n[Flying Meat Software](http://flyingmeat.com/)의 [FMDB](https://github.com/ccgus/fmdb)를 만들어 준 [Gus Mueller](https://shapeof.com/)에게 감사드립니다. 오픈 소스 협업을 쉽고 즐겁게 만들어 준 [GitHub](https://github.com)와 [Discourse](https://discourse.com)에도 감사드립니다. 동기화와 기사 렌더링에 큰 도움을 준 [Feedbin](https://feedbin.com)의 [Ben Ubois](https://benubois.com/)에게도, 그리고 [리더 보기용 서버를 호스팅해 준 것](https://feedbin.com/blog/2019/03/11/the-future-of-full-content/)에도 감사드립니다.";
+
+/* Account name
+The Old Reader */
+"The Old Reader" = "The Old Reader";
+
+/* Overwrite theme */
+"The theme “%@” already exists. Overwrite it?" = "테마 “%@”이(가) 이미 있습니다. 덮어쓰시겠습니까?";
+
+/* Theme installed */
+"The theme “%@” has been installed." = "테마 “%@”이(가) 설치되었습니다.";
+
+/* Theme installed */
+"Theme installed" = "테마 설치됨";
+
+/* Duplicate Error */
+"There is already a Feedbin account with that username created." = "해당 사용자 이름의 Feedbin 계정이 이미 있습니다.";
+
+/* Duplicate Error */
+"There is already a NewsBlur account with that username created." = "해당 사용자 이름의 NewsBlur 계정이 이미 있습니다.";
+
+/* Duplicate Error */
+"There is already an account of that type with that username created." = "해당 사용자 이름의 같은 유형 계정이 이미 있습니다.";
+
+/* This device cannot send emails. */
+"This device cannot send emails." = "이 기기에서는 이메일을 보낼 수 없습니다.";
+
+/* Clean up confirmation suffix */
+"This may take several minutes." = "몇 분 정도 걸릴 수 있습니다.";
+
+/* Decoding key missing */
+"This theme cannot be used because of data corruption in the Info.plist. %@." = "Info.plist의 데이터가 손상되어 이 테마를 사용할 수 없습니다. %@.";
+
+/* Decoding key missing */
+"This theme cannot be used because the the key—“%@”—is not found in the Info.plist." = "Info.plist에서 키 “%@”를 찾을 수 없어 이 테마를 사용할 수 없습니다.";
+
+/* Type mismatch */
+"This theme cannot be used because the the type—“%@”—is mismatched in the Info.plist" = "Info.plist에서 유형 “%@”이(가) 일치하지 않아 이 테마를 사용할 수 없습니다";
+
+/* Decoding value missing */
+"This theme cannot be used because the the value—“%@”—is not found in the Info.plist." = "Info.plist에서 값 “%@”를 찾을 수 없어 이 테마를 사용할 수 없습니다.";
+
+/* Clean up confirmation when plan is stale */
+"This will delete any not-starred content records.\n\nThis may take several minutes." = "별표 표시되지 않은 콘텐츠 기록이 삭제됩니다.\n\n몇 분 정도 걸릴 수 있습니다.";
+
+/* Clean up confirmation when sync unread is on and plan is stale */
+"This will delete any read content records.\n\nThis may take several minutes." = "읽은 콘텐츠 기록이 삭제됩니다.\n\n몇 분 정도 걸릴 수 있습니다.";
+
+/* Clean up confirmation prefix */
+"This will delete:" = "다음 항목이 삭제됩니다:";
+
+/* Timeline Layout */
+"Timeline Layout" = "타임라인 레이아웃";
+
+/* Today pseudo-feed title */
+"Today" = "오늘";
+
+/* Toggle Read Articles Filter */
+"Toggle Read Articles Filter" = "읽은 기사 필터 전환";
+
+/* Toggle Read Feeds Filter */
+"Toggle Read Feeds Filter" = "읽은 피드 필터 전환";
+
+/* Toggle Read Status */
+"Toggle Read Status" = "읽음 상태 전환";
+
+/* Toggle Reader View */
+"Toggle Reader View" = "리더 보기 전환";
+
+/* Toggle Sidebar */
+"Toggle Sidebar" = "사이드바 전환";
+
+/* Toggle Starred Status */
+"Toggle Starred Status" = "별표 상태 전환";
+
+/* No comment provided by engineer. */
+"Under-the-hood magic & CSS" = "내부 구현과 CSS";
+
+/* Unknown Value */
+"Unknown" = "알 수 없음";
+
+/* Unread label for accessibility */
+"unread" = "읽지 않음";
+
+/* Unread
+Unread label */
+"Unread" = "읽지 않음";
+
+/* Unread content deleted label */
+"Unread Content Deleted" = "읽지 않은 콘텐츠 삭제";
+
+/* Singular label for unread content records */
+"unread content record" = "읽지 않은 콘텐츠 기록";
+
+/* Plural label for unread content records */
+"unread content records" = "읽지 않은 콘텐츠 기록";
+
+/* Unstar */
+"Unstar" = "별표 해제";
+
+/* Accessibility announcement */
+"Unstarred" = "별표 해제됨";
+
+/* Feed name */
+"Untitled" = "제목 없음";
+
+/* Update Credentials */
+"Update Credentials" = "로그인 정보 업데이트";
+
+/* Updated */
+"Updated %@" = "%@ 업데이트됨";
+
+/* Updated Just Now */
+"Updated Just Now" = "방금 업데이트됨";
+
+/* Updating… */
+"Updating…" = "업데이트 중…";
+
+/* Credentials Error */
+"Username & password required." = "사용자 이름과 비밀번호가 필요합니다.";
+
+/* Credentials Error */
+"Username and password are required." = "사용자 이름과 비밀번호가 필요합니다.";
+
+/* Credentials Error */
+"Username required." = "사용자 이름이 필요합니다.";
+
+/* Credentials Error */
+"Username, password, and API URL are required." = "사용자 이름, 비밀번호 및 API URL이 필요합니다.";
+
+/* Import Failed Message */
+"We were unable to process the selected file.  Please ensure that it is a properly formatted OPML file." = "선택한 파일을 처리할 수 없습니다. 올바른 형식의 OPML 파일인지 확인해 주세요.";
+
+/* Web Account */
+"Web" = "웹";
+
+/* Web Account */
+"Web accounts sync your feeds across all your devices" = "웹 계정은 모든 기기에서 피드를 동기화합니다";
+
+/* You can turn this confirmation off in Settings. */
+"You can turn this confirmation off in Settings." = "이 확인 메시지는 설정에서 끌 수 있습니다.";
+
+/* Missing active account */
+"You must have at least one active account." = "활성 계정이 하나 이상 있어야 합니다.";
+
+/* iCloud Account */
+"Your iCloud account syncs your feeds across your Mac and iOS devices" = "iCloud 계정은 Mac과 iOS 기기 간에 피드를 동기화합니다";

--- a/iOS/Settings/AboutContributor.swift
+++ b/iOS/Settings/AboutContributor.swift
@@ -61,7 +61,8 @@ public enum Contributors: CaseIterable {
 		case .ryanDotson:
 			return AboutContributor(name: "Ryan Dotson", url: URL(string: "https://github.com/nostodnayr")!)
 		case .others:
-			return AboutContributor(name: "and many more", url: URL(string: "https://github.com/Ranchero-Software/NetNewsWire/graphs/contributors")!)
+			let othersTitle = NSLocalizedString("and many more", comment: "Additional contributors")
+			return AboutContributor(name: othersTitle, url: URL(string: "https://github.com/Ranchero-Software/NetNewsWire/graphs/contributors")!)
 		}
 	}
 }

--- a/iOS/Settings/AboutCreditView.swift
+++ b/iOS/Settings/AboutCreditView.swift
@@ -10,13 +10,13 @@ import SwiftUI
 
 struct AboutCreditView: View {
 
-	let contributorType: String
+	let contributorType: LocalizedStringKey
 	let contributors: [Contributors]
 
     var body: some View {
 		HStack(alignment: .top) {
 			Spacer()
-			Text(verbatim: contributorType)
+			Text(contributorType)
 				.foregroundStyle(.secondary)
 				.frame(maxWidth: .infinity, alignment: .trailing)
 				.lineLimit(3)

--- a/iOS/Settings/AboutView.swift
+++ b/iOS/Settings/AboutView.swift
@@ -20,12 +20,12 @@ struct AboutView: View {
 				Text(verbatim: "NetNewsWire")
 					.font(.largeTitle)
 
-				Text(verbatim: "By Brent Simmons and the Ranchero Software team")
+				Text("By Brent Simmons and the Ranchero Software team")
 					.foregroundStyle(.secondary)
 				Text("[netnewswire.com](https://netnewswire.com/)")
 
 				VStack(spacing: 6) {
-					Text(verbatim: "Credits")
+					Text("Credits")
 						.bold()
 						.foregroundStyle(.secondary)
 						.padding(.top, 16)
@@ -40,7 +40,7 @@ struct AboutView: View {
 				}
 
 				VStack(spacing: 6) {
-					Text(verbatim: "Thanks")
+					Text("Thanks")
 						.bold()
 						.foregroundStyle(.secondary)
 						.padding(.top, 16)
@@ -48,14 +48,14 @@ struct AboutView: View {
 				}
 
 				VStack(spacing: 6) {
-					Text(verbatim: "Dedication")
+					Text("Dedication")
 						.bold()
 						.foregroundStyle(.secondary)
 						.padding(.top, 16)
 					Text("NetNewsWire 7 is dedicated to everyone working to save democracy in the United States and around the world.")
 				}
 
-				Text(verbatim: "Copyright © 2002-2026 Brent Simmons")
+				Text("Copyright © 2002-2026 Brent Simmons")
 					.font(.caption)
 					.foregroundStyle(.secondary)
 					.padding(.bottom)
@@ -64,7 +64,7 @@ struct AboutView: View {
 		}
 		.multilineTextAlignment(.center)
 		.background(Color(uiColor: .systemBackground))
-		.navigationTitle(Text(verbatim: "About NetNewsWire"))
+		.navigationTitle("About NetNewsWire")
     }
 }
 

--- a/iOS/Settings/SettingsViewController.swift
+++ b/iOS/Settings/SettingsViewController.swift
@@ -418,7 +418,7 @@ private extension SettingsViewController {
 	func importOPML(sourceView: UIView, sourceRect: CGRect) {
 		switch AccountManager.shared.activeAccounts.count {
 		case 0:
-			presentError(title: "Error", message: NSLocalizedString("You must have at least one active account.", comment: "Missing active account"))
+			presentError(title: NSLocalizedString("Error", comment: "Error"), message: NSLocalizedString("You must have at least one active account.", comment: "Missing active account"))
 		case 1:
 			opmlAccount = AccountManager.shared.activeAccounts.first
 			importOPMLDocumentPicker()
@@ -516,7 +516,8 @@ private extension SettingsViewController {
 		do {
 			try opmlString.write(to: tempFile, atomically: true, encoding: String.Encoding.utf8)
 		} catch {
-			self.presentError(title: "OPML Export Error", message: error.localizedDescription)
+			let errorTitle = NSLocalizedString("OPML Export Error", comment: "OPML export error")
+			self.presentError(title: errorTitle, message: error.localizedDescription)
 		}
 
 		let docPicker = UIDocumentPickerViewController(forExporting: [tempFile])

--- a/iOS/ShareExtension/ShareViewController.swift
+++ b/iOS/ShareExtension/ShareViewController.swift
@@ -43,9 +43,9 @@ final class ShareViewController: SLComposeServiceViewController, ShareFolderPick
 		}
 
 		title = "NetNewsWire"
-		placeholder = "Feed Name (Optional)"
+		placeholder = NSLocalizedString("Feed Name (Optional)", comment: "Optional feed name placeholder")
 		if let button = navigationController?.navigationBar.topItem?.rightBarButtonItem {
-			button.title = "Add Feed"
+			button.title = NSLocalizedString("Add Feed", comment: "Add Feed")
 			button.isEnabled = true
 		}
 
@@ -140,11 +140,11 @@ final class ShareViewController: SLComposeServiceViewController, ShareFolderPick
 	override func configurationItems() -> [Any]! {
 		// To add configuration options via table cells at the bottom of the sheet, return an array of SLComposeSheetConfigurationItem here.
 		guard let urlItem = SLComposeSheetConfigurationItem() else { return nil }
-		urlItem.title = "URL"
+		urlItem.title = NSLocalizedString("URL", comment: "URL")
 		urlItem.value = url?.absoluteString ?? ""
 
 		folderItem = SLComposeSheetConfigurationItem()
-		folderItem.title = "Folder"
+		folderItem.title = NSLocalizedString("Folder", comment: "Folder")
 		updateFolderItemValue()
 
 		folderItem.tapHandler = {

--- a/iOS/ShareExtension/ko.lproj/InfoPlist.strings
+++ b/iOS/ShareExtension/ko.lproj/InfoPlist.strings
@@ -1,0 +1,5 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "NetNewsWire iOS 공유 확장 프로그램";
+
+/* Bundle name */
+"CFBundleName" = "NetNewsWire iOS 공유 확장 프로그램";

--- a/iOS/ShareExtension/ko.lproj/Localizable.strings
+++ b/iOS/ShareExtension/ko.lproj/Localizable.strings
@@ -1,0 +1,20 @@
+/* Add Feed */
+"Add Feed" = "피드 추가";
+
+/* Automatic */
+"Automatic" = "자동";
+
+/* Dark */
+"Dark" = "다크";
+
+/* Optional feed name placeholder */
+"Feed Name (Optional)" = "피드 이름(선택 사항)";
+
+/* Folder */
+"Folder" = "폴더";
+
+/* Light */
+"Light" = "라이트";
+
+/* URL */
+"URL" = "URL";

--- a/iOS/ko.lproj/Main.strings
+++ b/iOS/ko.lproj/Main.strings
@@ -1,0 +1,104 @@
+/* Class = "UILabel"; text = "Label"; ObjectID = "0Hz-Dv-MhU"; */
+"0Hz-Dv-MhU.text" = "날짜";
+
+/* Class = "UILabel"; text = "Article Content"; ObjectID = "1rh-TG-4t8"; */
+"1rh-TG-4t8.text" = "기사 내용";
+
+/* Class = "UILabel"; text = "articleDate"; ObjectID = "1tb-Fr-7LL"; */
+"1tb-Fr-7LL.text" = "게시일";
+
+/* Class = "UIBarButtonItem"; title = "Next Article"; ObjectID = "2qz-M5-Yhk"; */
+"2qz-M5-Yhk.title" = "다음 기사";
+
+/* Class = "UIBarButtonItem"; title = "Next Unread"; ObjectID = "2w5-e9-C2V"; */
+"2w5-e9-C2V.title" = "다음 읽지 않은 기사";
+
+/* Class = "UICollectionViewController"; title = "Feeds"; ObjectID = "6Bn-mF-MPS"; */
+"6Bn-mF-MPS.title" = "피드";
+
+/* Class = "UILabel"; text = "Blog Author"; ObjectID = "7GV-PV-YVq"; */
+"7GV-PV-YVq.text" = "블로그 작성자";
+
+/* Class = "UILabel"; text = "authorByLine"; ObjectID = "9nR-Dd-ZuE"; */
+"9nR-Dd-ZuE.text" = "작성자";
+
+/* Class = "UILabel"; text = "articleDate"; ObjectID = "aGY-Xq-5YU"; */
+"aGY-Xq-5YU.text" = "게시일";
+
+/* Class = "UILabel"; text = "Feed Title"; ObjectID = "fHH-rW-0hD"; */
+"fHH-rW-0hD.text" = "피드 제목";
+
+/* Class = "UILabel"; text = "Article Content"; ObjectID = "h4j-SE-f60"; */
+"h4j-SE-f60.text" = "기사 내용";
+
+/* Class = "UIBarButtonItem"; title = "Toggle Read"; ObjectID = "hy0-LS-MzE"; */
+"hy0-LS-MzE.title" = "읽음 상태 전환";
+
+/* Class = "UILabel"; text = "Article Title"; ObjectID = "iFp-rn-HhQ"; */
+"iFp-rn-HhQ.text" = "기사 제목";
+
+/* Class = "UIBarButtonItem"; title = "Add"; ObjectID = "iTI-PO-3e6"; */
+"iTI-PO-3e6.title" = "추가";
+
+/* Class = "UIViewController"; title = "Detail"; ObjectID = "JEX-9P-axG"; */
+"JEX-9P-axG.title" = "상세";
+
+/* Class = "UIBarButtonItem"; title = "Item"; ObjectID = "jGC-TX-BdL"; */
+"jGC-TX-BdL.title" = "항목";
+
+/* Class = "UILabel"; text = "authorByLine"; ObjectID = "kYC-07-iWu"; */
+"kYC-07-iWu.text" = "작성자";
+
+/* Class = "UILabel"; text = "8888"; ObjectID = "LVW-Zu-z90"; */
+"LVW-Zu-z90.text" = "8888";
+
+/* Class = "UIBarButtonItem"; title = "Settings"; ObjectID = "N0L-yy-Bfq"; */
+"N0L-yy-Bfq.title" = "설정";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "noV-fz-88z"; */
+"noV-fz-88z.normalTitle" = "버튼";
+
+/* Class = "UILabel"; text = "authorByLine"; ObjectID = "NSi-68-toP"; */
+"NSi-68-toP.text" = "작성자";
+
+/* Class = "UILabel"; text = "Article Content"; ObjectID = "O03-6u-AcE"; */
+"O03-6u-AcE.text" = "기사 내용";
+
+/* Class = "UILabel"; text = "authorByLine"; ObjectID = "o3c-FZ-gKE"; */
+"o3c-FZ-gKE.text" = "작성자";
+
+/* Class = "UILabel"; text = "8888"; ObjectID = "oRt-Cv-vvU"; */
+"oRt-Cv-vvU.text" = "8888";
+
+/* Class = "UILabel"; text = "ContainerTitle"; ObjectID = "p16-Uj-CBX"; */
+"p16-Uj-CBX.text" = "섹션 제목";
+
+/* Class = "UILabel"; text = "articleDate"; ObjectID = "pk2-pA-n2G"; */
+"pk2-pA-n2G.text" = "게시일";
+
+/* Class = "UILabel"; text = "articleDate"; ObjectID = "pLf-h1-h8G"; */
+"pLf-h1-h8G.text" = "게시일";
+
+/* Class = "UIViewController"; title = "Timeline"; ObjectID = "QJM-al-rDe"; */
+"QJM-al-rDe.title" = "타임라인";
+
+/* Class = "UILabel"; text = "Folder Title"; ObjectID = "qoe-rn-pwE"; */
+"qoe-rn-pwE.text" = "폴더 제목";
+
+/* Class = "UILabel"; text = "8888"; ObjectID = "TBA-io-5jo"; */
+"TBA-io-5jo.text" = "8888";
+
+/* Class = "UIBarButtonItem"; title = "Previous Article"; ObjectID = "v4j-fq-23N"; */
+"v4j-fq-23N.title" = "이전 기사";
+
+/* Class = "UIBarButtonItem"; title = "Toggle Starred"; ObjectID = "wU4-eH-wC9"; */
+"wU4-eH-wC9.title" = "별표 상태 전환";
+
+/* Class = "UILabel"; text = "Article Content"; ObjectID = "Yan-r6-V5Z"; */
+"Yan-r6-V5Z.text" = "기사 내용";
+
+/* Class = "UILabel"; text = "Blog Name"; ObjectID = "YsT-Lt-Zry"; */
+"YsT-Lt-Zry.text" = "블로그 이름";
+
+/* Class = "UINavigationItem"; title = "Feeds"; ObjectID = "zgM-dx-bIO"; */
+"zgM-dx-bIO.title" = "피드";


### PR DESCRIPTION
## Summary
- add Korean localization resources for the macOS and iOS apps, share extensions, widget, Safari extension, and intents
- register `ko` as a supported localization in the Xcode project and populate the shared string catalogs
- localize remaining hard-coded English UI strings in account, settings, search, and share flows so the new locale is actually reachable
- refine the iOS `Starred` label to match the Korean terminology used elsewhere in the app after manual QA

## Why
NetNewsWire already had localization plumbing in place, but the app shipped only with English UI resources. This change adds a first Korean translation pass across the app targets and closes a handful of hard-coded English strings that would otherwise bypass localization.

## Validation
- `xcodebuild -project NetNewsWire.xcodeproj -scheme NetNewsWire -destination "platform=macOS,arch=arm64" build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project NetNewsWire.xcodeproj -scheme NetNewsWire-iOS -destination 'platform=iOS Simulator,id=8A7BCEDF-9115-4F24-AEEB-CECA80D86ED3' build CODE_SIGNING_ALLOWED=NO`
- `plutil -lint` on the generated `ko.lproj/*.strings` files, plus the updated `iOS/Resources/ko.lproj/Localizable.strings`
- manual Korean-locale QA on macOS for the launch dialog, main window, Preferences > General, Preferences > Accounts, and the add-account sheet
- manual Korean-locale QA on iOS simulator for the Smart Feeds screen and first-launch notification prompt

## Notes
- I did not use the earlier local macOS test run as a final gate because `xcodebuild test` completed the suites but then hung during teardown on this machine
