### PR TITLE
Find Feed: prefer a page-specific feed over a site-wide <head> feed (#5299)

### DIFF
--- a/Modules/FeedFinder/Sources/FeedFinder/FeedFinder.swift
+++ b/Modules/FeedFinder/Sources/FeedFinder/FeedFinder.swift
@@ -144,6 +144,32 @@ public final class FeedFinder {
 	}
 }
 
+extension FeedFinder {
+
+	/// True when `feedURLString` is on the same host as `pageURLString` and its
+	/// path equals or is nested under the page's path. The page must have a
+	/// non-root path — a root request (e.g. example.com/) gets no on-path
+	/// preference, preserving the existing <head>-feed behavior for whole sites.
+	static func feedURLString(_ feedURLString: String, isUnderRequestedPageURLString pageURLString: String) -> Bool {
+		guard let feedURL = URL(string: feedURLString), let pageURL = URL(string: pageURLString),
+			let feedHost = feedURL.host(), let pageHost = pageURL.host() else {
+			return false
+		}
+		func normalizedHost(_ host: String) -> String {
+			let lowered = host.lowercased(with: localeForLowercasing)
+			return lowered.hasPrefix("www.") ? String(lowered.dropFirst("www.".count)) : lowered
+		}
+		guard normalizedHost(feedHost) == normalizedHost(pageHost) else {
+			return false
+		}
+		let pagePath = pageURL.path.hasSuffix("/") ? String(pageURL.path.dropLast()) : pageURL.path
+		guard pagePath.count > 1 else {
+			return false
+		}
+		return feedURL.path == pagePath || feedURL.path.hasPrefix(pagePath + "/")
+	}
+}
+
 private extension FeedFinder {
 
 	static func addFeedSpecifier(_ feedSpecifier: FeedSpecifier, feedSpecifiers: inout [String: FeedSpecifier]) {
@@ -177,6 +203,23 @@ private extension FeedFinder {
 				if feedSpecifiers[oneFeedSpecifier.urlString] == nil {
 					feedSpecifiersToDownload.insert(oneFeedSpecifier)
 				}
+			}
+		}
+
+		// A body-linked feed whose URL lives *under* the requested page's path
+		// (e.g. /blog/feed for a /blog request) is more specific than a
+		// site-wide feed declared in <head> (e.g. a network master feed). Prefer
+		// it: validate the on-path body candidates and, if any are real feeds,
+		// return those instead of the <head> feed. Without this, any <head> feed
+		// unconditionally suppressed every body feed, so a page-specific feed was
+		// discarded before it could be considered. (#5299)
+		let onPathToDownload = feedSpecifiersToDownload.filter {
+			Self.feedURLString($0.urlString, isUnderRequestedPageURLString: urlString)
+		}
+		if !onPathToDownload.isEmpty {
+			let onPathFeeds = await downloadFeedSpecifiers(onPathToDownload, feedSpecifiers: [:])
+			if !onPathFeeds.isEmpty {
+				return (onPathFeeds, .candidates)
 			}
 		}
 

--- a/Modules/FeedFinder/Tests/FeedFinderTests/FeedFinderTests.swift
+++ b/Modules/FeedFinder/Tests/FeedFinderTests/FeedFinderTests.swift
@@ -15,4 +15,35 @@ final class FeedFinderTests: XCTestCase {
 		let feedFinder = FeedFinder()
 		XCTAssertNotNil(feedFinder)
 	}
+
+	// Covers #5299: a page-specific feed linked in the body (e.g. /blog/feed)
+	// must be recognized as "under" the requested page path so it can be
+	// preferred over a site-wide <head> feed.
+	func testFeedURLIsUnderRequestedPagePath() {
+		func isUnder(_ feed: String, _ page: String) -> Bool {
+			FeedFinder.feedURLString(feed, isUnderRequestedPageURLString: page)
+		}
+
+		// The bug case: /blog/feed is under the requested /blog page…
+		XCTAssertTrue(isUnder("https://www.relay.fm/blog/feed", "https://www.relay.fm/blog"))
+		// …while the site-wide feed at a different path is not on-path.
+		XCTAssertFalse(isUnder("http://relay.fm/master/feed", "https://www.relay.fm/blog"))
+
+		// Host comparison is www- and case-insensitive.
+		XCTAssertTrue(isUnder("https://relay.fm/blog/feed", "https://www.relay.fm/blog"))
+		XCTAssertTrue(isUnder("https://WWW.Relay.FM/blog/feed", "https://www.relay.fm/blog"))
+
+		// A different host is never on-path.
+		XCTAssertFalse(isUnder("https://example.com/blog/feed", "https://www.relay.fm/blog"))
+
+		// A root request gets no on-path preference (whole-site Find Feed unchanged).
+		XCTAssertFalse(isUnder("https://relay.fm/feed", "https://relay.fm/"))
+		XCTAssertFalse(isUnder("https://relay.fm/feed", "https://relay.fm"))
+
+		// A sibling that merely shares a path prefix is not nested under it.
+		XCTAssertFalse(isUnder("https://relay.fm/blogger/feed", "https://relay.fm/blog"))
+
+		// An exact path match counts as on-path.
+		XCTAssertTrue(isUnder("https://relay.fm/blog", "https://relay.fm/blog"))
+	}
 }


### PR DESCRIPTION
Fixes #5299. I asked first on Discourse and got the go-ahead: https://discourse.netnewswire.com/t/first-time-contributing-can-i-fix-issue-5299/299

### Problem
Find Feed on `https://www.relay.fm/blog` selects `http://relay.fm/master/feed` (the all-network feed) instead of the page's own `https://www.relay.fm/blog/feed`.

### Root cause
The page advertises two feeds:
- `http://relay.fm/master/feed` — a `<link rel="alternate">` in `<head>` (`.HTMLHead`)
- `https://www.relay.fm/blog/feed` — a body "Subscribe via RSS" link (`.HTMLLink`)

In `FeedFinder.findFeedsInHTMLPage`, as soon as any `<head>` feed is found it sets `didFindFeedInHTMLHead = true` and returns the `<head>` feeds, so the body candidate sitting in `feedSpecifiersToDownload` is discarded. `bestFeed` then receives a single-element set and returns `master/feed` without ever scoring — so `/blog/feed` is dropped before it can be considered. (Confirmed by tracing the discovery at runtime: both feeds were discovered; the body feed was discarded by the early return.) This isn't a relay.fm misconfiguration — both feeds are valid and advertised.

### Fix
Before falling back to the `<head>` feed, validate any body-linked candidate whose URL is on the same host and nested under the requested page's path (e.g. `/blog/feed` for a `/blog` request) and prefer it. Host comparison is `www`- and case-insensitive (via `localeForLowercasing`). Root-domain requests (no path) keep the existing `<head>`-feed behavior, so whole-site Find Feed is unchanged.

### Testing
- New unit test `testFeedURLIsUnderRequestedPagePath` — on-path preference, `www`/case-insensitive host matching, different-host rejection, root-path exclusion, and the sibling-prefix trap (`/blogger` is not under `/blog`).
- `swiftlint lint --strict` clean; `FeedFinder` module build has no new warnings; module tests pass.
- Verified end to end: Find Feed on `relay.fm/blog` now resolves to `https://www.relay.fm/blog/feed`.

### Disclosure
Diagnosed and drafted with LLM assistance (Claude Opus 4.8), reviewed to meet the project's quality bar — per CONTRIBUTING.md.
