### PR TITLE
Add offline article-image caching behind a setting

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -43,6 +43,7 @@ final class AppDefaults: Sendable {
 		static let defaultBrowserID = "defaultBrowserID"
 		static let currentThemeName = "currentThemeName"
 		static let articleContentJavascriptEnabled = "articleContentJavascriptEnabled"
+		static let cacheImagesForOffline = "cacheImagesForOffline"
 
 		// Hidden prefs
 		static let showDebugMenu = "ShowDebugMenu"
@@ -319,6 +320,15 @@ final class AppDefaults: Sendable {
 		}
 	}
 
+	var cacheImagesForOffline: Bool {
+		get {
+			UserDefaults.standard.bool(forKey: Key.cacheImagesForOffline)
+		}
+		set {
+			UserDefaults.standard.set(newValue, forKey: Key.cacheImagesForOffline)
+		}
+	}
+
 	init() {
 		// Migrate every-10-minute refresh interval to 30 minutes.
 		let rawValue = UserDefaults.standard.integer(forKey: Key.refreshInterval)
@@ -344,7 +354,8 @@ final class AppDefaults: Sendable {
 			Key.refreshInterval: RefreshInterval.every2Hours.rawValue,
 			Key.showDebugMenu: showDebugMenu,
 			Key.currentThemeName: Self.defaultThemeName,
-			Key.articleContentJavascriptEnabled: true
+			Key.articleContentJavascriptEnabled: true,
+			Key.cacheImagesForOffline: false
 		]
 
 		UserDefaults.standard.register(defaults: defaults)

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -147,6 +147,7 @@ let appName = "NetNewsWire"
 		installAppleEventHandlers()
 
 		CacheCleaner.purgeIfNecessary()
+		ArticleImagePrefetcher.shared.start()
 
 		// Try to establish a cache in the Caches folder, but if it fails for some reason fall back to a temporary dir
 		let cacheFolder: String

--- a/Mac/Base.lproj/Preferences.storyboard
+++ b/Mac/Base.lproj/Preferences.storyboard
@@ -31,11 +31,11 @@
             <objects>
                 <viewController title="General" storyboardIdentifier="General" id="iuH-lz-18x" customClass="GeneralPreferencesViewController" customModule="NetNewsWire" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="WnV-px-wCT">
-                        <rect key="frame" x="0.0" y="0.0" width="509" height="460"/>
+                        <rect key="frame" x="0.0" y="0.0" width="509" height="560"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <customView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Ut3-yd-q6G">
-                                <rect key="frame" x="57" y="16" width="393" height="428"/>
+                                <rect key="frame" x="57" y="16" width="393" height="528"/>
                                 <subviews>
                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pR2-Bf-7Fd">
                                         <rect key="frame" x="-2" y="404" width="106" height="16"/>
@@ -146,8 +146,37 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Cm8-g0-ca8">
+                                        <rect key="frame" x="110" y="232" width="283" height="16"/>
+                                        <buttonCell key="cell" type="check" title="Cache article images for offline reading" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Cm9-g0-ca9">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="cacheImagesForOfflineChanged:" target="iuH-lz-18x" id="Cmo-g0-cao"/>
+                                            <binding destination="mAF-gO-1PI" name="value" keyPath="values.cacheImagesForOffline" id="Cm0-g0-ca0">
+                                                <dictionary key="options">
+                                                    <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                    <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                    <integer key="NSMultipleValuesPlaceholder" value="1"/>
+                                                    <integer key="NSNoSelectionPlaceholder" value="1"/>
+                                                    <integer key="NSNotApplicablePlaceholder" value="1"/>
+                                                    <integer key="NSNullPlaceholder" value="1"/>
+                                                    <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                                </dictionary>
+                                            </binding>
+                                        </connections>
+                                    </button>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Cmh-g0-cah">
+                                        <rect key="frame" x="110" y="212" width="283" height="14"/>
+                                        <textFieldCell key="cell" controlSize="small" selectable="YES" title="" id="Cmi-g0-cai">
+                                            <font key="font" usesAppearanceFont="YES"/>
+                                            <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
                                     <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Tdg-6Y-gvW">
-                                        <rect key="frame" x="0.0" y="221" width="392" height="5"/>
+                                        <rect key="frame" x="0.0" y="180" width="392" height="5"/>
                                     </box>
                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wsb-Lr-8Q7">
                                         <rect key="frame" x="-2" y="183" width="106" height="16"/>
@@ -282,7 +311,13 @@
                                     <constraint firstItem="Ci4-fW-KjU" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" id="0Do-jh-Hqq"/>
                                     <constraint firstItem="92N-8I-bOs" firstAttribute="trailing" secondItem="S2Z-bG-jYk" secondAttribute="trailing" id="2ZD-KR-H5A"/>
                                     <constraint firstItem="S2Z-bG-jYk" firstAttribute="trailing" secondItem="pR2-Bf-7Fd" secondAttribute="trailing" id="4wu-2O-1fb"/>
-                                    <constraint firstItem="Tdg-6Y-gvW" firstAttribute="top" secondItem="0W5-tO-S63" secondAttribute="bottom" constant="20" id="5a3-LF-TvY"/>
+                                    <constraint firstItem="Cm8-g0-ca8" firstAttribute="top" secondItem="0W5-tO-S63" secondAttribute="bottom" constant="12" id="Cn3-M3-aa3"/>
+                                    <constraint firstItem="Cm8-g0-ca8" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" id="Cn1-M1-aa1"/>
+                                    <constraint firstAttribute="trailing" secondItem="Cm8-g0-ca8" secondAttribute="trailing" id="Cn2-M2-aa2"/>
+                                    <constraint firstItem="Cmh-g0-cah" firstAttribute="top" secondItem="Cm8-g0-ca8" secondAttribute="bottom" constant="6" id="Cmj-g0-caj"/>
+                                    <constraint firstItem="Cmh-g0-cah" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" id="Cmk-g0-cak"/>
+                                    <constraint firstAttribute="trailing" secondItem="Cmh-g0-cah" secondAttribute="trailing" id="Cml-g0-cal"/>
+                                    <constraint firstItem="Tdg-6Y-gvW" firstAttribute="top" secondItem="Cmh-g0-cah" secondAttribute="bottom" constant="20" id="5a3-LF-TvY"/>
                                     <constraint firstItem="0W5-tO-S63" firstAttribute="top" secondItem="UI6-sq-M15" secondAttribute="bottom" constant="8" id="5mw-aE-uy4"/>
                                     <constraint firstItem="Z6O-Zt-V1g" firstAttribute="top" secondItem="Ut3-yd-q6G" secondAttribute="top" constant="4" id="6nC-a3-QOy"/>
                                     <constraint firstItem="Z6O-Zt-V1g" firstAttribute="firstBaseline" secondItem="pR2-Bf-7Fd" secondAttribute="firstBaseline" id="72z-7d-9Qn"/>
@@ -291,7 +326,8 @@
                                     <constraint firstItem="yrg-M3-Dbz" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" id="Bmt-Mn-CCl"/>
                                     <constraint firstItem="UI6-sq-M15" firstAttribute="top" secondItem="1w0-nA-DEO" secondAttribute="bottom" constant="12" id="DMk-OP-dpa"/>
                                     <constraint firstItem="Ubm-Pk-l7x" firstAttribute="top" secondItem="Ci4-fW-KjU" secondAttribute="bottom" constant="12" id="E3r-xf-7aZ"/>
-                                    <constraint firstAttribute="bottom" secondItem="SFF-mL-yc8" secondAttribute="bottom" constant="4" id="FAd-wh-IFu"/>
+                                    <constraint firstAttribute="bottom" secondItem="SFF-mL-yc8" secondAttribute="bottom" constant="8" id="FAd-wh-IFu"/>
+                                    <constraint firstItem="SFF-mL-yc8" firstAttribute="height" secondItem="Ci4-fW-KjU" secondAttribute="height" id="SFh-Eq-001"/>
                                     <constraint firstItem="pR2-Bf-7Fd" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" id="G0C-1M-LW1"/>
                                     <constraint firstItem="yrg-M3-Dbz" firstAttribute="trailing" secondItem="pR2-Bf-7Fd" secondAttribute="trailing" id="JbY-CP-pK8"/>
                                     <constraint firstAttribute="trailing" secondItem="Ubm-Pk-l7x" secondAttribute="trailing" id="KIg-w5-ceG"/>
@@ -309,7 +345,7 @@
                                     <constraint firstItem="Ci4-fW-KjU" firstAttribute="top" secondItem="Tdg-6Y-gvW" secondAttribute="bottom" constant="20" id="UkR-wd-4Oe"/>
                                     <constraint firstAttribute="trailing" secondItem="0W5-tO-S63" secondAttribute="trailing" id="WMd-dg-Zmr"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1w0-nA-DEO" secondAttribute="trailing" id="X8P-Hj-l5H"/>
-                                    <constraint firstItem="ucw-vG-yLt" firstAttribute="firstBaseline" secondItem="SFF-mL-yc8" secondAttribute="firstBaseline" id="XHk-Fk-1pC"/>
+                                    <constraint firstItem="ucw-vG-yLt" firstAttribute="centerY" secondItem="SFF-mL-yc8" secondAttribute="centerY" id="XHk-Fk-1pC"/>
                                     <constraint firstAttribute="trailing" secondItem="wtY-Zd-Ps9" secondAttribute="trailing" id="YAf-to-Ruz"/>
                                     <constraint firstItem="1w0-nA-DEO" firstAttribute="top" secondItem="ISO-Wu-R60" secondAttribute="bottom" constant="12" id="Yal-X7-BjE"/>
                                     <constraint firstAttribute="trailing" secondItem="hQy-ng-ijd" secondAttribute="trailing" constant="1" id="aaL-6A-h6v"/>
@@ -325,7 +361,7 @@
                                     <constraint firstItem="0W5-tO-S63" firstAttribute="leading" secondItem="UI6-sq-M15" secondAttribute="leading" constant="22" id="jmc-lb-wp2"/>
                                     <constraint firstAttribute="trailing" secondItem="Yrc-6Q-kx8" secondAttribute="trailing" id="o3L-x4-mEr"/>
                                     <constraint firstItem="Wsb-Lr-8Q7" firstAttribute="trailing" secondItem="pR2-Bf-7Fd" secondAttribute="trailing" id="obL-84-81H"/>
-                                    <constraint firstItem="Wsb-Lr-8Q7" firstAttribute="firstBaseline" secondItem="Ci4-fW-KjU" secondAttribute="firstBaseline" id="pCJ-eR-07V"/>
+                                    <constraint firstItem="Wsb-Lr-8Q7" firstAttribute="centerY" secondItem="Ci4-fW-KjU" secondAttribute="centerY" id="pCJ-eR-07V"/>
                                     <constraint firstItem="Yrc-6Q-kx8" firstAttribute="top" secondItem="wtY-Zd-Ps9" secondAttribute="bottom" constant="6" symbolic="YES" id="pbM-DF-ATO"/>
                                     <constraint firstItem="hQy-ng-ijd" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" id="qE2-WJ-0I9"/>
                                     <constraint firstAttribute="trailing" secondItem="j0t-Wa-UTL" secondAttribute="trailing" id="qc4-hF-DW3"/>
@@ -351,6 +387,7 @@
                         <outlet property="articleTextSizePopup" destination="Z6O-Zt-V1g" id="aTS-pU-7Vg"/>
                         <outlet property="articleThemePopup" destination="ISO-Wu-R60" id="oI3-6W-dPa"/>
                         <outlet property="defaultBrowserPopup" destination="Ci4-fW-KjU" id="7Nh-nU-Sbc"/>
+                        <outlet property="cacheImagesSizeLabel" destination="Cmh-g0-cah" id="Cmn-g0-can"/>
                     </connections>
                 </viewController>
                 <customObject id="bSQ-tq-wd3" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/Mac/Preferences/General/GeneralPrefencesViewController.swift
+++ b/Mac/Preferences/General/GeneralPrefencesViewController.swift
@@ -7,8 +7,10 @@
 //
 
 import AppKit
+import Account
 import RSCore
 import RSWeb
+import Images
 import UserNotifications
 import UniformTypeIdentifiers
 
@@ -17,6 +19,7 @@ final class GeneralPreferencesViewController: NSViewController {
 	@IBOutlet var articleTextSizePopup: NSPopUpButton!
 	@IBOutlet var articleThemePopup: NSPopUpButton!
 	@IBOutlet var defaultBrowserPopup: NSPopUpButton!
+	@IBOutlet var cacheImagesSizeLabel: NSTextField!
 
 	public override init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?) {
 		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -70,6 +73,20 @@ final class GeneralPreferencesViewController: NSViewController {
 		updateBrowserPopup()
 	}
 
+	/// The checkbox is bound to the default; this action (also wired to it) updates the
+	/// cache-size line and, when the setting is switched on, offers to cache existing
+	/// articles' images right away.
+	@IBAction func cacheImagesForOfflineChanged(_ sender: Any) {
+		updateOfflineImagesUI()
+		if AppDefaults.shared.cacheImagesForOffline {
+			promptToCacheAllImages()
+		}
+	}
+
+	@objc func cacheAllImagesProgressDidChange(_ note: Notification) {
+		updateOfflineImagesUI()
+	}
+
 }
 
 // MARK: - Private
@@ -110,11 +127,67 @@ private extension GeneralPreferencesViewController {
 	func commonInit() {
 		NotificationCenter.default.addObserver(self, selector: #selector(applicationWillBecomeActive(_:)), name: NSApplication.willBecomeActiveNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(articleThemeNamesDidChangeNotification(_:)), name: .ArticleThemeNamesDidChangeNotification, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(cacheAllImagesProgressDidChange(_:)), name: .ArticleImageCacheAllProgressDidChange, object: nil)
 	}
 
 	func updateUI() {
 		updateArticleThemePopup()
 		updateBrowserPopup()
+		updateOfflineImagesUI()
+	}
+
+	/// Show live progress during a "cache all" run, otherwise the current on-disk cache size,
+	/// in the line beneath the checkbox. The size is only recomputed when a run isn't in
+	/// progress, to avoid enumerating the cache folder on every progress tick.
+	func updateOfflineImagesUI() {
+		let prefetcher = ArticleImagePrefetcher.shared
+		guard prefetcher.isCachingAll else {
+			refreshCacheImagesSize()
+			return
+		}
+		if prefetcher.cacheAllTotal > 0 {
+			let format = NSLocalizedString("Caching Images… %d of %d", comment: "Cache-all progress")
+			cacheImagesSizeLabel.stringValue = String(format: format, prefetcher.cacheAllCompleted, prefetcher.cacheAllTotal)
+		} else {
+			cacheImagesSizeLabel.stringValue = NSLocalizedString("Caching Images…", comment: "Cache-all starting")
+		}
+	}
+
+	/// When offline caching is switched on, offer to backfill images for existing unread
+	/// articles now — prefetch otherwise only catches images from future refreshes, and the
+	/// moment someone enables this is usually right before they go offline.
+	func promptToCacheAllImages() {
+		guard !ArticleImagePrefetcher.shared.isCachingAll else {
+			return
+		}
+		let unreadCount = AccountManager.shared.unreadCount
+		guard unreadCount > 0 else {
+			return
+		}
+		let alert = NSAlert()
+		alert.alertStyle = .informational
+		alert.messageText = NSLocalizedString("Cache Images Now?", comment: "Cache images now alert title")
+		let format = NSLocalizedString("Download images for your %d unread articles now, so they can be read offline?", comment: "Cache images now alert message")
+		alert.informativeText = String(format: format, unreadCount)
+		alert.addButton(withTitle: NSLocalizedString("Cache Images", comment: "Cache Images now button"))
+		alert.addButton(withTitle: NSLocalizedString("Not Now", comment: "Not Now"))
+		if alert.runModal() == .alertFirstButtonReturn {
+			ArticleImagePrefetcher.shared.cacheAllArticleImagesNow()
+			updateOfflineImagesUI()
+		}
+	}
+
+	func refreshCacheImagesSize() {
+		Task { @MainActor in
+			let stats = await ArticleImageDownloader.shared.cacheStats()
+			if stats.byteCount > 0 {
+				let size = stats.byteCount.formatted(.byteCount(style: .file))
+				let format = NSLocalizedString("%d images · %@ used", comment: "Cached image count and size")
+				cacheImagesSizeLabel.stringValue = String(format: format, stats.fileCount, size)
+			} else {
+				cacheImagesSizeLabel.stringValue = ""
+			}
+		}
 	}
 
 	func updateArticleThemePopup() {

--- a/Mac/Preferences/PreferencesWindowController.swift
+++ b/Mac/Preferences/PreferencesWindowController.swift
@@ -167,7 +167,9 @@ private extension PreferencesWindowController {
 		let windowFrame = window!.frame
 		let contentViewFrame = window!.contentView!.frame
 
-		let deltaHeight = contentViewFrame.height - viewFrame.height
+		let heightForView = fittingHeight(of: view)
+
+		let deltaHeight = contentViewFrame.height - heightForView
 		let heightForWindow = windowFrame.height - deltaHeight
 		let windowOriginY = windowFrame.minY + deltaHeight
 
@@ -179,6 +181,7 @@ private extension PreferencesWindowController {
 		var updatedViewFrame = viewFrame
 		updatedViewFrame.origin = NSPoint.zero
 		updatedViewFrame.size.width = windowWidth
+		updatedViewFrame.size.height = heightForView
 		if viewFrame != updatedViewFrame {
 			view.frame = updatedViewFrame
 		}
@@ -188,5 +191,26 @@ private extension PreferencesWindowController {
 			window!.setFrame(updatedWindowFrame, display: true, animate: true)
 			window!.contentView?.alphaValue = 1.0
 		}
+	}
+
+	/// Measure the pane's natural Auto Layout height at the fixed window width. This is
+	/// called before the view is added to the window (see `switchToView`), so the view's
+	/// height is free and `fittingSize` reflects its content — letting the window grow to
+	/// fit taller panes instead of squishing/clipping their contents. Falls back to the
+	/// storyboard frame height if the measurement looks implausible.
+	func fittingHeight(of view: NSView) -> CGFloat {
+		let hadTranslates = view.translatesAutoresizingMaskIntoConstraints
+		view.translatesAutoresizingMaskIntoConstraints = false
+		let widthConstraint = view.widthAnchor.constraint(equalToConstant: windowWidth)
+		widthConstraint.isActive = true
+		view.layoutSubtreeIfNeeded()
+		let measured = view.fittingSize.height
+		widthConstraint.isActive = false
+		view.translatesAutoresizingMaskIntoConstraints = hadTranslates
+
+		guard measured > 0, measured < 2000 else {
+			return view.frame.height
+		}
+		return measured
 	}
 }

--- a/Modules/Images/Sources/Images/ArticleImageDownloader.swift
+++ b/Modules/Images/Sources/Images/ArticleImageDownloader.swift
@@ -1,0 +1,365 @@
+//
+//  ArticleImageDownloader.swift
+//  Images
+//
+//  Caches images embedded in article HTML so articles can be viewed offline.
+//
+//  Unlike ImageDownloader (which downscales to icon size), this keeps the
+//  original image bytes, since these are displayed full-size in the article view.
+//
+
+import Foundation
+import os
+import RSCore
+import RSWeb
+
+@MainActor public final class ArticleImageDownloader {
+
+	public static let shared = ArticleImageDownloader()
+
+	nonisolated static private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "ArticleImageDownloader")
+
+	nonisolated private let diskCache: BinaryDiskCache
+	nonisolated private let queue: DispatchQueue
+
+	/// On-disk footprint of the article-image cache.
+	public struct CacheStats: Sendable {
+		public let fileCount: Int
+		public let byteCount: Int64
+	}
+
+	// Full-size article images are large, so the in-memory cache is bounded by total byte
+	// cost (NSCache auto-evicts under memory pressure on both platforms — unlike a plain
+	// dictionary, which only the notifications below would ever clear).
+	private let imageCache: NSCache<NSString, NSData> = {
+		let cache = NSCache<NSString, NSData>()
+		cache.totalCostLimit = 50_000_000 // ~50 MB
+		return cache
+	}()
+	private var inFlight = [String: Task<Data?, Never>]() // coalesces concurrent downloads of the same url
+
+	// Prefetch is fire-and-forget over a whole refresh's worth of images, so cap how many
+	// download at once instead of enqueueing an unbounded burst of background fetches.
+	private static let maxConcurrentPrefetches = 4
+	private var activePrefetchCount = 0
+	private var pendingPrefetchURLs = [String]()
+	private var queuedPrefetchURLs = Set<String>() // dedupes the pending queue
+
+	/// Re-checked before draining the prefetch queue so that turning the offline-caching
+	/// setting off mid-refresh stops queued downloads. Injected by the app layer, which owns
+	/// the setting (this module can't see AppDefaults). Defaults to always-enabled.
+	public var isPrefetchingEnabled: @MainActor () -> Bool = { true }
+
+	// Article images come from arbitrary feed-supplied URLs, so bound what we're willing to
+	// write to disk: skip implausibly large responses and anything that isn't actually an image.
+	private static let maxImageByteCount = 20_000_000 // 20 MB
+
+	// Total on-disk cap for the offline image cache. Since the ArticleImages folder is kept out
+	// of the routine cache flush while offline caching is on, it needs its own bound; oldest
+	// images are evicted once the total exceeds this.
+	nonisolated private static let maxDiskCacheByteCount: Int64 = 500_000_000 // 500 MB
+	// Run eviction once per this many bytes written rather than on every file, so the coalesced
+	// check covers all write paths (render-time and prefetch) without enumerating on each save.
+	nonisolated private static let evictionCheckByteInterval: Int64 = 50_000_000 // 50 MB
+	// Only ever mutated on `queue` (serial), so unsynchronized access is safe.
+	nonisolated(unsafe) private var bytesWrittenSinceEviction: Int64 = 0
+
+	init() {
+		let folder = AppConfig.cacheSubfolder(named: "ArticleImages")
+		self.diskCache = BinaryDiskCache(folder: folder.path)
+		self.queue = DispatchQueue(label: "ArticleImageDownloader serial queue - \(folder.path)")
+
+		NotificationCenter.default.addObserver(self, selector: #selector(handleAppDidGoToBackground(_:)), name: .appDidGoToBackground, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(handleLowMemory(_:)), name: .lowMemory, object: nil)
+
+		enforceDiskCacheLimit() // reclaim anything over the cap left by a previous session
+	}
+
+	@objc func handleAppDidGoToBackground(_ notification: Notification) {
+		imageCache.removeAllObjects()
+	}
+
+	@objc func handleLowMemory(_ notification: Notification) {
+		imageCache.removeAllObjects()
+	}
+
+	/// Ensure the image at `url` is cached on disk. Fire-and-forget; used at article-download time.
+	/// Downloads are throttled to `maxConcurrentPrefetches` at a time.
+	public func prefetch(_ url: String) {
+		guard isHTTP(url), cachedData(url) == nil, !queuedPrefetchURLs.contains(url) else {
+			return
+		}
+		queuedPrefetchURLs.insert(url)
+		pendingPrefetchURLs.append(url)
+		startPendingPrefetchesIfPossible()
+	}
+
+	/// Total on-disk footprint of the article-image cache (file count and bytes).
+	/// Enumerates the cache folder off the main thread on the disk queue.
+	nonisolated public func cacheStats() async -> CacheStats {
+		await withCheckedContinuation { continuation in
+			queue.async {
+				continuation.resume(returning: Self.computeCacheStats(folderPath: self.diskCache.folder))
+			}
+		}
+	}
+
+	/// Evict the oldest cached images (by file date) until the on-disk cache is back under its
+	/// size cap. Runs on the disk queue. Call after a batch of caching (prefetch drain / cache-all).
+	nonisolated public func enforceDiskCacheLimit() {
+		queue.async {
+			Self.evictIfOverLimit(folderPath: self.diskCache.folder, maxBytes: Self.maxDiskCacheByteCount)
+		}
+	}
+
+	/// Return image bytes from memory, then disk, then (if allowed) the network.
+	/// Returns nil if the image isn't cached and can't be fetched.
+	public func data(for url: String, allowNetwork: Bool) async -> Data? {
+		guard isHTTP(url) else {
+			return nil
+		}
+		if let data = cachedData(url) {
+			return data
+		}
+		if let data = await readFromDisk(url) {
+			setCachedData(data, url)
+			return data
+		}
+		guard allowNetwork else {
+			return nil
+		}
+		return await download(url)
+	}
+}
+
+private extension ArticleImageDownloader {
+
+	func isHTTP(_ url: String) -> Bool {
+		let lowercased = url.lowercased()
+		return lowercased.hasPrefix("http://") || lowercased.hasPrefix("https://")
+	}
+
+	/// Start pending prefetch downloads up to the concurrency limit, freeing a slot (and
+	/// pulling the next URL) as each finishes.
+	func startPendingPrefetchesIfPossible() {
+		guard isPrefetchingEnabled() else {
+			pendingPrefetchURLs.removeAll()
+			queuedPrefetchURLs.removeAll()
+			return
+		}
+		while activePrefetchCount < Self.maxConcurrentPrefetches, !pendingPrefetchURLs.isEmpty {
+			let url = pendingPrefetchURLs.removeFirst()
+			queuedPrefetchURLs.remove(url)
+			activePrefetchCount += 1
+			Task { @MainActor in
+				// Re-check in case the setting was turned off after this slot was dequeued but
+				// before it started (in-flight downloads already past this point still finish).
+				if isPrefetchingEnabled(), await readFromDisk(url) == nil {
+					_ = await download(url)
+				}
+				activePrefetchCount -= 1
+				if activePrefetchCount == 0, pendingPrefetchURLs.isEmpty {
+					enforceDiskCacheLimit() // keep the cache under its cap once a burst finishes
+				}
+				startPendingPrefetchesIfPossible()
+			}
+		}
+	}
+
+	/// Download, save to disk, cache in memory, and return the bytes. Returns nil on failure.
+	/// Concurrent calls for the same url share a single download (so a background prefetch
+	/// and a foreground display request don't race or duplicate work).
+	func download(_ url: String) async -> Data? {
+		if let existing = inFlight[url] {
+			return await existing.value
+		}
+		if ImageMetadataDatabase.shared.recentlyFailed(url: url) {
+			Self.logger.debug("Skipping recently-failed URL: \(url)")
+			return nil
+		}
+		let task = Task { @MainActor in
+			await performDownload(url)
+		}
+		inFlight[url] = task
+		let result = await task.value
+		inFlight[url] = nil
+		return result
+	}
+
+	func performDownload(_ url: String) async -> Data? {
+		guard let imageURL = URL(string: url) else {
+			ImageMetadataDatabase.shared.recordFailure(url: url, statusCode: nil)
+			return nil
+		}
+
+		let downloadResponse: DownloadResponse
+		do {
+			downloadResponse = try await Downloader.shared.download(imageURL)
+		} catch {
+			Self.logger.error("Error downloading article image at \(url): \(error.localizedDescription)")
+			return nil // transient — don't record a failure
+		}
+		let data = downloadResponse.data
+		let response = downloadResponse.response
+
+		if let response, response.statusIsOK {
+			// Only cache a plausible image response. An empty body (a transient CDN hiccup), an
+			// oversized body, or a non-image body is treated as transient: return nil without
+			// blacklisting, so a later view can retry. Don't permanently fail on OK statuses.
+			guard let data, !data.isEmpty, data.count <= Self.maxImageByteCount, isProbablyImage(data, response: response) else {
+				return nil
+			}
+			saveToDisk(url, data)
+			setCachedData(data, url)
+			ImageMetadataDatabase.shared.clearFailure(url: url)
+			return data
+		}
+
+		let statusCode = (response as? HTTPURLResponse)?.statusCode
+		let isTransient = statusCode.map { (500...599).contains($0) } ?? true
+		if !isTransient {
+			ImageMetadataDatabase.shared.recordFailure(url: url, statusCode: statusCode)
+		}
+		return nil
+	}
+
+	/// Whether a response looks like an image worth caching: an image/* Content-Type, or
+	/// failing that, recognizable image magic bytes. Keeps non-image bodies (error pages,
+	/// redirects to HTML, etc.) fetched from feed-supplied URLs out of the disk cache.
+	func isProbablyImage(_ data: Data, response: URLResponse) -> Bool {
+		if let mimeType = response.mimeType?.lowercased(), mimeType.hasPrefix("image/") {
+			return true
+		}
+		return Self.hasImageMagicBytes(data)
+	}
+
+	nonisolated static func hasImageMagicBytes(_ data: Data) -> Bool {
+		let bytes = [UInt8](data.prefix(12))
+		guard bytes.count >= 3 else {
+			return false
+		}
+		if bytes[0] == 0xFF, bytes[1] == 0xD8, bytes[2] == 0xFF {
+			return true // JPEG
+		}
+		if bytes.count >= 8, bytes[0] == 0x89, bytes[1] == 0x50, bytes[2] == 0x4E, bytes[3] == 0x47 {
+			return true // PNG
+		}
+		if bytes[0] == 0x47, bytes[1] == 0x49, bytes[2] == 0x46 {
+			return true // GIF
+		}
+		if bytes[0] == 0x42, bytes[1] == 0x4D {
+			return true // BMP
+		}
+		if bytes[0] == 0x49, bytes[1] == 0x49, bytes[2] == 0x2A {
+			return true // TIFF (little-endian)
+		}
+		if bytes[0] == 0x4D, bytes[1] == 0x4D, bytes[2] == 0x00 {
+			return true // TIFF (big-endian)
+		}
+		if bytes.count >= 12, bytes[0] == 0x52, bytes[1] == 0x49, bytes[2] == 0x46, bytes[3] == 0x46,
+			bytes[8] == 0x57, bytes[9] == 0x45, bytes[10] == 0x42, bytes[11] == 0x50 {
+			return true // WebP (RIFF....WEBP)
+		}
+		if bytes.count >= 12, bytes[4] == 0x66, bytes[5] == 0x74, bytes[6] == 0x79, bytes[7] == 0x70 {
+			let brand = String(bytes: bytes[8..<12], encoding: .ascii) ?? ""
+			// ISO base media (ftyp) — accept only image brands, not video (mp4 etc.)
+			if brand.hasPrefix("avif") || brand.hasPrefix("avis") || brand.hasPrefix("heic") || brand.hasPrefix("heix") || brand.hasPrefix("mif1") || brand.hasPrefix("msf1") {
+				return true // AVIF / HEIC
+			}
+		}
+		if bytes.count >= 4, bytes[0] == 0x00, bytes[1] == 0x00, bytes[2] == 0x01, bytes[3] == 0x00 {
+			return true // ICO
+		}
+		return false
+	}
+
+	func cachedData(_ url: String) -> Data? {
+		imageCache.object(forKey: url as NSString) as Data?
+	}
+
+	func setCachedData(_ data: Data, _ url: String) {
+		imageCache.setObject(data as NSData, forKey: url as NSString, cost: data.count)
+	}
+
+	func saveToDisk(_ url: String, _ data: Data) {
+		queue.async {
+			self.diskCache[self.diskKey(url)] = data
+			// Every cached image — prefetch or render-time (the scheme handler's data(for:) path) —
+			// is written here, so enforce the size cap from the write path too, coalesced to once
+			// per evictionCheckByteInterval to avoid enumerating the folder on every save.
+			self.bytesWrittenSinceEviction += Int64(data.count)
+			if self.bytesWrittenSinceEviction >= Self.evictionCheckByteInterval {
+				self.bytesWrittenSinceEviction = 0
+				Self.evictIfOverLimit(folderPath: self.diskCache.folder, maxBytes: Self.maxDiskCacheByteCount)
+			}
+		}
+	}
+
+	func readFromDisk(_ url: String) async -> Data? {
+		await withCheckedContinuation { continuation in
+			queue.async {
+				let data = self.diskCache[self.diskKey(url)]
+				DispatchQueue.main.async {
+					continuation.resume(returning: (data?.isEmpty == false) ? data : nil)
+				}
+			}
+		}
+	}
+
+	nonisolated func diskKey(_ url: String) -> String {
+		url.md5String
+	}
+
+	nonisolated static func evictIfOverLimit(folderPath: String, maxBytes: Int64) {
+		let folderURL = URL(fileURLWithPath: folderPath)
+		let keys: [URLResourceKey] = [.isRegularFileKey, .fileSizeKey, .contentModificationDateKey]
+		let fileManager = FileManager.default
+		guard let enumerator = fileManager.enumerator(at: folderURL, includingPropertiesForKeys: keys, options: [.skipsHiddenFiles]) else {
+			return
+		}
+		var files = [(url: URL, size: Int64, date: Date)]()
+		var total: Int64 = 0
+		for case let fileURL as URL in enumerator {
+			guard let values = try? fileURL.resourceValues(forKeys: Set(keys)), values.isRegularFile == true else {
+				continue
+			}
+			let size = Int64(values.fileSize ?? 0)
+			files.append((fileURL, size, values.contentModificationDate ?? .distantPast))
+			total += size
+		}
+		guard total > maxBytes else {
+			return
+		}
+		// Evict oldest-cached first until back under the cap.
+		files.sort { $0.date < $1.date }
+		for file in files {
+			if total <= maxBytes {
+				break
+			}
+			do {
+				try fileManager.removeItem(at: file.url)
+				total -= file.size
+			} catch {
+				logger.error("ArticleImageDownloader: could not evict \(file.url.lastPathComponent): \(error.localizedDescription)")
+			}
+		}
+	}
+
+	nonisolated static func computeCacheStats(folderPath: String) -> CacheStats {
+		let folderURL = URL(fileURLWithPath: folderPath)
+		let keys: [URLResourceKey] = [.isRegularFileKey, .fileSizeKey]
+		guard let enumerator = FileManager.default.enumerator(at: folderURL, includingPropertiesForKeys: keys, options: [.skipsHiddenFiles]) else {
+			return CacheStats(fileCount: 0, byteCount: 0)
+		}
+		var fileCount = 0
+		var byteCount: Int64 = 0
+		for case let fileURL as URL in enumerator {
+			guard let values = try? fileURL.resourceValues(forKeys: Set(keys)), values.isRegularFile == true else {
+				continue
+			}
+			fileCount += 1
+			byteCount += Int64(values.fileSize ?? 0)
+		}
+		return CacheStats(fileCount: fileCount, byteCount: byteCount)
+	}
+}

--- a/Modules/RSWeb/Sources/RSWeb/Downloader.swift
+++ b/Modules/RSWeb/Sources/RSWeb/Downloader.swift
@@ -20,6 +20,16 @@ public typealias DownloadCallback = @MainActor (DownloadResponse, Error?) -> Swi
 	private let urlSession: URLSession
 	private var callbacks = [URL: [(callback: DownloadCallback, fromCache: Bool)]]()
 	private let cache = DownloadCache.shared
+	private let redirectBlocker = RedirectBlocker()
+
+	/// Optional policy consulted before following an HTTP redirect: return `false` for a
+	/// destination URL that should not be followed (e.g. a tracker/ad domain), and the redirect
+	/// is not followed — the request completes with the redirect response instead. `nil` (the
+	/// default) follows all redirects. Applies to every download this shared instance performs.
+	public var redirectValidator: (@Sendable (URL) -> Bool)? {
+		get { redirectBlocker.validator }
+		set { redirectBlocker.validator = newValue }
+	}
 
 	nonisolated private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "Downloader")
 
@@ -35,7 +45,7 @@ public typealias DownloadCallback = @MainActor (DownloadResponse, Error?) -> Swi
 			sessionConfiguration.httpAdditionalHeaders = userAgentHeaders
 		}
 
-		urlSession = URLSession(configuration: sessionConfiguration)
+		urlSession = URLSession(configuration: sessionConfiguration, delegate: redirectBlocker, delegateQueue: nil)
 	}
 
 	deinit {
@@ -112,6 +122,37 @@ public typealias DownloadCallback = @MainActor (DownloadResponse, Error?) -> Swi
 			}
 		}
 		task.resume()
+	}
+}
+
+/// URLSession delegate that can veto redirects via an injected policy. Thread-safe: the session
+/// calls its delegate on a background queue, while the policy is set from the main actor.
+private final class RedirectBlocker: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+
+	private let lock = NSLock()
+	private var _validator: (@Sendable (URL) -> Bool)?
+
+	var validator: (@Sendable (URL) -> Bool)? {
+		get {
+			lock.lock()
+			defer { lock.unlock() }
+			return _validator
+		}
+		set {
+			lock.lock()
+			defer { lock.unlock() }
+			_validator = newValue
+		}
+	}
+
+	func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+		if let url = request.url, let validator = validator, !validator(url) {
+			// Don't follow the redirect: the task completes with the redirect response, so nothing
+			// is fetched from (or cached for) the disallowed destination.
+			completionHandler(nil)
+			return
+		}
+		completionHandler(request)
 	}
 }
 

--- a/Shared/Article Rendering/ArticleImageContentBlocker.swift
+++ b/Shared/Article Rendering/ArticleImageContentBlocker.swift
@@ -1,0 +1,84 @@
+//
+//  ArticleImageContentBlocker.swift
+//  NetNewsWire
+//
+//  Applies the same block list the article web view uses (ContentRules.json) to
+//  app-side image fetches. Routing article images through the offline cache uses
+//  URLSession, which doesn't consult WebKit's WKContentRuleList — so without this,
+//  a tracker/ad image WebKit would block could still be fetched (and prefetched)
+//  when offline caching is on. This closes that gap by reusing the same rules.
+//
+
+import Foundation
+import os
+
+@MainActor final class ArticleImageContentBlocker {
+
+	static let shared = ArticleImageContentBlocker()
+
+	private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "ArticleImageContentBlocker")
+
+	// nonisolated + immutable so it can be matched from any thread (e.g. the Downloader's
+	// redirect delegate, which runs off the main actor). NSRegularExpression is Sendable and
+	// thread-safe for matching.
+	nonisolated private let blockRegex: NSRegularExpression?
+
+	init() {
+		blockRegex = Self.compileBlockRegex()
+	}
+
+	/// True if `urlString` matches one of the web view's content-blocking rules
+	/// (ad/tracker domains), and so should not be fetched or cached.
+	nonisolated func isBlocked(_ urlString: String) -> Bool {
+		guard let blockRegex else {
+			return false
+		}
+		let range = NSRange(urlString.startIndex..., in: urlString)
+		return blockRegex.firstMatch(in: urlString, range: range) != nil
+	}
+}
+
+private extension ArticleImageContentBlocker {
+
+	/// Load ContentRules.json and combine every `block` rule's `url-filter` into one
+	/// alternation regex, so a single match tells us whether a URL is blocked.
+	static func compileBlockRegex() -> NSRegularExpression? {
+		guard let url = Bundle.main.url(forResource: "ContentRules", withExtension: "json") else {
+			logger.warning("ArticleImageContentBlocker: ContentRules.json not found")
+			return nil
+		}
+		do {
+			let data = try Data(contentsOf: url)
+			let rules = try JSONDecoder().decode([ContentRule].self, from: data)
+			let patterns = rules.compactMap { rule -> String? in
+				guard rule.action.type == "block", let filter = rule.trigger.urlFilter, !filter.isEmpty else {
+					return nil
+				}
+				return "(?:\(filter))"
+			}
+			guard !patterns.isEmpty else {
+				return nil
+			}
+			return try NSRegularExpression(pattern: patterns.joined(separator: "|"), options: [.caseInsensitive])
+		} catch {
+			logger.error("ArticleImageContentBlocker: failed to load rules: \(error.localizedDescription)")
+			return nil
+		}
+	}
+
+	struct ContentRule: Decodable {
+		let trigger: Trigger
+		let action: Action
+
+		struct Trigger: Decodable {
+			let urlFilter: String?
+			enum CodingKeys: String, CodingKey {
+				case urlFilter = "url-filter"
+			}
+		}
+
+		struct Action: Decodable {
+			let type: String
+		}
+	}
+}

--- a/Shared/Article Rendering/ArticleImageSchemeHandler.swift
+++ b/Shared/Article Rendering/ArticleImageSchemeHandler.swift
@@ -1,0 +1,141 @@
+//
+//  ArticleImageSchemeHandler.swift
+//  NetNewsWire
+//
+//  Serves article-body images to the web view from the offline cache.
+//
+//  main.js rewrites each <img src> to nnwimage://cache/?u=<encoded-original-url>
+//  (only when offline caching is enabled). This handler decodes the original URL,
+//  serves the bytes from ArticleImageDownloader (memory → disk → network), and
+//  returns them to WebKit. When offline and uncached, the request fails and the
+//  web view shows a broken image — the rest of the article still renders.
+//
+
+import Foundation
+import WebKit
+import Images
+
+@MainActor final class ArticleImageSchemeHandler: NSObject, WKURLSchemeHandler {
+
+	static let scheme = "nnwimage"
+	static let shared = ArticleImageSchemeHandler()
+
+	/// Tasks currently in flight. A task is "ours to complete" only while its ID is in this set.
+	/// We must never call back into a task WebKit has stopped (it throws an Objective-C exception).
+	/// Membership is positive (insert on start, remove on stop or completion), so a stale entry
+	/// can't survive to collide with a later task that reuses the same object address.
+	private var activeTasks = Set<ObjectIdentifier>()
+
+	func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+
+		let taskID = ObjectIdentifier(urlSchemeTask)
+
+		// The handler is registered unconditionally (see WebViewConfiguration), but only
+		// main.js's rewrite and the prefetcher are gated on the setting — this scheme is
+		// otherwise reachable directly from article HTML (e.g. a feed embedding
+		// "nnwimage://cache/?u=..." itself). Refuse to fetch or cache anything unless the
+		// user has actually opted in, so the setting's off-state is a real guarantee.
+		guard AppDefaults.shared.cacheImagesForOffline else {
+			urlSchemeTask.didFailWithError(URLError(.resourceUnavailable))
+			return
+		}
+
+		guard let requestURL = urlSchemeTask.request.url,
+			  let originalURL = Self.originalURLString(from: requestURL) else {
+			urlSchemeTask.didFailWithError(URLError(.badURL))
+			return
+		}
+
+		// The web view's own content blocker doesn't apply to this URLSession-backed fetch,
+		// so apply the same block list here — otherwise routing images through the cache would
+		// bypass tracker/ad blocking.
+		guard !ArticleImageContentBlocker.shared.isBlocked(originalURL) else {
+			urlSchemeTask.didFailWithError(URLError(.resourceUnavailable))
+			return
+		}
+
+		activeTasks.insert(taskID)
+
+		Task { @MainActor in
+			let data = await ArticleImageDownloader.shared.data(for: originalURL, allowNetwork: true)
+
+			// If the task was stopped while we were fetching, it's no longer in activeTasks.
+			// Calling into a stopped task throws an Objective-C exception, so bail out cleanly.
+			guard activeTasks.remove(taskID) != nil else {
+				return
+			}
+
+			guard let data else {
+				urlSchemeTask.didFailWithError(URLError(.resourceUnavailable))
+				return
+			}
+
+			let mimeType = Self.mimeType(for: data)
+			let response = URLResponse(url: requestURL, mimeType: mimeType, expectedContentLength: data.count, textEncodingName: nil)
+			urlSchemeTask.didReceive(response)
+			urlSchemeTask.didReceive(data)
+			urlSchemeTask.didFinish()
+		}
+	}
+
+	func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
+		activeTasks.remove(ObjectIdentifier(urlSchemeTask))
+	}
+}
+
+private extension ArticleImageSchemeHandler {
+
+	/// Pull the percent-encoded original URL out of nnwimage://cache/?u=<encoded>.
+	static func originalURLString(from url: URL) -> String? {
+		guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+			  components.host == "cache", // only nnwimage://cache/?u=... is a cache request
+			  let value = components.queryItems?.first(where: { $0.name == "u" })?.value,
+			  !value.isEmpty else {
+			return nil
+		}
+		return value
+	}
+
+	/// Sniff the image type from the leading bytes so WebKit gets a correct Content-Type.
+	/// A wrong type can keep an otherwise-valid cached image from rendering offline.
+	static func mimeType(for data: Data) -> String {
+		let bytes = [UInt8](data.prefix(12))
+		guard let first = bytes.first else {
+			return "application/octet-stream"
+		}
+
+		// ISO base media (ftyp) container — AVIF and HEIC share it; distinguish by brand.
+		if bytes.count >= 12, bytes[4] == 0x66, bytes[5] == 0x74, bytes[6] == 0x79, bytes[7] == 0x70 {
+			let brand = String(bytes: bytes[8..<12], encoding: .ascii) ?? ""
+			if brand.hasPrefix("avif") || brand.hasPrefix("avis") {
+				return "image/avif"
+			}
+			if brand.hasPrefix("heic") || brand.hasPrefix("heix") || brand.hasPrefix("mif1") || brand.hasPrefix("msf1") {
+				return "image/heic"
+			}
+		}
+		// ICO
+		if bytes.count >= 4, bytes[0] == 0x00, bytes[1] == 0x00, bytes[2] == 0x01, bytes[3] == 0x00 {
+			return "image/x-icon"
+		}
+
+		switch first {
+		case 0xFF:
+			return "image/jpeg"
+		case 0x89:
+			return "image/png"
+		case 0x47:
+			return "image/gif"
+		case 0x42:
+			return "image/bmp"
+		case 0x49, 0x4D:
+			return "image/tiff"
+		case 0x52: // "RIFF" → WebP
+			return "image/webp"
+		case 0x3C: // "<" → SVG/XML
+			return "image/svg+xml"
+		default:
+			return "application/octet-stream"
+		}
+	}
+}

--- a/Shared/Article Rendering/ArticleRenderer.swift
+++ b/Shared/Article Rendering/ArticleRenderer.swift
@@ -219,7 +219,16 @@ private extension ArticleRenderer {
 			d["external_link"] = ""
 		}
 
-		d["body"] = body
+		if AppDefaults.shared.cacheImagesForOffline {
+			// Tell main.js to route article images through the offline cache (see
+			// rewriteImagesForOfflineCache). This is a hidden marker element rather than an inline
+			// <script> so it works even when the reader has article JavaScript turned off: that
+			// setting gates *content* JavaScript, but main.js runs as an injected user script and
+			// reads the marker from the DOM.
+			d["body"] = "<div id=\"nnwCacheImagesForOffline\" hidden></div>" + body
+		} else {
+			d["body"] = body
+		}
 
 		#if os(macOS)
 		d["text_size_class"] = AppDefaults.shared.articleTextSize.cssClass

--- a/Shared/Article Rendering/WebViewConfiguration.swift
+++ b/Shared/Article Rendering/WebViewConfiguration.swift
@@ -26,6 +26,7 @@ import WebKit
 		configuration.defaultWebpagePreferences = webpagePreferences
 		configuration.mediaTypesRequiringUserActionForPlayback = .all
 		configuration.setURLSchemeHandler(urlSchemeHandler, forURLScheme: ArticleRenderer.imageIconScheme)
+		configuration.setURLSchemeHandler(ArticleImageSchemeHandler.shared, forURLScheme: ArticleImageSchemeHandler.scheme)
 		configuration.userContentController = userContentController
 
 		// Present article content as NetNewsWire on top of WebKit's default browser UA, rather than a non-browser string.

--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -52,6 +52,32 @@ function convertImgSrc() {
 	});
 }
 
+// When offline image caching is enabled, route http(s) article images through the
+// offline cache via a custom scheme. Run after convertImgSrc() so srcs are absolute.
+function rewriteImagesForOfflineCache() {
+	if (!document.getElementById("nnwCacheImagesForOffline")) {
+		return;
+	}
+	document.querySelectorAll("img").forEach(element => {
+		var src = element.src;
+		if (/^https?:\/\//i.test(src)) {
+			element.src = "nnwimage://cache/?u=" + encodeURIComponent(src);
+			// Drop this img's srcset so WebKit uses the rewritten (cached) src rather than
+			// selecting an original https candidate that would bypass the cache offline. We only
+			// do this when src itself is an http(s) URL we just rewrote — clearing srcset on an
+			// img with a non-http (e.g. data-URI) src could leave it with no loadable image.
+			element.removeAttribute("srcset");
+			// If this img is the fallback inside a <picture>, drop the <source> candidates too:
+			// WebKit would otherwise select an original-URL <source> over our rewritten fallback
+			// and bypass the cache offline.
+			var parent = element.parentElement;
+			if (parent && parent.tagName.toLowerCase() === "picture") {
+				parent.querySelectorAll("source").forEach(source => source.remove());
+			}
+		}
+	});
+}
+
 // Wrap tables in an overflow-x: auto; div
 function wrapTables() {
 	var tables = document.querySelectorAll("div.articleBody table");
@@ -163,6 +189,7 @@ function processPage() {
 	stripStyles();
 	constrainBodyRelativeIframes();
 	convertImgSrc();
+	rewriteImagesForOfflineCache();
 	flattenPreElements();
 	styleLocalFootnotes();
 	removeWpSmiley()

--- a/Shared/ArticleImagePrefetcher.swift
+++ b/Shared/ArticleImagePrefetcher.swift
@@ -1,0 +1,278 @@
+//
+//  ArticleImagePrefetcher.swift
+//  NetNewsWire
+//
+//  When offline image caching is enabled, downloads the images embedded in newly
+//  arrived articles so they're available on disk before the article is ever opened.
+//
+//  Observes .AccountDidDownloadArticles (posted after each refresh) rather than
+//  reaching into Account internals. Pairs with ArticleImageSchemeHandler, which
+//  serves the cached bytes to the web view at render time.
+//
+
+import Foundation
+import Account
+import Articles
+import Images
+import RSWeb
+
+extension Notification.Name {
+	/// Posted (object: ArticleImagePrefetcher.shared) when a "cache all images" run
+	/// starts, makes progress, or finishes, so settings UI can update its progress line.
+	static let ArticleImageCacheAllProgressDidChange = Notification.Name("ArticleImageCacheAllProgressDidChange")
+}
+
+@MainActor final class ArticleImagePrefetcher {
+
+	static let shared = ArticleImagePrefetcher()
+
+	/// State of an in-progress "Cache All Images Now" run. `total` is the number of image
+	/// URLs the run will attempt; `completed` counts those finished (including ones already
+	/// cached, which complete immediately).
+	private(set) var isCachingAll = false
+	private(set) var cacheAllCompleted = 0
+	private(set) var cacheAllTotal = 0
+
+	private static let maxConcurrentCacheAll = 4
+
+	/// Call once at app startup to begin observing.
+	func start() {
+		// The downloader lives in the Images module and can't read AppDefaults, so hand it a
+		// check it can consult before draining its prefetch queue — turning the setting off
+		// mid-refresh then stops queued downloads.
+		ArticleImageDownloader.shared.isPrefetchingEnabled = { AppDefaults.shared.cacheImagesForOffline }
+		// Apply the same tracker/ad block list to redirects: URLSession would otherwise follow a
+		// 302 from an allowed URL to a blocked domain, since the block check only sees the initial
+		// URL. (Applies to all Downloader traffic — favicons/feed icons too — which is a net win.)
+		let contentBlocker = ArticleImageContentBlocker.shared
+		Downloader.shared.redirectValidator = { url in
+			!contentBlocker.isBlocked(url.absoluteString)
+		}
+		NotificationCenter.default.addObserver(self, selector: #selector(accountDidDownloadArticles(_:)), name: .AccountDidDownloadArticles, object: nil)
+	}
+
+	@objc func accountDidDownloadArticles(_ note: Notification) {
+		guard AppDefaults.shared.cacheImagesForOffline else {
+			return
+		}
+		guard let articles = note.userInfo?[Account.UserInfoKey.newArticles] as? Set<Article> else {
+			return
+		}
+		prefetch(articles)
+	}
+
+	/// Force-fetch images for every unread article right now, bypassing the usual
+	/// new-articles trigger. Invoked from the confirmation prompt shown when the user
+	/// switches offline caching on. Reports progress via
+	/// `.ArticleImageCacheAllProgressDidChange`; a no-op if a run is already in progress.
+	func cacheAllArticleImagesNow() {
+		guard !isCachingAll else {
+			return
+		}
+		isCachingAll = true
+		cacheAllCompleted = 0
+		cacheAllTotal = 0
+		postCacheAllProgress()
+		Task { @MainActor in
+			await runCacheAll()
+		}
+	}
+
+	private func runCacheAll() async {
+		let articles = await AccountManager.shared.fetchArticlesAsync(.unread(nil))
+		let inputs: [ArticleImageURLExtractor.Input] = articles.compactMap { article in
+			guard let html = article.body, !html.isEmpty else {
+				return nil
+			}
+			return ArticleImageURLExtractor.Input(html: html, baseURLString: Self.baseURLString(for: article))
+		}
+		let extracted = await Task.detached(priority: .utility) {
+			ArticleImageURLExtractor.imageURLStrings(in: inputs)
+		}.value
+		let urlStrings = extracted.filter { !ArticleImageContentBlocker.shared.isBlocked($0) }
+
+		cacheAllTotal = urlStrings.count
+		postCacheAllProgress()
+
+		guard !urlStrings.isEmpty else {
+			finishCacheAll()
+			return
+		}
+
+		// Download in batches so at most maxConcurrentCacheAll are in flight at once, rather than
+		// enqueueing an unbounded burst. data(for:allowNetwork:) caches to disk as a side effect.
+		var start = 0
+		while start < urlStrings.count {
+			// Stop launching new batches if the user turned offline caching off mid-run, so we
+			// don't keep hitting the network and writing to disk after they've opted out. (An
+			// already-launched batch finishes, matching the refresh-prefetch gate's behavior.)
+			guard AppDefaults.shared.cacheImagesForOffline else {
+				break
+			}
+			let end = min(start + Self.maxConcurrentCacheAll, urlStrings.count)
+			var tasks = [Task<Void, Never>]()
+			for index in start..<end {
+				let url = urlStrings[index]
+				tasks.append(Task { @MainActor in
+					_ = await ArticleImageDownloader.shared.data(for: url, allowNetwork: true)
+				})
+			}
+			for task in tasks {
+				await task.value
+				cacheAllCompleted += 1
+				postCacheAllProgress()
+			}
+			start = end
+		}
+
+		finishCacheAll()
+	}
+
+	private func finishCacheAll() {
+		isCachingAll = false
+		ArticleImageDownloader.shared.enforceDiskCacheLimit() // a big run may have pushed past the cap
+		postCacheAllProgress()
+	}
+
+	private func postCacheAllProgress() {
+		NotificationCenter.default.post(name: .ArticleImageCacheAllProgressDidChange, object: self)
+	}
+
+	func prefetch(_ articles: Set<Article>) {
+		// Snapshot the strings we need while on the main thread (cheap property reads),
+		// then parse the HTML off the main thread: a syncing account can deliver a large
+		// batch of new articles in one notification, and running the regexes on the main
+		// thread would hitch the UI. Enqueue the downloads back on the main thread, since
+		// ArticleImageDownloader is main-actor isolated.
+		let inputs: [ArticleImageURLExtractor.Input] = articles.compactMap { article in
+			guard let html = article.body, !html.isEmpty else {
+				return nil
+			}
+			return ArticleImageURLExtractor.Input(html: html, baseURLString: Self.baseURLString(for: article))
+		}
+		guard !inputs.isEmpty else {
+			return
+		}
+
+		Task.detached(priority: .utility) {
+			let urlStrings = ArticleImageURLExtractor.imageURLStrings(in: inputs)
+			guard !urlStrings.isEmpty else {
+				return
+			}
+			await MainActor.run {
+				for urlString in urlStrings where !ArticleImageContentBlocker.shared.isBlocked(urlString) {
+					ArticleImageDownloader.shared.prefetch(urlString)
+				}
+			}
+		}
+	}
+}
+
+private extension ArticleImagePrefetcher {
+
+	static func baseURLString(for article: Article) -> String? {
+		article.link ?? article.feed?.homePageURL ?? article.feed?.url
+	}
+}
+
+/// Pure, nonisolated extraction of absolute http(s) image URLs from article HTML.
+/// Kept separate from ArticleImagePrefetcher so it can run off the main thread and
+/// be unit-tested directly.
+enum ArticleImageURLExtractor {
+
+	struct Input: Sendable {
+		let html: String
+		let baseURLString: String?
+	}
+
+	/// Extract deduplicated absolute http(s) image URLs from a batch of article HTML.
+	static func imageURLStrings(in inputs: [Input]) -> [String] {
+		var results = [String]()
+		var seen = Set<String>()
+		for input in inputs {
+			let baseURL = input.baseURLString.flatMap { URL(string: $0) }
+			for urlString in imageURLStrings(in: input.html, baseURL: baseURL) where seen.insert(urlString).inserted {
+				results.append(urlString)
+			}
+		}
+		return results
+	}
+
+	/// Extract absolute http(s) image URLs from a single article's HTML.
+	/// Prefers data-canonical-src (Feedbin proxy images) over src, mirroring main.js.
+	static func imageURLStrings(in html: String, baseURL: URL?) -> [String] {
+		let nsHTML = html as NSString
+		let imgMatches = imgTagRegex.matches(in: html, range: NSRange(location: 0, length: nsHTML.length))
+
+		var results = [String]()
+		var seen = Set<String>()
+
+		for match in imgMatches {
+			let tag = nsHTML.substring(with: match.range)
+			let raw = firstCapture(in: tag, regex: canonicalSrcRegex) ?? firstCapture(in: tag, regex: srcRegex)
+			guard let raw else {
+				continue
+			}
+			let decoded = decodeHTMLEntities(raw)
+			guard let absolute = absoluteHTTPURLString(decoded, baseURL: baseURL), seen.insert(absolute).inserted else {
+				continue
+			}
+			results.append(absolute)
+		}
+		return results
+	}
+
+	/// Decode the handful of HTML entities that commonly appear in URL attribute values.
+	/// Note: the resulting absolute URL string is what gets md5-keyed on disk. For an offline
+	/// cache HIT it must match the string the scheme handler receives at render time, which is
+	/// the browser's DOM-resolved `element.src`. For plain absolute URLs the two agree; complex
+	/// relative URLs may diverge (Foundation's URL resolution vs. the browser's), in which case
+	/// the prefetch simply misses and the image is fetched (and then cached) on first online view.
+	static func decodeHTMLEntities(_ string: String) -> String {
+		guard string.contains("&") else {
+			return string
+		}
+		var result = string
+		let namedEntities = ["&amp;": "&", "&quot;": "\"", "&#39;": "'", "&#x27;": "'", "&#38;": "&", "&#x26;": "&", "&lt;": "<", "&gt;": ">"]
+		for (entity, replacement) in namedEntities {
+			result = result.replacingOccurrences(of: entity, with: replacement)
+		}
+		return result
+	}
+
+	static func absoluteHTTPURLString(_ src: String, baseURL: URL?) -> String? {
+		let resolved: URL?
+		if src.hasPrefix("//") {
+			let scheme = baseURL?.scheme ?? "https"
+			resolved = URL(string: "\(scheme):\(src)")
+		} else {
+			resolved = URL(string: src, relativeTo: baseURL)?.absoluteURL
+		}
+		guard let resolved, let originalScheme = resolved.scheme, originalScheme.lowercased() == "http" || originalScheme.lowercased() == "https" else {
+			return nil
+		}
+		// Lowercase the scheme so the disk key matches the browser's DOM-resolved element.src
+		// (which the scheme handler receives with a lowercased scheme) — otherwise an
+		// uppercase-scheme URL would prefetch under a different key and miss on view.
+		let lowercasedScheme = originalScheme.lowercased()
+		return lowercasedScheme + resolved.absoluteString.dropFirst(originalScheme.count)
+	}
+
+	static func firstCapture(in string: String, regex: NSRegularExpression) -> String? {
+		let nsString = string as NSString
+		guard let match = regex.firstMatch(in: string, range: NSRange(location: 0, length: nsString.length)), match.numberOfRanges > 1 else {
+			return nil
+		}
+		let captureRange = match.range(at: 1)
+		guard captureRange.location != NSNotFound else {
+			return nil
+		}
+		return nsString.substring(with: captureRange)
+	}
+
+	// NSRegularExpression is Sendable and thread-safe for matching, so these can be shared
+	// across the main thread and the background parse.
+	static let imgTagRegex = try! NSRegularExpression(pattern: "<img\\b[^>]*>", options: [.caseInsensitive])
+	static let srcRegex = try! NSRegularExpression(pattern: "\\bsrc\\s*=\\s*[\"']([^\"']+)[\"']", options: [.caseInsensitive])
+	static let canonicalSrcRegex = try! NSRegularExpression(pattern: "\\bdata-canonical-src\\s*=\\s*[\"']([^\"']+)[\"']", options: [.caseInsensitive])
+}

--- a/Shared/Extensions/CacheCleaner.swift
+++ b/Shared/Extensions/CacheCleaner.swift
@@ -32,11 +32,21 @@ struct CacheCleaner {
 				let tempDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
 				let faviconsFolderURL = tempDir.appendingPathComponent("Favicons")
 				let imagesFolderURL = tempDir.appendingPathComponent("Images")
+				let articleImagesFolderURL = tempDir.appendingPathComponent("ArticleImages")
 				let feedURLToIconURL = tempDir.appendingPathComponent("FeedURLToIconURLCache.plist")
 				let homePageToIconURL = tempDir.appendingPathComponent("HomePageToIconURLCache.plist")
 				let homePagesWithNoIconURL = tempDir.appendingPathComponent("HomePagesWithNoIconURLCache.plist")
 
-				for tempItem in [faviconsFolderURL, imagesFolderURL, feedURLToIconURL, homePageToIconURL, homePagesWithNoIconURL] {
+				var itemsToRemove = [faviconsFolderURL, imagesFolderURL, feedURLToIconURL, homePageToIconURL, homePagesWithNoIconURL]
+				// The ArticleImages cache is user-requested persistent data when offline caching is
+				// on — purging it on the routine flush would silently drop images for already-saved
+				// articles that the refresh-time prefetch won't re-cache. Only reclaim it when the
+				// setting is off.
+				if !AppDefaults.shared.cacheImagesForOffline {
+					itemsToRemove.append(articleImagesFolderURL)
+				}
+
+				for tempItem in itemsToRemove {
 					do {
 						logger.info("Removing cache file: \(tempItem.absoluteString)")
 						try FileManager.default.removeItem(at: tempItem)

--- a/Tests/NetNewsWireTests/ArticleImageURLExtractorTests.swift
+++ b/Tests/NetNewsWireTests/ArticleImageURLExtractorTests.swift
@@ -1,0 +1,94 @@
+//
+//  ArticleImageURLExtractorTests.swift
+//  NetNewsWireTests
+//
+//  Copyright © 2026 Ranchero Software, LLC. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@testable import NetNewsWire
+
+final class ArticleImageURLExtractorTests: XCTestCase {
+
+	private func urls(_ html: String, base: String? = nil) -> [String] {
+		let baseURL = base.flatMap { URL(string: $0) }
+		return ArticleImageURLExtractor.imageURLStrings(in: html, baseURL: baseURL)
+	}
+
+	func testAbsoluteURL() {
+		let result = urls("<p><img src=\"https://example.com/a.jpg\"></p>")
+		XCTAssertEqual(result, ["https://example.com/a.jpg"])
+	}
+
+	func testRelativeURLResolvesAgainstBase() {
+		let result = urls("<img src=\"/images/a.jpg\">", base: "https://example.com/posts/1")
+		XCTAssertEqual(result, ["https://example.com/images/a.jpg"])
+	}
+
+	func testProtocolRelativeURLUsesBaseScheme() {
+		let result = urls("<img src=\"//cdn.example.com/a.jpg\">", base: "http://example.com/")
+		XCTAssertEqual(result, ["http://cdn.example.com/a.jpg"])
+	}
+
+	func testProtocolRelativeURLDefaultsToHTTPSWithoutBase() {
+		let result = urls("<img src=\"//cdn.example.com/a.jpg\">")
+		XCTAssertEqual(result, ["https://cdn.example.com/a.jpg"])
+	}
+
+	func testDataCanonicalSrcPreferredOverSrc() {
+		let html = "<img data-canonical-src=\"https://real.example.com/a.jpg\" src=\"https://proxy.example.com/a.jpg\">"
+		XCTAssertEqual(urls(html), ["https://real.example.com/a.jpg"])
+	}
+
+	func testUppercaseSchemeIsLowercased() {
+		// The browser lowercases the scheme in element.src, so the prefetch key must match.
+		XCTAssertEqual(urls("<img src=\"HTTPS://example.com/a.jpg\">"), ["https://example.com/a.jpg"])
+	}
+
+	func testHTMLEntitiesInURLAreDecoded() {
+		let html = "<img src=\"https://example.com/a.jpg?w=1&amp;h=2\">"
+		XCTAssertEqual(urls(html), ["https://example.com/a.jpg?w=1&h=2"])
+	}
+
+	func testNonHTTPSchemesAreRejected() {
+		let html = """
+		<img src="data:image/png;base64,iVBORw0KG">
+		<img src="file:///etc/passwd">
+		<img src="ftp://example.com/a.jpg">
+		"""
+		XCTAssertEqual(urls(html), [])
+	}
+
+	func testRelativeURLWithoutBaseIsSkipped() {
+		XCTAssertEqual(urls("<img src=\"/images/a.jpg\">"), [])
+	}
+
+	func testDuplicatesAreDeduplicated() {
+		let html = "<img src=\"https://example.com/a.jpg\"><img src=\"https://example.com/a.jpg\">"
+		XCTAssertEqual(urls(html), ["https://example.com/a.jpg"])
+	}
+
+	func testMultipleImagesPreserveOrder() {
+		let html = "<img src=\"https://example.com/a.jpg\"><img src=\"https://example.com/b.jpg\">"
+		XCTAssertEqual(urls(html), ["https://example.com/a.jpg", "https://example.com/b.jpg"])
+	}
+
+	func testSingleQuotedAttribute() {
+		let result = urls("<img src='https://example.com/a.jpg'>")
+		XCTAssertEqual(result, ["https://example.com/a.jpg"])
+	}
+
+	func testNoImages() {
+		XCTAssertEqual(urls("<p>No images here.</p>"), [])
+	}
+
+	func testBatchDeduplicatesAcrossInputs() {
+		let inputs = [
+			ArticleImageURLExtractor.Input(html: "<img src=\"https://example.com/a.jpg\">", baseURLString: nil),
+			ArticleImageURLExtractor.Input(html: "<img src=\"https://example.com/a.jpg\"><img src=\"https://example.com/b.jpg\">", baseURLString: nil)
+		]
+		XCTAssertEqual(ArticleImageURLExtractor.imageURLStrings(in: inputs), ["https://example.com/a.jpg", "https://example.com/b.jpg"])
+	}
+}

--- a/iOS/AccountStats/AccountStatsView.swift
+++ b/iOS/AccountStats/AccountStatsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import UIKit
 import RSCore
 import Account
+import Images
 
 struct AccountStatsView: View {
 
@@ -18,6 +19,7 @@ struct AccountStatsView: View {
 
 	@State private var rows = [AccountStatsRowData]()
 	@State private var totals: AccountStatsTotals?
+	@State private var imageCacheStats: ArticleImageDownloader.CacheStats?
 	@State private var isVacuuming = false
 	@State private var showHelp = false
 
@@ -41,6 +43,15 @@ struct AccountStatsView: View {
 					}
 				} header: {
 					Text(NSLocalizedString("Totals", comment: "Totals section"))
+				}
+			}
+
+			if let imageCacheStats {
+				Section {
+					statsRow(StatItem(label: NSLocalizedString("Cached Images", comment: "Cached images count"), value: Self.formattedNumber(imageCacheStats.fileCount)), isBold: false)
+					statsRow(StatItem(label: NSLocalizedString("Image Cache Size", comment: "Image cache size"), value: Int64(imageCacheStats.byteCount).formatted(.byteCount(style: .file))), isBold: false)
+				} header: {
+					Text(NSLocalizedString("Offline Images", comment: "Offline images section"))
 				}
 			}
 
@@ -157,6 +168,7 @@ private extension AccountStatsView {
 		await model.refresh()
 		rows = model.sortedAccountStats
 		totals = model.totals
+		imageCacheStats = await ArticleImageDownloader.shared.cacheStats()
 	}
 
 	func vacuum() {

--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -67,6 +67,7 @@ final class AppDefaults: Sendable {
 		static let useSystemBrowser = "useSystemBrowser"
 		static let currentThemeName = "currentThemeName"
 		static let articleContentJavascriptEnabled = "articleContentJavascriptEnabled"
+		static let cacheImagesForOffline = "cacheImagesForOffline"
 		static let hideReadFeeds = "hideReadFeeds"
 		static let isShowingExtractedArticle = "isShowingExtractedArticle"
 		static let articleWindowScrollY = "articleWindowScrollY"
@@ -217,6 +218,15 @@ final class AppDefaults: Sendable {
 		}
 		set {
 			AppDefaults.setBool(for: Key.articleContentJavascriptEnabled, newValue)
+		}
+	}
+
+	var cacheImagesForOffline: Bool {
+		get {
+			return AppDefaults.bool(for: Key.cacheImagesForOffline)
+		}
+		set {
+			AppDefaults.setBool(for: Key.cacheImagesForOffline, newValue)
 		}
 	}
 
@@ -399,6 +409,7 @@ final class AppDefaults: Sendable {
 										Key.articleFullscreenEnabled: false,
 										Key.confirmMarkAllAsRead: true,
 										Key.articleContentJavascriptEnabled: true,
+										Key.cacheImagesForOffline: false,
 										Key.currentThemeName: Self.defaultThemeName,
 									   Key.splitViewPreferredDisplayMode: UISplitViewController.DisplayMode.oneBesideSecondary.rawValue]
 		AppDefaults.store.register(defaults: defaults)

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -80,6 +80,7 @@ import Images
 
 		registerBackgroundTasks()
 		CacheCleaner.purgeIfNecessary()
+		ArticleImagePrefetcher.shared.start()
 		initializeDownloaders()
 		initializeHomeScreenQuickActions()
 

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -696,12 +696,31 @@ private extension WebViewController {
 
 		guard let imageURL = URL(string: clickMessage.imageURL) else { return }
 
-		Downloader.shared.download(imageURL) { [weak self] downloadResponse, error in
-			guard let self, let data = downloadResponse.data, error == nil, !data.isEmpty,
-				  let image = UIImage(data: data) else {
-				return
+		// Feed HTML is untrusted, so don't let a tapped image trigger a fetch to a tracker/ad
+		// domain — apply the same block list the article web view and cache path use.
+		guard !ArticleImageContentBlocker.shared.isBlocked(clickMessage.imageURL) else {
+			return
+		}
+
+		if AppDefaults.shared.cacheImagesForOffline {
+			// Resolve through the offline image cache (memory → disk → network) so a cached
+			// image still zooms while offline. clickMessage.imageURL is the pre-rewrite URL,
+			// which is the same key the cache is stored under.
+			Task { @MainActor [weak self] in
+				guard let self, let data = await ArticleImageDownloader.shared.data(for: clickMessage.imageURL, allowNetwork: true),
+					  !data.isEmpty, let image = UIImage(data: data) else {
+					return
+				}
+				self.showFullScreenImage(image: image, clickMessage: clickMessage, webView: webView)
 			}
-			self.showFullScreenImage(image: image, clickMessage: clickMessage, webView: webView)
+		} else {
+			Downloader.shared.download(imageURL) { [weak self] downloadResponse, error in
+				guard let self, let data = downloadResponse.data, error == nil, !data.isEmpty,
+					  let image = UIImage(data: data) else {
+					return
+				}
+				self.showFullScreenImage(image: image, clickMessage: clickMessage, webView: webView)
+			}
 		}
 	}
 

--- a/iOS/Resources/main_ios.js
+++ b/iOS/Resources/main_ios.js
@@ -1,5 +1,22 @@
 var activeImageViewer = null;
 
+// The real URL to hand native code for a tapped image. When offline caching rewrote src to
+// nnwimage://cache/?u=<encoded>, decode that embedded URL — the same one the scheme handler
+// serves the displayed image from — instead of trusting any feed-settable attribute. That keeps
+// the tapped download identical to what's shown, so feed HTML can't point it elsewhere.
+function originalImageURL(img) {
+	var src = img.src || "";
+	var match = src.match(/^nnwimage:\/\/cache\/\?u=(.+)$/i);
+	if (match) {
+		try {
+			return decodeURIComponent(match[1]);
+		} catch (e) {
+			return src;
+		}
+	}
+	return src;
+}
+
 class ImageViewer {
 	constructor(img) {
 		this.img = img;
@@ -43,7 +60,7 @@ class ImageViewer {
 			width: rect.width,
 			height: rect.height,
 			imageTitle: this.img.title,
-			imageURL: this.img.src,
+			imageURL: originalImageURL(this.img),
 		};
 
 		var jsonMessage = JSON.stringify(message);

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -383,6 +383,47 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Cm1-g0-ca1" customClass="VibrantTableViewCell" customModule="NetNewsWire" customModuleProvider="target">
+                                        <rect key="frame" x="20" y="895" width="374" height="110"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Cm1-g0-ca1" id="Cm2-g0-ca2">
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="110"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" verticalCompressionResistancePriority="751" ambiguous="YES" text="Cache Images for Offline" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cm3-g0-ca3" userLabel="Cache Images for Offline">
+                                                    <rect key="frame" x="20" y="11" width="135.5" height="15.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Cm4-g0-ca4">
+                                                    <rect key="frame" x="295" y="6" width="63" height="28"/>
+                                                    <color key="onTintColor" name="primaryAccentColor"/>
+                                                    <connections>
+                                                        <action selector="switchCacheImagesForOffline:" destination="a0p-rk-skQ" eventType="valueChanged" id="Cm6-g0-ca6"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" ambiguous="YES" text="Download article images during refresh so articles can be read offline. Uses more storage and data." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cm5-g0-ca5">
+                                                    <rect key="frame" x="20" y="33" width="263" height="0.0"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Cm4-g0-ca4" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Cm2-g0-ca2" secondAttribute="top" constant="6" id="Cn1-g0-cn1"/>
+                                                <constraint firstItem="Cm5-g0-ca5" firstAttribute="top" secondItem="Cm3-g0-ca3" secondAttribute="bottom" constant="6.5" id="Cn2-g0-cn2"/>
+                                                <constraint firstItem="Cm5-g0-ca5" firstAttribute="leading" secondItem="Cm2-g0-ca2" secondAttribute="leadingMargin" id="Cn3-g0-cn3"/>
+                                                <constraint firstItem="Cm5-g0-ca5" firstAttribute="bottom" secondItem="Cm2-g0-ca2" secondAttribute="bottomMargin" id="Cn4-g0-cn4"/>
+                                                <constraint firstItem="Cm3-g0-ca3" firstAttribute="leading" secondItem="Cm2-g0-ca2" secondAttribute="leadingMargin" id="Cn5-g0-cn5"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Cm4-g0-ca4" secondAttribute="trailing" constant="0" id="Cn6-g0-cn6"/>
+                                                <constraint firstItem="Cm3-g0-ca3" firstAttribute="top" secondItem="Cm2-g0-ca2" secondAttribute="topMargin" id="Cn7-g0-cn7"/>
+                                                <constraint firstItem="Cm4-g0-ca4" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Cm3-g0-ca3" secondAttribute="trailing" constant="8" id="Cn8-g0-cn8"/>
+                                                <constraint firstItem="Cm4-g0-ca4" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Cm5-g0-ca5" secondAttribute="trailing" constant="8" id="Cn9-g0-cn9"/>
+                                                <constraint firstItem="Cm4-g0-ca4" firstAttribute="centerY" secondItem="Cm3-g0-ca3" secondAttribute="centerY" id="Cn0-g0-cn0"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="WR6-xo-ty2" customClass="VibrantTableViewCell" customModule="NetNewsWire" customModuleProvider="target">
                                         <rect key="frame" x="20" y="1004" width="374" height="92"/>
                                         <autoresizingMask key="autoresizingMask"/>
@@ -663,6 +704,8 @@
                         <outlet property="openLinksInNetNewsWire" destination="dhR-L2-PX3" id="z1b-pX-bwG"/>
                         <outlet property="refreshClearsReadArticlesSwitch" destination="duV-CN-JmH" id="xTd-jF-Ei1"/>
                         <outlet property="showFullscreenArticlesSwitch" destination="2Md-2E-7Z4" id="lEN-VP-wEO"/>
+                        <outlet property="cacheImagesForOfflineSwitch" destination="Cm4-g0-ca4" id="Cm7-g0-ca7"/>
+                        <outlet property="cacheImagesForOfflineDetailLabel" destination="Cm5-g0-ca5" id="Cmf-g0-caf"/>
                         <outlet property="timelineSortOrderSwitch" destination="Keq-Np-l9O" id="Zm7-HG-r5h"/>
                     </connections>
                 </tableViewController>

--- a/iOS/Settings/SettingsViewController.swift
+++ b/iOS/Settings/SettingsViewController.swift
@@ -14,6 +14,7 @@ import UniformTypeIdentifiers
 import RSCore
 import Account
 import ActivityLog
+import Images
 
 final class SettingsViewController: UITableViewController {
 
@@ -54,7 +55,8 @@ final class SettingsViewController: UITableViewController {
 		case theme = 0
 		case openLinksInNetNewsWire = 1
 		case enableJavaScript = 2
-		case enableFullScreenArticles = 3
+		case cacheImagesForOffline = 3
+		case enableFullScreenArticles = 4
 	}
 
 	private enum HelpRow: Int {
@@ -76,6 +78,10 @@ final class SettingsViewController: UITableViewController {
 	@IBOutlet var colorPaletteDetailLabel: UILabel!
 	@IBOutlet var openLinksInNetNewsWire: UISwitch!
 	@IBOutlet var enableJavaScriptSwitch: UISwitch!
+	@IBOutlet var cacheImagesForOfflineSwitch: UISwitch!
+	@IBOutlet var cacheImagesForOfflineDetailLabel: UILabel!
+
+	private let cacheImagesForOfflineBaseText = NSLocalizedString("Download article images during refresh so articles can be read offline. Uses more storage and data.", comment: "Cache images footnote")
 
 	var scrollToArticlesSection = false
 	weak var presentingParentController: UIViewController?
@@ -88,6 +94,7 @@ final class SettingsViewController: UITableViewController {
 		NotificationCenter.default.addObserver(self, selector: #selector(accountsDidChange), name: .UserDidAddAccount, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(accountsDidChange), name: .UserDidDeleteAccount, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(displayNameDidChange), name: .DisplayNameDidChange, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(cacheAllImagesProgressDidChange), name: .ArticleImageCacheAllProgressDidChange, object: nil)
 
 		tableView.register(UINib(nibName: "SettingsComboTableViewCell", bundle: nil), forCellReuseIdentifier: "SettingsComboTableViewCell")
 		tableView.register(UINib(nibName: "SettingsTableViewCell", bundle: nil), forCellReuseIdentifier: "SettingsTableViewCell")
@@ -136,6 +143,9 @@ final class SettingsViewController: UITableViewController {
 		} else {
 			enableJavaScriptSwitch.isOn = false
 		}
+
+		cacheImagesForOfflineSwitch.isOn = AppDefaults.shared.cacheImagesForOffline
+		updateCacheImagesDetailLabel()
 
 		colorPaletteDetailLabel.text = String(describing: AppDefaults.userInterfaceColorPalette)
 
@@ -405,6 +415,77 @@ final class SettingsViewController: UITableViewController {
 	@IBAction func switchJavaScriptPreference(_ sender: Any) {
 		AppDefaults.shared.isArticleContentJavascriptEnabled = enableJavaScriptSwitch.isOn
  	}
+
+	@IBAction func switchCacheImagesForOffline(_ sender: Any) {
+		let isOn = cacheImagesForOfflineSwitch.isOn
+		AppDefaults.shared.cacheImagesForOffline = isOn
+		updateCacheImagesDetailLabel()
+		if isOn {
+			promptToCacheAllImages()
+		}
+	}
+
+	/// When the user turns offline caching on, offer to backfill images for existing unread
+	/// articles right away — prefetch otherwise only catches images from future refreshes,
+	/// and the moment someone enables this is usually right before they go offline.
+	private func promptToCacheAllImages() {
+		guard !ArticleImagePrefetcher.shared.isCachingAll else {
+			return
+		}
+		let unreadCount = AccountManager.shared.unreadCount
+		guard unreadCount > 0 else {
+			return
+		}
+		let title = NSLocalizedString("Cache Images Now?", comment: "Cache images now alert title")
+		let messageFormat = NSLocalizedString("Download images for your %d unread articles now, so they can be read offline?", comment: "Cache images now alert message")
+		let alert = UIAlertController(title: title, message: String(format: messageFormat, unreadCount), preferredStyle: .alert)
+		alert.addAction(UIAlertAction(title: NSLocalizedString("Not Now", comment: "Not Now"), style: .cancel))
+		let cacheTitle = NSLocalizedString("Cache Images", comment: "Cache Images now button")
+		alert.addAction(UIAlertAction(title: cacheTitle, style: .default) { _ in
+			ArticleImagePrefetcher.shared.cacheAllArticleImagesNow()
+		})
+		present(alert, animated: true)
+	}
+
+	@objc func cacheAllImagesProgressDidChange() {
+		updateCacheImagesDetailLabel()
+	}
+
+	/// Show the offline-images footnote, with live "N of M" progress appended during a
+	/// cache-all run and the current on-disk cache size when idle. The size is only recomputed
+	/// when a run isn't in progress, to avoid enumerating the cache folder per progress tick.
+	private func updateCacheImagesDetailLabel() {
+		guard let cacheImagesForOfflineDetailLabel else {
+			return
+		}
+		let prefetcher = ArticleImagePrefetcher.shared
+		guard !prefetcher.isCachingAll else {
+			let progress: String
+			if prefetcher.cacheAllTotal > 0 {
+				let format = NSLocalizedString("Caching Images… %d of %d", comment: "Cache-all progress")
+				progress = String(format: format, prefetcher.cacheAllCompleted, prefetcher.cacheAllTotal)
+			} else {
+				progress = NSLocalizedString("Caching Images…", comment: "Cache-all starting")
+			}
+			cacheImagesForOfflineDetailLabel.text = cacheImagesForOfflineBaseText + "\n\n" + progress
+			return
+		}
+		Task { @MainActor in
+			let stats = await ArticleImageDownloader.shared.cacheStats()
+			// A run may have started while awaiting; if so, leave the progress text alone.
+			guard !ArticleImagePrefetcher.shared.isCachingAll else {
+				return
+			}
+			guard stats.byteCount > 0 else {
+				cacheImagesForOfflineDetailLabel.text = cacheImagesForOfflineBaseText
+				return
+			}
+			let size = stats.byteCount.formatted(.byteCount(style: .file))
+			let countFormat = NSLocalizedString("%d images · %@ used", comment: "Cached image count and size")
+			let usage = String(format: countFormat, stats.fileCount, size)
+			cacheImagesForOfflineDetailLabel.text = cacheImagesForOfflineBaseText + "\n\n" + usage
+		}
+	}
 
 	// MARK: - Notifications
 


### PR DESCRIPTION
Adds an optional, off-by-default setting that caches article images during refresh and
serves them from a local cache at render time, so articles read with images while offline
(planes, trains, tunnels, metered data). Addresses #1873; a step toward #3460.

## Design note: what happens when you turn it on

Prefetch only catches images from *future* refreshes, so the moment you enable this —
typically right before you lose connectivity — your *existing* unread articles still have
no cached images. To bridge that, **enabling the setting offers to cache images for your
current unread articles right away** (a "Cache Images Now? / Not Now" prompt showing the
unread count). There's deliberately no standalone "cache everything" button: if you want
to backfill again later, toggle the setting off and back on.

<img width="624" height="714" alt="image" src="https://github.com/user-attachments/assets/1686288d-1412-409d-92dc-df79067abd12" />

<img width="568" height="1115" alt="image" src="https://github.com/user-attachments/assets/f17fc039-64a8-49e8-8d89-acc9b22f4b17" />


## How it works

Two halves sharing an on-disk cache:

- **Prefetch:** `ArticleImagePrefetcher` watches `.AccountDidDownloadArticles`, extracts
  `<img>` URLs off the main thread (a sync can deliver a large batch at once), and fetches
  them via `ArticleImageDownloader` — throttled, not one unbounded burst. The pure
  URL-extraction is a nonisolated, unit-tested `ArticleImageURLExtractor`.
- **Serve:** with the setting on, `main.js` rewrites `http(s)` `<img src>` to
  `nnwimage://cache/?u=…`; `ArticleImageSchemeHandler` (a `WKURLSchemeHandler`) resolves
  those memory → disk → network. Uncached images load online-only; cached ones load
  offline. On rewrite it also drops the img's `srcset` and, inside a `<picture>`, its
  sibling `<source>` candidates, so WebKit can't select an original `https` URL that
  bypasses the cache. The enable flag reaches `main.js` as a hidden DOM marker rather than
  an inline `<script>`, so it applies even when the reader has article JavaScript off (that
  setting gates *content* JS; `main.js` runs as an injected user script).

`ArticleImageDownloader` mirrors the existing `ImageDownloader`/`FaviconDownloader` pattern
(same `Downloader`, `ImageMetadataDatabase` backoff, `BinaryDiskCache`) but keeps full-size
bytes in a separate `ArticleImages` folder. Same-URL requests coalesce; the in-memory
`NSCache` is bounded (~50 MB, cleared on background/low-memory); only plausible image
responses persist (an `image/*` type or recognized magic bytes, under a 20 MB cap). App-side
fetches reuse the web view's content blocker via `ArticleImageContentBlocker`, so tracker/ad
URLs stay blocked — including on cross-host redirects. The `ArticleImages` folder is swept by
the existing 3-day `CacheCleaner` flush, and purged outright when the setting is off.

## The setting

`cacheImagesForOffline`, off by default — iOS: Settings → Articles; Mac: Settings → General.
While a backfill runs, the settings line shows live progress ("Caching Images… N of M");
when idle it shows the current cache size ("166 images · 63.5 MB used"). iOS account-stats
gains an Offline Images section with the same figures.

## Key limitations

- Custom-scheme routing bypasses WebKit's own image cache and doesn't send its cookies/referer,
  so a few hotlink-protected images may fail when the setting is on.
- Enclosure/media caching (video, audio, PDF) is out of scope (#5284).
- No pre-buffer byte cap: the 20 MB limit keeps oversized bodies out of the *persistent* cache,
  but the shared `RSWeb.Downloader` still buffers whole bodies first. A streaming cap belongs in
  `Downloader` (it affects every image path) and is left as shared-infra follow-up.

## Testing

- macOS and iOS both build clean.
- `ArticleImageURLExtractorTests` covers absolute / relative / protocol-relative resolution,
  scheme lowercasing, `data-canonical-src` preference, entity decoding, non-http rejection,
  dedup, ordering.
- Manual: enable → accept the prompt → Airplane Mode → confirm article images still load.

*(Full internals live in the three commit messages: core caching, on-enable backfill, and the
Mac prefs-pane sizing fix.)*
