### PR TITLE
Only trickle Reddit feeds after rate limit

### DIFF
--- a/Modules/Account/Sources/Account/LocalAccount/LocalAccountRefresher.swift
+++ b/Modules/Account/Sources/Account/LocalAccount/LocalAccountRefresher.swift
@@ -355,7 +355,7 @@ import os
 
 		feed.lastCheckDate = Date()
 		feed.lastResponseCode = statusCode
-		if statusCode == HTTPResponseCode.tooManyRequests && SpecialCase.urlStringMatchesDomain(feed.url, [SpecialCase.redditHostName]) {
+		if Self.feedHasRedditRateLimitResponse(feed) {
 			hasDetectedRedditRateLimit = true
 		}
 
@@ -502,10 +502,12 @@ private extension LocalAccountRefresher {
 	}
 
 	static func feedsContainRedditRateLimitResponse(_ feeds: Set<Feed>) -> Bool {
-		feeds.contains {
-			$0.lastResponseCode == HTTPResponseCode.tooManyRequests &&
-			SpecialCase.urlStringMatchesDomain($0.url, [SpecialCase.redditHostName])
-		}
+		feeds.contains { feedHasRedditRateLimitResponse($0) }
+	}
+
+	static func feedHasRedditRateLimitResponse(_ feed: Feed) -> Bool {
+		feed.lastResponseCode == HTTPResponseCode.tooManyRequests &&
+		SpecialCase.urlStringMatchesDomain(feed.url, [SpecialCase.redditHostName])
 	}
 
 	static func feedShouldBeSkippedForRedditReasons(_ feed: Feed, _ redditURLToRefresh: String?) -> (Bool, String?) {

--- a/Modules/Account/Sources/Account/LocalAccount/LocalAccountRefresher.swift
+++ b/Modules/Account/Sources/Account/LocalAccount/LocalAccountRefresher.swift
@@ -64,6 +64,7 @@ import os
 
 	private var completion: (() -> Void)?
 	private var isSuspended = false
+	private var hasDetectedRedditRateLimit = false
 
 	private lazy var downloadSession: DownloadSession = {
 		let session = DownloadSession(delegate: self)
@@ -87,7 +88,10 @@ import os
 
 	@MainActor private func refreshFeeds(_ feeds: Set<Feed>, completion: (() -> Void)? = nil) {
 		let specialCaseCutoffDate = Date().bySubtracting(hours: 25)
-		let redditURLToRefresh = Self.redditURLToRefresh(in: feeds)
+		if Self.feedsContainRedditRateLimitResponse(feeds) {
+			hasDetectedRedditRateLimit = true
+		}
+		let redditURLToRefresh = Self.redditURLToRefresh(in: feeds, hasDetectedRedditRateLimit: hasDetectedRedditRateLimit)
 
 		var filteredFeeds = Set<Feed>()
 		var skippedFeeds = [(Feed, String)]() // feed and skip reason
@@ -351,6 +355,9 @@ import os
 
 		feed.lastCheckDate = Date()
 		feed.lastResponseCode = statusCode
+		if statusCode == HTTPResponseCode.tooManyRequests && SpecialCase.urlStringMatchesDomain(feed.url, [SpecialCase.redditHostName]) {
+			hasDetectedRedditRateLimit = true
+		}
 
 		let webserviceError = WebserviceError.httpError(status: statusCode)
 		let statusDescription = webserviceError.localizedDescription
@@ -470,9 +477,11 @@ private extension LocalAccountRefresher {
 		if skipForDisallowedHost {
 			return (true, disallowedHostReason)
 		}
-		let (skipForReddit, redditReason) = feedShouldBeSkippedForRedditReasons(feed, redditURLToRefresh)
-		if skipForReddit {
-			return (true, redditReason)
+		if redditURLToRefresh != nil {
+			let (skipForReddit, redditReason) = feedShouldBeSkippedForRedditReasons(feed, redditURLToRefresh)
+			if skipForReddit {
+				return (true, redditReason)
+			}
 		}
 		let (skipForTiming, timingReason) = feedShouldBeSkippedForTimingReasons(feed, specialCaseCutoffDate)
 		if skipForTiming {
@@ -481,12 +490,22 @@ private extension LocalAccountRefresher {
 		return (false, nil)
 	}
 
-	/// Reddit rate-limits to one feed per minute, so we
-	/// refresh the least recently checked one.
-	static func redditURLToRefresh(in feeds: Set<Feed>) -> String? {
+	/// Reddit rate-limits to one feed per minute, so once we get a 429,
+	/// we refresh the least recently checked feed.
+	static func redditURLToRefresh(in feeds: Set<Feed>, hasDetectedRedditRateLimit: Bool) -> String? {
+		guard hasDetectedRedditRateLimit else {
+			return nil
+		}
 		let redditFeeds = feeds.filter { SpecialCase.urlStringMatchesDomain($0.url, [SpecialCase.redditHostName]) }
 		let winner = redditFeeds.min { ($0.lastCheckDate ?? .distantPast) < ($1.lastCheckDate ?? .distantPast) }
 		return winner?.url
+	}
+
+	static func feedsContainRedditRateLimitResponse(_ feeds: Set<Feed>) -> Bool {
+		feeds.contains {
+			$0.lastResponseCode == HTTPResponseCode.tooManyRequests &&
+			SpecialCase.urlStringMatchesDomain($0.url, [SpecialCase.redditHostName])
+		}
 	}
 
 	static func feedShouldBeSkippedForRedditReasons(_ feed: Feed, _ redditURLToRefresh: String?) -> (Bool, String?) {

--- a/Modules/Account/Sources/Account/LocalAccount/LocalAccountRefresher.swift
+++ b/Modules/Account/Sources/Account/LocalAccount/LocalAccountRefresher.swift
@@ -88,10 +88,11 @@ import os
 
 	@MainActor private func refreshFeeds(_ feeds: Set<Feed>, completion: (() -> Void)? = nil) {
 		let specialCaseCutoffDate = Date().bySubtracting(hours: 25)
-		if Self.feedsContainRedditRateLimitResponse(feeds) {
+		let (hasRedditRateLimitResponse, redditURL) = Self.redditURLToRefresh(in: feeds)
+		if hasRedditRateLimitResponse {
 			hasDetectedRedditRateLimit = true
 		}
-		let redditURLToRefresh = Self.redditURLToRefresh(in: feeds, hasDetectedRedditRateLimit: hasDetectedRedditRateLimit)
+		let redditURLToRefresh = hasDetectedRedditRateLimit ? redditURL : nil
 
 		var filteredFeeds = Set<Feed>()
 		var skippedFeeds = [(Feed, String)]() // feed and skip reason
@@ -355,9 +356,6 @@ import os
 
 		feed.lastCheckDate = Date()
 		feed.lastResponseCode = statusCode
-		if Self.feedHasRedditRateLimitResponse(feed) {
-			hasDetectedRedditRateLimit = true
-		}
 
 		let webserviceError = WebserviceError.httpError(status: statusCode)
 		let statusDescription = webserviceError.localizedDescription
@@ -492,22 +490,11 @@ private extension LocalAccountRefresher {
 
 	/// Reddit rate-limits to one feed per minute, so once we get a 429,
 	/// we refresh the least recently checked feed.
-	static func redditURLToRefresh(in feeds: Set<Feed>, hasDetectedRedditRateLimit: Bool) -> String? {
-		guard hasDetectedRedditRateLimit else {
-			return nil
-		}
+	static func redditURLToRefresh(in feeds: Set<Feed>) -> (Bool, String?) {
 		let redditFeeds = feeds.filter { SpecialCase.urlStringMatchesDomain($0.url, [SpecialCase.redditHostName]) }
+		let hasRedditRateLimitResponse = redditFeeds.contains { $0.lastResponseCode == HTTPResponseCode.tooManyRequests }
 		let winner = redditFeeds.min { ($0.lastCheckDate ?? .distantPast) < ($1.lastCheckDate ?? .distantPast) }
-		return winner?.url
-	}
-
-	static func feedsContainRedditRateLimitResponse(_ feeds: Set<Feed>) -> Bool {
-		feeds.contains { feedHasRedditRateLimitResponse($0) }
-	}
-
-	static func feedHasRedditRateLimitResponse(_ feed: Feed) -> Bool {
-		feed.lastResponseCode == HTTPResponseCode.tooManyRequests &&
-		SpecialCase.urlStringMatchesDomain(feed.url, [SpecialCase.redditHostName])
+		return (hasRedditRateLimitResponse, winner?.url)
 	}
 
 	static func feedShouldBeSkippedForRedditReasons(_ feed: Feed, _ redditURLToRefresh: String?) -> (Bool, String?) {


### PR DESCRIPTION
related to #5328

Reddit allows personalized feeds with `?feed=&user=` that are not throttled the same way. Current logic applies equally to all reddit feeds. This PR changes the implementation to wait for the first 429 before trickling all reddit feeds. 

I did not want to specialize based on QSP and just make sure to not throttle unconditionally.